### PR TITLE
Fixing incorrect code sample for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "connect": "^3.5.0",
     "connect-livereload": "~0.3.0",
     "grunt": "~0.4.1",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^0.12.3",

--- a/source/get-started/setup/index.md
+++ b/source/get-started/setup/index.md
@@ -78,7 +78,7 @@ layout: page
 <div class="row">
   <div class="col-xs-12 col-sm-12 col-md-12">
     <h3>Step 3: Apply PatternFly in your project</h3>
-    <p>Now we can includ the necessary assets by directly specifying their path inside the node_modules folder.</p>
+    <p>Now we can include the necessary assets by directly specifying their path inside the node_modules folder.</p>
   </div>
   <div class="col-xs-12 col-sm-12 col-md-12">
     <pre class="prettyprint">
@@ -87,8 +87,8 @@ layout: page
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css">
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly-additions.min.css">
+  <link rel="stylesheet" type="text/css" href="/node_modules/patternfly/dist/css/patternfly.css">
+  <link rel="stylesheet" type="text/css" href="/node_modules/patternfly/dist/css/patternfly-additions.css">
 </head>
 <body>
   <div class="container">
@@ -101,9 +101,8 @@ layout: page
 
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css"></script>
+  <script src="/node_modules/jquery/dist/jquery.js"></script>
+  <script src="/node_modules/bootstrap/dist/js/bootstrap.js"></script>
 </body>
 </html>
 {% endescape_html %}</code>


### PR DESCRIPTION
Corrected typo and added correct path for setting up patternfly page using npm. This would close #426

<img width="1234" alt="screen shot 2017-07-06 at 2 35 55 pm" src="https://user-images.githubusercontent.com/20052391/27927078-95b625a4-6258-11e7-9b36-d22dee731eec.png">

