### PR TITLE
Find dropdown is not opening in Toolbar component #293

### DIFF
--- a/source/pattern-library/forms-and-controls/toolbar/index.md
+++ b/source/pattern-library/forms-and-controls/toolbar/index.md
@@ -62,9 +62,38 @@ layout: page-tabs
         </div>
         <p class="reference-markup"><a class="collapse-toggle" data-toggle="collapse" aria-expanded="true" aria-controls="markup-1" href="#markup-1">Reference Markup</a></p>
         <div class="collapse in" id="markup-1">
-          <pre class="prettyprint">{% capture markup_include %}{% include widgets/layouts/toolbar.html %}{% endcapture %}{{ markup_include | xml_escape }}</pre>
+          <pre class="prettyprint">{% capture markup_include %}{% include widgets/layouts/toolbar.html %}{% endcapture %}{{ markup_include | xml_escape }}
+      &lt;script&gt;
+        (function($) {
+          $(document).ready(function() {
+            // Upon clicking the find button, show the find dropdown content
+            $(".btn-find").click(function () {
+              $(this).parent().find(".find-pf-dropdown-container").toggle();
+            });
+            // Upon clicking the find close button, hide the find dropdown content
+            $(".btn-find-close").click(function () {
+              $(".find-pf-dropdown-container").hide();
+            });
+          });
+        })(jQuery);
+      &lt;/script&gt;</pre>
         </div>
       </div>
     </div>
   </div>
 </div>
+<script>
+(function($) {
+  $(document).ready(function() {
+    // Upon clicking the find button, show the find dropdown content
+    $(".btn-find").click(function () {
+      $(this).parent().find(".find-pf-dropdown-container").toggle();
+    });
+    // Upon clicking the find close button, hide the find dropdown content
+    $(".btn-find-close").click(function () {
+      $(".find-pf-dropdown-container").hide();
+    });
+
+  });
+})(jQuery);
+</script>


### PR DESCRIPTION
Fix for issue #293.
Problem is that the javascript was inside the toolbar.html, that was being imported twice. Thus, the duplicated javascript was not working.
I removed the javascript from the toolbar.html and added it to the page code.
This depends on an update in patternfly project.