### PR TITLE
Fixed broken links.

### DIFF
--- a/source/pattern-library/communication/about-modal/index.md
+++ b/source/pattern-library/communication/about-modal/index.md
@@ -25,7 +25,7 @@ codetab: false
       </div>
       <div class="col-md-4 col-lg-5">
         <ol>
-          <li><b>PatternFly Modal:</b> Utilizes the existing <a href="https://www.patternfly.org/widgets/#modal">PatternFly Modal</a>. Upon opening, the background behind the modal should “dim” in order to provide a focused view of the modal, reducing confusion. The modal should be centered on the screen.</li>
+          <li><b>PatternFly Modal:</b> Utilizes the existing <a href="{{site.baseurl}}pattern-library/widgets/#modal">PatternFly Modal</a>. Upon opening, the background behind the modal should “dim” in order to provide a focused view of the modal, reducing confusion. The modal should be centered on the screen.</li>
           <li><b>Close Button:</b> Clicking the close button (pficon-close) will dismiss the modal and return the background to it’s original state.</li>
           <li><b>Content:</b> Title of product, label and version, and legal text are present. Adequate spacing and font weight consideration should be provided for legibility. Two columns are available for versions that contain both a release name and version number or in the event more space is needed.</li>
           <li><b>Corner Graphic:</b> Corner graphic allows the opportunity for branding.</li>

--- a/source/pattern-library/communication/notification-drawer/index.md
+++ b/source/pattern-library/communication/notification-drawer/index.md
@@ -23,7 +23,7 @@ codetab: false
       </div>
       <div class="col-md-4 col-lg-5">
         <ol>
-          <li><b>Toast Notification:</b> The drawer should utilize the current <a href="https://www.patternfly.org/patterns/toast-notifications/">Toast Notification</a>. Shows the notification title and and optional content relevant icon. </li>
+          <li><b>Toast Notification:</b> The drawer should utilize the current <a href="{{site.baseurl}}pattern-library/communication/toast-notifications/">Toast Notification</a>. Shows the notification title and and optional content relevant icon. </li>
         </ol>
       </div>
     </div>
@@ -36,12 +36,12 @@ codetab: false
         <ol>
           <li><b>Icon:</b> Displays visual differentiator when new or unread notifications are present. Clicking on the icon will slide out a drawer and dismiss the toast notification. Clicking on the icon again will close the drawer. </li>
           <li><b>Drawer Title:</b> Title of Drawer.</li>
-          <li><b>Accordian:</b> Only one notification tab may be opened at a given time -maximizing drawer space. Italicized text will indicate number of new events. Clicking on the title will expand accordion.</li>
+          <li><b>Accordion:</b> Only one notification tab may be opened at a given time -maximizing drawer space. Italicized text will indicate number of new events. Clicking on the title will expand accordion.</li>
           <li><b>Row:</b> Example content shows relevant icon creating a visual differentiator between content severity or object type. New/unread notifications are shown in bold.</li>
           <li><b>Row Hover State:</b> Example of hover state.</li>
           <li><b>Mark All Read:</b> Clicking “Mark All Read” changes all visible unread rows (bold row type) to read (regular row type).</li>
           <li><b>Icon Empty:</b> The empty state shows no new events.</li>
-          <li><b>Row Actions:</b> Clicking on the <a href="https://www.patternfly.org/widgets/#kebabs">Kabob</a> menu will reveal a drop down containing actions for that item.</li>
+          <li><b>Row Actions:</b> Clicking on the <a href="{{site.baseurl}}pattern-library/widgets/#kebabs">Kabob</a> menu will reveal a drop down containing actions for that item.</li>
           <li><b>Infinite Scroll:</b> Infinite scroll reduces need to identify time range on accordion tab. Allows for free-range historical search of notifications.</li>
         </ol>
       </div>


### PR DESCRIPTION
New PatternFly site: PatternFly Modal Design page - link goes to old site #119
New PatternFly site: Notification Drawer Design page - link goes to old site #121
New PatternFly site: Notification Drawer Design page - Misspelled word #122