### PR TITLE
fix jQuery selector

### DIFF
--- a/source/assets/js/patternfly-site.js
+++ b/source/assets/js/patternfly-site.js
@@ -35,7 +35,7 @@ jQuery( document ).ready(function() {
     for (var i=0;i<hpieces.length;i++) {
       var domelid = hpieces[i].replace(prefix,'');
       if (domelid) {
-        var domitem = $('a[href=#' + domelid + '][data-toggle=tab]');
+        var domitem = $('a[href="#' + domelid + '"][data-toggle=tab]');
         if (domitem.length > 0) {
           domitem.tab('show');
         }


### PR DESCRIPTION
Fix for URL handling in Pattern Library.

jQuery requires special characters in quotes, i.e. `a[href="#api"]`, instead of just `a[href=#api]` (which doesn't work and unlike other situations throws an error).