### PR TITLE
fixed typo in readme.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The site is generated using [Jekyll](http://jekyllrb.com/).  After ensuring Ruby
 
 A local development server can be quickly fired up by using the Gruntjs server task:
 
-    grunt serve
+    grunt server
 
 This local server (i.e., [http://localhost:9002](http://localhost:9002)) has the advantage of having livereload integration. Thus, if you start the Gruntjs server, any changes you make to `.html` or `.less` files will be automatically reloaded into your browser and the changes reflected almost immediately. This has the obvious benefit of not having to refresh your browser and still be able to see the changes as you add or remove them from your development files.  Additionally, any changes made to Jekyll source files (`source/`) will trigger a Jekyll build.
 


### PR DESCRIPTION
original readme has "grunt serve" to start up the server and it should be "grunt server"