### PR TITLE
Table View - Selected Row color not being applied

### DIFF
--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -38,6 +38,12 @@
   <script src="{{ "/components/c3/c3.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/components/d3/d3.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/components/datatables/media/js/jquery.dataTables.js" | prepend: site.baseurl }}"></script>
+  <script src="//cdn.datatables.net/select/1.2.0/js/dataTables.select.min.js"></script>
+  <script src="{{ "/components/patternfly/dist/js/patternfly.dataTables.pfEmpty.min.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/components/patternfly/dist/js/patternfly.dataTables.pfFilter.min.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/components/patternfly/dist/js/patternfly.dataTables.pfPagination.min.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/components/patternfly/dist/js/patternfly.dataTables.pfResize.min.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/components/patternfly/dist/js/patternfly.dataTables.pfSelect.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/components/google-code-prettify/bin/prettify.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/components/clipboard/dist/clipboard.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/components/patternfly/dist/js/patternfly.min.js" | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
This PR is used to fix the [bug](https://github.com/patternfly/patternfly/issues/577).

Additionally, there are still two issues we need to consider:

1.  Maybe we should add datatables.net-select as a dependency in bower.js file of patternfly repo. Then we can introduce datatables.net-select with the form of ``` <script src="{{ "/components/...```

2. I found that the following code snippets of patternfly-site.js have a conflict with the page resize feature of table-view. @rhamilto, could you re-verify the practical use of the following sentence. As far as now, I can not  find any changes or issues if I delete this statement.
````js
  // Initialize Bootstrap-select
  jQuery('.selectpicker').selectpicker();
````