### PR TITLE
A CSS hack to fix the tables that were covering the links

### DIFF
--- a/source/styles/icons/index.md
+++ b/source/styles/icons/index.md
@@ -7,9 +7,9 @@ PatternFly icons are two dimensional and flat. Most of the icons are gray, with 
 
 PatternFly includes custom icons and selections from [IcoMoon &#8211; Free][1] and [FontAwesome][2]. Not all of the FontAwesome icons are recommended for use with PatternFly, but are included for convenience. [Bootstrap Glyphicons][3] are also included in PatternFly, but are not recommended for use. See below for recommendations.
 
-To copy any icon to the clipboard, just click on the icon. To use an icon within desktop applications, install [PatternFlyIcons-webfont.ttf](https://github.com/patternfly/patternfly/raw/master-dist/dist/fonts/PatternFlyIcons-webfont.ttf) or [FontAwesome.otf](https://github.com/patternfly/patternfly/raw/master-dist/dist/fonts/FontAwesome.otf), set it as the font in your application, and paste the icons into your designs.
+To copy any icon to the clipboard, just click on the icon. To use an icon within desktop applications, install [PatternFlyIcons-webfont.ttf][4] or [FontAwesome.otf][5], set it as the font in your application, and paste the icons into your designs.
 
-You can also download the set of [PatternFly icon SVGs](https://rawgit.com/patternfly/patternfly-design/master/styles/icons/patternfly-svg-icons.zip).
+You can also download the set of [PatternFly icon SVGs][6].
 
 <div class="row">
   <div class="col-sm-6 col-md-6 icomoon">
@@ -22,9 +22,15 @@ You can also download the set of [PatternFly icon SVGs](https://rawgit.com/patte
   </div>
 </div>
 
+<style>
+.post_content h2[id], .post_content h3[id], .post_content h4[id], .post_content h5[id], .post_content p[id] {
+  margin-top: 0;
+  padding-top: 0;
+}
+</style>
+
 <script>
   $('table td:nth-child(3),th:nth-child(3)').hide();
-  $('table').addClass('table table-striped table-bordered')
   $('td').tooltip({container: 'body'}).attr('title', 'Copy to clipboard').tooltip('fixTitle');
   var clipboard = new Clipboard('td', {
     text: function (trigger) {
@@ -62,4 +68,6 @@ You can also download the set of [PatternFly icon SVGs](https://rawgit.com/patte
  [1]: http://icomoon.io/#icons
  [2]: http://fontawesome.io/icons/
  [3]: http://getbootstrap.com/components/#glyphicons
- [4]: {{site.baseurl}}/styles/icons/cheatsheet
+ [4]: https://github.com/patternfly/patternfly/raw/master-dist/dist/fonts/PatternFlyIcons-webfont.ttf
+ [5]: https://github.com/patternfly/patternfly/raw/master-dist/dist/fonts/FontAwesome.otf
+ [6]: https://rawgit.com/patternfly/patternfly-design/master/styles/icons/patternfly-svg-icons.zip


### PR DESCRIPTION
There is an offending line in our site CSS that positions the table overtop of the paragraph, so the padding of the table obscures the links and captures the click events.  This PR introduces a style tag into the page to overcome this bug.  A proper treatment of the underlying CSS problem will be followed up on in a PTNFLY story.

cc: @jennyhaines @LHinson 