### PR TITLE
Updated all the posts for what's new

### DIFF
--- a/source/_whats-news/2015-11-19.md
+++ b/source/_whats-news/2015-11-19.md
@@ -1,6 +1,0 @@
----
-date: 2015-11-19
----
-<ul>
-  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.0.0-alpha" title="PatternFly reference implementation v3.0.0 on Github">reference implementation v3.0.0 alpha</a>.  Note:  this is a <strong>pre-release</strong> and should not be considered production-ready.</li>
-</ul>

--- a/source/_whats-news/2015-12-04.md
+++ b/source/_whats-news/2015-12-04.md
@@ -1,0 +1,9 @@
+---
+date: 2015-12-04
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/communication/toast-notifications">Toast Notification</a> documentation was added under Patterns.</li>
+  <li><a href="{{site.baseurl}}pattern-library/forms-and-controls/find">Find</a> documentation was added under Patterns.</li>
+  <li>Added a tertiary level under Patterns called Notifications and moved <a href="{{site.baseurl}}pattern-library/communication/inline-notifications">Inline Notifications</a> underneath along with <a href="{{site.baseurl}}pattern-library/communication/toast-notifications">Toast Notifications</a>.</li>
+  <li>Added a tertiary level under Patterns called Forms and Controls and moved <a href="{{site.baseurl}}pattern-library/forms-and-controls/date-picker">Datepicker</a> and <a href="{{site.baseurl}}pattern-library/forms-and-controls/field-level-help">Field Level Help</a> underneath along with <a href="{{site.baseurl}}pattern-library/forms-and-controls/find">Find</a>.</li>
+</ul>

--- a/source/_whats-news/2015-12-07.md
+++ b/source/_whats-news/2015-12-07.md
@@ -3,4 +3,10 @@ date: 2015-12-07
 ---
 <ul>
   <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v2.7.0" title="PatternFly reference implementation v2.7.0 on Github">reference implementation v2.7.0</a>.</li>
+  <li><a href="{{site.baseurl}}pattern-library/dashboard/dashboard-card">Dashboard Card (Base)</a> updated.</li>
+  <ul>
+    <li>Dashboard Cards renamed to Dashboard Card Base.</li>
+    <li>Live example and reference implementation added.</li>
+    <li>Images updated to show the base card only.</li>
+  </ul>
 </ul>

--- a/source/_whats-news/2015-12-08.md
+++ b/source/_whats-news/2015-12-08.md
@@ -1,0 +1,8 @@
+---
+date: 2015-12-08
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/navigation/vertical-navigation">Vertical Navigation and Persistent Secondary</a> documentation and image examples added.</li>
+  <li>Added a tertiary level under Patterns called Content Views and moved <a href="{{site.baseurl}}pattern-library/content-views/table-view">Table View</a> underneath.</li>
+  <li><a href="{{site.baseurl}}pattern-library/content-views/list-view">List View</a> documentation and examples were added under Patterns &gt; Content Views.</li>
+</ul>

--- a/source/_whats-news/2015-12-14.md
+++ b/source/_whats-news/2015-12-14.md
@@ -1,0 +1,6 @@
+---
+date: 2015-12-14
+---
+<ul>
+<li>Added a tertiary level under Patterns called Communication and moved <a href="{{site.baseurl}}pattern-library/communication/inline-notifications">Inline Notifications</a>, <a href="{{site.baseurl}}pattern-library/communication/toast-notifications">Toast Notifications</a> and <a href="{{site.baseurl}}pattern-library/communication/empty-state">Empty State</a> underneath.</li>
+</ul>

--- a/source/_whats-news/2015-12-22.md
+++ b/source/_whats-news/2015-12-22.md
@@ -1,0 +1,9 @@
+---
+date: 2015-12-22
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/content-views/table-view">Table View</a> documentation and examples were added under Patterns &gt; Content Views.</li>
+  <li><a href="{{site.baseurl}}pattern-library/widgets/#cnt-remaining-chars">Count Remaining Characters</a> documentation and examples were added under Widgets &gt; Javascript.</li>
+  <li>The function c3ChartDefaults was added to provide default settings for chart colors, spark line charts, and donut charts.</li>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v2.8.0" title="PatternFly reference implementation v2.8.0 on Github">reference implementation v2.8.0</a>.</li>
+</ul>

