### PR TITLE
Renamed code tab to "AngularJS".

### DIFF
--- a/source/_includes/nav-tabs-code.html
+++ b/source/_includes/nav-tabs-code.html
@@ -1,12 +1,12 @@
 <ul class="nav nav-tabs nav-tabs-pf nav-tabs-code" id="tabs-code" role="tablist">
 {% if include.html == false %}
   <li role="presentation" class="disabled"><a class="nested" aria-controls="html-css" role="tab" disabled="disabled" title="HTML/CSS example is not available">HTML/CSS</a></li>
-  <li role="presentation" class="active"><a class="nested" href="#angular" aria-controls="angular" role="tab" data-toggle="tab">Angular-PatternFly</a></li>
+  <li role="presentation" class="active"><a class="nested" href="#angular" aria-controls="angular" role="tab" data-toggle="tab">AngularJS</a></li>
 {% elsif include.angular == false %}
   <li role="presentation" class="active"><a class="nested" href="#html-css" aria-controls="html-css" role="tab" data-toggle="tab">HTML/CSS</a></li>
-  <li role="presentation" class="disabled"><a class="nested" aria-controls="angular" role="tab" disabled="disabled" title="Angular-Patternfly example is not available">Angular-PatternFly</a></li>
+  <li role="presentation" class="disabled"><a class="nested" aria-controls="angular" role="tab" disabled="disabled" title="AngularJS example is not available">AngularJS</a></li>
 {% else %}
   <li role="presentation" class="active"><a class="nested" href="#html-css" aria-controls="html-css" role="tab" data-toggle="tab">HTML/CSS</a></li>
-  <li role="presentation"><a class="nested" href="#angular" aria-controls="angular" role="tab" data-toggle="tab">Angular-PatternFly</a></li>
+  <li role="presentation"><a class="nested" href="#angular" aria-controls="angular" role="tab" data-toggle="tab">AngularJS</a></li>
 {% endif %}
 </ul>

--- a/source/pattern-library/application-framework/login-page/index.md
+++ b/source/pattern-library/application-framework/login-page/index.md
@@ -66,6 +66,7 @@ layout: page-tabs
     </ol>
   </div>
   <div role="tabpanel" class="tab-pane" id="code">
+   {% include nav-tabs-code.html angular=false %}
     <div class="example-pf">
       <iframe src="{{ site.baseurl }}pattern-library/application-framework/login-page/login.html"
               width="100%" height="650px;" scrolling="no" seamless></iframe>


### PR DESCRIPTION
Fix for issue #89 
Renamed code tab from "Angular-PatternFly" to "AngularJS".
Added missing nav for login code page.
