### PR TITLE
Cleaning up the contribute page.

### DIFF
--- a/source/get-started/contribute/index.md
+++ b/source/get-started/contribute/index.md
@@ -16,8 +16,8 @@ PatternFly adheres to the [Contributor Covenant Code of Conduct][1]. As a Patter
 
 ### Contact Us
 By contacting the community you can get feedback on the contributions or ideas that you’re excited about. Here are the best ways to get in touch:
-- Chat (IRC):
-  - Join us in the [#patternfly channel on Freenode][2]. If you don't have an IRC client, you can use the [web-based][3] client.
+- Chat (Slack):
+  - Join the conversation on [Slack][2].
 - Mailing List:
   - [Subscribe to our mailing list][4] to participate or follow a variety of discussions on both technical and design topics. This is also a good place to ask questions, gather requirements, or join forces with other community members. Older threads are found in the [archive][5].
 - Community Meetings:
@@ -25,8 +25,8 @@ By contacting the community you can get feedback on the contributions or ideas t
 
 ## Contribute
 
-### Reports Bugs
-Before creating a bug report, check the list of [known bugs][7] and [open issues][8]. Bugs are tracked as [GitHub issues][9]. When you create a bug report, include as many details as possible, use a clear and descriptive title, and remember that an image is worth a thousand words, so try to add images and links to rawgit when possible.
+### Report Bugs
+Bugs are tracked as GitHub issues. Before creating a bug report, check the list of [known bugs and issues][7]. When you create a bug report, include as many details as possible, use a clear and descriptive title, and remember that an image is worth a thousand words, so try to add images and links to rawgit when possible.
 
 ### Proposing or Modifying a Design  
 You may want to start by sharing your idea on the mailing list ([patternfly@redhat.com][4]) to kick off the discussion. A design proposal may have many forms, but it should answer these questions:
@@ -34,11 +34,11 @@ You may want to start by sharing your idea on the mailing list ([patternfly@redh
 - What problem does it solve?
 - When do you use it or what are the use cases?
 
-Once your design proposal is ready for review, send a [pull request (PR)][10] written in [markdown][11] to the [PatternFly Doc repo][12]. The PR will be a way to discuss and refine the design with the goal of merging it as PatternFly documentation and making it viewable on patternfly.org. Design documents are living documents, therefore new PRs may be opened to add to or modify the documentation as necessary.
+Once your design proposal is ready for review, send a [pull request (PR)][10] written in [markdown][11] to the [PatternFly Design repo][12]. The PR will be a way to discuss and refine the design with the goal of merging it as PatternFly documentation and making it viewable on patternfly.org. Design documents are living documents, therefore new PRs may be opened to add to or modify the documentation as necessary.
 
 If you don’t know how to send a PR using GitHub, don’t worry! We are aware that GitHub was created by and for developers. That’s why we’ve created [guides][13] to get you up and running. If you need additional help, [contact us][4].
 
-### Contributing code
+### Contributing Code
 Check out our [PatternFly Code Guide][14]. Both developers and designers review PRs, so if you are committing a new design or modifying an existing design, be sure to add a link to a graphic or a working version on rawgit so that designers can preview the request.
 
 To provide as much background as possible to reviewers, when possible, provide a link to the design documentation or specification that supported the development of the code. If you need help or guidance, [contact us][4].
@@ -46,14 +46,12 @@ To provide as much background as possible to reviewers, when possible, provide a
 The PR will be reviewed by the community and merged once two people from the team approve it.
 
  [1]: http://contributor-covenant.org/
- [2]: http://webchat.freenode.net/?channels=#patternfly
- [3]: http://webchat.freenode.net/?channels=patternfly
- [4]: mailto:patternfly@redhat.com
+ [2]: https://patternfly.slack.com
+ [4]: https://www.redhat.com/mailman/listinfo/patternfly
  [5]: https://www.redhat.com/archives/patternfly/
  [6]: https://www.patternfly.org/community/monthly-community-meeting/
- [7]:https://patternfly.atlassian.net/issues/?filter=10300
+ [7]:https://github.com/patternfly/patternfly/issues
  [8]: https://github.com/patternfly/patternfly/labels/bug
- [9]: https://guides.github.com/features/issues/
  [10]: https://help.github.com/articles/using-pull-requests/
  [11]:https://guides.github.com/features/mastering-markdown/
  [12]: https://github.com/patternfly/patternfly-design


### PR DESCRIPTION
- Typo "Reports Bugs"
- Updated Slack info
- Updated links to GitHub issues vs Jira since this is where community is tracking bugs. Jira issues link is empty.
- Fixed "Contributing code" to "Contributing Code"
- Renamed Doc Repo to match the repo (“PatternFly Design Repo”)
- Subscribe to our mailing list is a link to send us an email, updated link to be able to subscribe.

