### PR TITLE
Travis build needs to pick a "suitable version" of patternfly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,8 @@
     "jquery.scrollTo": "~2.1.2",
     "patternfly": "f012b78c7f90fada15718705a6d99f72d7060d5c",
     "wowjs": "~1.1.2"
+  },
+  "resolutions": {
+    "patternfly": "f012b78c7f90fada15718705a6d99f72d7060d5c"
   }
 }
-


### PR DESCRIPTION
Travis build won't complete until a "suitable version" of patternfly is selected -- angular-patternfly is using an older version.