### PR TITLE
Added TravisCI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/patternfly/patternfly-org.svg?branch=master)](https://travis-ci.org/patternfly/patternfly-org)
+
 # patternfly-org
 
 The PatternFly Org is the new source for the official documentation for PatternFly.


### PR DESCRIPTION
patternfly-org is already integrated with TravisCI, this PR just adds a badge to the README.md file.

![image](https://cloud.githubusercontent.com/assets/12733153/16666417/91a22f66-4455-11e6-8065-4f52b41903d9.png)
