### PR TITLE
📝 Fix the `grunt serve` command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The site is generated using [Jekyll](http://jekyllrb.com/).  After ensuring Ruby
 
 A local development server can be quickly fired up by using the Gruntjs server task:
 
-    grunt server
+    grunt serve
 
 This local server (i.e., [http://localhost:9002](http://localhost:9002)) has the advantage of having livereload integration. Thus, if you start the Gruntjs server, any changes you make to `.html` or `.less` files will be automatically reloaded into your browser and the changes reflected almost immediately. This has the obvious benefit of not having to refresh your browser and still be able to see the changes as you add or remove them from your development files.  Additionally, any changes made to Jekyll source files (`source/`) will trigger a Jekyll build.
 
@@ -46,5 +46,5 @@ This local server (i.e., [http://localhost:9002](http://localhost:9002)) has the
 
 Asssuming you've completed <a href="#development-setup">Development Setup</a>, from a command line run:
 
-1. `grunt server`
+1. `grunt serve`
 1.  Visit [http://localhost:9002](http://localhost:9002)


### PR DESCRIPTION
This will avoid running into a problem where the target is `undefined`
e.g.

```
Running "serve:undefined" (serve) task

....

Running "jekyll:undefined" (jekyll) task
Verifying property jekyll.undefined exists in config...ERROR
>> Unable to process task.
Warning: Required config property "jekyll.undefined" missing. Use --force to continue.
```