### PR TITLE
Date picker year behind navbar z-index fix

### DIFF
--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -384,6 +384,7 @@ header {
     font-size: @font-size-base + 1;
     margin-bottom: 0;
     filter: progid:DXImageTransform.Microsoft.gradient(enabled = false) !important;
+    z-index: 1;
     .home & {
       background: transparent !important;
       position: absolute !important;


### PR DESCRIPTION
Added a z-index to navbar to fix date picker year issue which would close #388 and #361 

<img width="1424" alt="screen shot 2017-07-11 at 4 19 14 pm" src="https://user-images.githubusercontent.com/20052391/28088751-b9aa2302-6654-11e7-9f3f-d134ef6636df.png">


I also played around in dev tools with moving the top to 70px for the date picker since it was absolute positioned but that would put it too close to the "Reference Markup" text and it would need to be moved over more to the right in that case. 

Can you please review @bleathem and @andresgalante :)