--- a/source/_whats-news/2016-01-19.md
+++ b/source/_whats-news/2016-01-19.md
@@ -1,0 +1,7 @@
+---
+date: 2016-01-19
+---
+<ul>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.0.0" title="PatternFly reference implementation v3.0.0 on Github">reference implementation v3.0.0</a>.</li>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v2.9.0" title="PatternFly reference implementation v2.9.0 on Github">reference implementation v2.9.0</a>.</li>
+</ul>

--- a/source/_whats-news/2016-01-21.md
+++ b/source/_whats-news/2016-01-21.md
@@ -1,0 +1,6 @@
+---
+date: 2016-01-21
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/communication/toast-notifications">Toast Notifications</a> live example and reference implementation added.</li>
+</ul>

--- a/source/_whats-news/2016-01-24.md
+++ b/source/_whats-news/2016-01-24.md
@@ -1,0 +1,6 @@
+---
+date: 2016-01-24
+---
+<ul>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.1.0" title="PatternFly reference implementation v3.1.0 on Github">reference implementation v3.1.0</a>.</li>
+</ul>

--- a/source/_whats-news/2016-02-02.md
+++ b/source/_whats-news/2016-02-02.md
@@ -1,0 +1,7 @@
+---
+date: 2016-02-02
+---
+<ul>
+  <li>Documentation was added regarding <a href="{{site.baseurl}}styles/terminology-and-wording/#links">Additional Information Links</a> under Terminology and Wording.</li>
+  <li><a href="{{site.baseurl}}pattern-library/widgets/#fixed-height-accordion">Fixed Height Accordion</a> was added to the Widgets page.</li>
+</ul>

--- a/source/_whats-news/2016-02-15.md
+++ b/source/_whats-news/2016-02-15.md
@@ -1,0 +1,7 @@
+---
+date: 2016-02-15
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/bar-chart/">Bar Chart</a> documentation and image examples added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/donut-chart/#example-overview-2">Donut Chart: Set of Values to a Whole</a> documentation and image examples added to the <a href="https://www.patternfly.org/patterns/donut-chart/">Donut Chart</a> pattern page.</li>
+</ul>

--- a/source/_whats-news/2016-02-26.md
+++ b/source/_whats-news/2016-02-26.md
@@ -1,0 +1,7 @@
+---
+date: 2016-02-26
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/content-views/list-view">List View</a> live examples and reference implementation added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/navigation/vertical-navigation">Vertical Navigation with Persistent Secondary</a> live example and reference implementation added.</li>
+</ul>

--- a/source/_whats-news/2016-02-29.md
+++ b/source/_whats-news/2016-02-29.md
@@ -1,0 +1,8 @@
+---
+date: 2016-02-29
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/heat-map/">Heat Map</a> documentation and image examples added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/line-chart/">Line Chart</a> documentation and image examples added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/content-views/list-view/">List View</a> pattern updated with <a href="{{site.baseurl}}pattern-library/content-views/list-view/#expanding-rows">Expand Row</a> documentation and image examples.</li>
+</ul>

--- a/source/_whats-news/2016-03-01.md
+++ b/source/_whats-news/2016-03-01.md
@@ -1,0 +1,7 @@
+---
+date: 2016-03-01
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/widgets/#kebabs">Kebabs</a> were added to the Widgets page.</li>
+  <li><a href="{{site.baseurl}}pattern-library/widgets/#treegrid-table">TreeGrid Table</a> was added to the Widgets page.</li>
+</ul>

