### PR TITLE
Semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: ruby
 rvm:
   - 2.3.1
 
+cache:
+  directories:
+    - node_modules
+
+notifications:
+  email: false
+
 env:
   global:
   - ENCRYPTION_LABEL: "195bd079f767"
@@ -22,4 +29,10 @@ script:
 
 after_success:
   - grunt build:production
+  - npm prune
+  - npm run semantic-release
   - npm run publish-travis
+
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "patternfly-org",
-  "version": "3.26.1",
+  "version": "0.0.0-semantically-released",
   "author": "Red Hat",
+  "release": {
+    "branch": "master",
+    "debug": false
+  },
   "scripts": {
     "publish": "ghpages",
     "publish-travis": "ghpages -t -r 'git@github.com:patternfly/patternfly.github.io.git' -b master _site",
-    "grunt": "grunt"
+    "grunt": "grunt",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "license": "Apache-2.0",
   "devDependencies": {
@@ -28,8 +33,9 @@
     "matchdep": "~0.3.0",
     "open": "0.0.5",
     "patternfly-eng-publish": "0.1.0-alpha.19",
-    "patternfly-eng-release": "3.26.2",
-    "serve-static": "^1.11.2"
+    "patternfly-eng-release": "^3.26.5",
+    "serve-static": "^1.11.2",
+    "semantic-release": "^6.3.6"
   },
   "description": "Documentation, etc. for PatternFly",
   "repository": {


### PR DESCRIPTION
Added semantic release to create a new package versions from master.

Note that the patternfly-eng-release scripts will continue to run npm install, bower install, grunt build, grunt ngdocs:publish, npm test, nsp shrinkwrap audit, and will verify npm/bower installs. An npm shrinkwrap file will also be created and committed to master-dist along with other generated files. The scripts will continue to ensure master-dist is not published during pull requests and tagged builds -- it must be a merge to master and not a fork.