### PR TITLE
fix type on bower install command on patternfly setup page

### DIFF
--- a/source/get-started/setup/index.md
+++ b/source/get-started/setup/index.md
@@ -40,7 +40,7 @@ layout: page
           <li><a href="https://bower.io/#installing-bower" target="top">Bower</a>: a package manager for the web.
             <ul>
               <li>
-                <kbd>$ sudo install -g bower</kbd>
+                <kbd>$ sudo npm install -g bower</kbd>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
On the "Setting Up PatternFly" page, the bower install command was missing the npm bit.