--- a/source/_whats-news/2016-03-02.md
+++ b/source/_whats-news/2016-03-02.md
@@ -1,0 +1,6 @@
+---
+date: 2016-03-02
+---
+<ul>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.2.0" title="PatternFly reference implementation v3.2.0 on Github">reference implementation v3.2.0</a>.</li>
+</ul>

--- a/source/_whats-news/2016-03-04.md
+++ b/source/_whats-news/2016-03-04.md
@@ -1,0 +1,10 @@
+---
+date: 2016-03-04
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/area-chart">Area Chart</a> live example and reference implementation was added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/bar-chart">Bar Chart</a> live examples and reference implementations were added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/donut-chart">Donut Chart</a> Relationship of a Set of Values to a Whole live example and reference implementation was added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/line-chart">Line Chart</a> live examples and reference implementations were added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/pie-chart">Pie Chart</a> live example and reference implementation was added.</li>
+</ul>

--- a/source/_whats-news/2016-03-17.md
+++ b/source/_whats-news/2016-03-17.md
@@ -1,0 +1,6 @@
+---
+date: 2016-03-17
+---
+<ul>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.3.0" title="PatternFly reference implementation v3.3.0 on Github">reference implementation v3.3.0</a>.</li>
+</ul>

--- a/source/_whats-news/2016-04-27.md
+++ b/source/_whats-news/2016-04-27.md
@@ -1,0 +1,8 @@
+---
+date: 2016-04-27
+---
+<ul>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.3.4" title="PatternFly reference implementation v3.3.4 on Github">reference implementation v3.3.4</a>.</li>
+  <li><a href="{{site.baseurl}}pattern-library/forms-and-controls/forms/">Forms</a> documentation and image examples added.</li>
+  <li><a href="{{site.baseurl}}pattern-library/communication/wizard/">Wizard</a> documentation and image examples added.</li>
+</ul>

--- a/source/_whats-news/2016-04-28.md
+++ b/source/_whats-news/2016-04-28.md
@@ -1,0 +1,6 @@
+---
+date: 2016-04-28
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/communication/notification-drawer/">Notification Drawer</a> documentation and image examples added.</li>
+</ul>

--- a/source/_whats-news/2016-04-29.md
+++ b/source/_whats-news/2016-04-29.md
@@ -1,0 +1,6 @@
+---
+date: 2016-04-29
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/data-visualization/area-chart/">Area Chart</a> documentation added.</li>
+</ul>

--- a/source/_whats-news/2016-05-10.md
+++ b/source/_whats-news/2016-05-10.md
@@ -1,0 +1,6 @@
+---
+date: 2016-05-10
+---
+<ul>
+  <li><a href="{{site.baseurl}}pattern-library/communication/about-modal/">About Modal</a> documentation added.</li>
+</ul>

--- a/source/_whats-news/2016-05-25.md
+++ b/source/_whats-news/2016-05-25.md
@@ -1,0 +1,6 @@
+---
+date: 2016-05-25
+---
+<ul>
+  <li>Release of <a href="https://github.com/patternfly/patternfly/releases/tag/v3.4.0" title="PatternFly reference implementation v3.4.0 on Github">reference implementation v3.4.0</a>.</li>
+</ul>

--- a/source/whats-new/index.html
+++ b/source/whats-new/index.html
@@ -6,7 +6,7 @@ layout: page
 
 <!-- This loops through the whats-new posts -->
 {% assign whats-news = site.whats-news | sort: 'date' | reverse %}
-{% for whatsnew in whats-news limit:10 %}
+{% for whatsnew in whats-news limit:50 %}
   <h2>{{ whatsnew.date | date: '%B %-d, %Y' }}</h2>
   {{ whatsnew.content }}
 {% endfor %}


### PR DESCRIPTION
Updated all the what's new posts for this year and up to November 5, 2015. There are older posts, but not certain we need all that or if it's even relevant for the new site? It's time consuming to add each post to it's own file, fix the broken links, etc.

By default, we're only showing the last 3 posts on the home page. If you click on the view more link, it was only showing the last 10; although, I changed that to 50.