### PR TITLE
Show Angular code for Inline Notifications on correct page

### DIFF
--- a/source/pattern-library/communication/inline-notifications/index.md
+++ b/source/pattern-library/communication/inline-notifications/index.md
@@ -47,7 +47,7 @@ layout: page-tabs
     </div>
   </div>
   <div role="tabpanel" class="tab-pane" id="code">
-    {% include nav-tabs-code.html angular=false %}
+    {% include nav-tabs-code.html %}
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane nested active" id="html-css">
         <p>Jump to <a href="#example-code-1">Examples</a>, <a href="#example-code-2">Variations</a> or <a href="#example-code-3">In Context</a></p>

--- a/source/pattern-library/communication/toast-notifications/index.md
+++ b/source/pattern-library/communication/toast-notifications/index.md
@@ -46,7 +46,7 @@ layout: page-tabs
     </div>
   </div>
   <div role="tabpanel" class="tab-pane" id="code">
-    {% include nav-tabs-code.html %}
+    {% include nav-tabs-code.html angular=false %}
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane nested active" id="html-css">
         <p>Jump to <a href="#example-code-1">Examples</a>, <a href="#example-code-2">With Max-Width</a> or <a href="#example-code-3">In Context</a></p>


### PR DESCRIPTION
Addresses #259 by showing the Angular code for Inline Notifications on the [Inline Notifications](https://www.patternfly.org/pattern-library/communication/inline-notifications/#/_code) page and hide the same code on the [Toast Notifications](https://www.patternfly.org/pattern-library/communication/toast-notifications/#/_code) page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patternfly/patternfly-org/260)
<!-- Reviewable:end -->
