### PR TITLE
Includes css to overwrite ng-docs.css for app launcher

### DIFF
--- a/source/_includes/code/application-framework/launcher/code.md
+++ b/source/_includes/code/application-framework/launcher/code.md
@@ -1,3 +1,5 @@
+<div class="example-navbar">
+
 <h2>Horizontal Nav Bar</h2>
 
 <h3>Grid Menu</h3>
@@ -34,6 +36,8 @@
 
 <h4>No Icons</h4>
 {% include widgets/layouts/navbar-vertical.html launcher-grid=false launcher-icons=false navindex=8 %}
+
+</div>
 
 <script>
   $(document).ready(function() {

--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -151,6 +151,13 @@ body {
     margin: 0;
   }
 }
+// Overwriting inherited ng-docs.css styles for vertical nav example.
+.example-navbar .navbar-pf-vertical{
+  .navbar-brand > img {
+    height: auto;
+    width: auto;
+  }
+}
 
 .example-pf {
   font-size: @font-size-base;


### PR DESCRIPTION
CSS in ng-docs.css was causing the issue noted in #451 related to the logo. I found that the horizontal nav example had additional css to fix this. I added the same class `example-navbar`, and then included additional css for this class to fix the display within the vertical nav as well.