### PR TITLE
Updated community meeting page for PF-R

### DIFF
--- a/source/community/monthly-community-meeting/index.md
+++ b/source/community/monthly-community-meeting/index.md
@@ -33,7 +33,7 @@ layout: page
 <li>Patternfly Web Components: Brian Leathem and Patrick Riley </li>
 </ul>
 
-<h2>Upcoming Community Meetings and Agendas</h2>
+<!-- <h2>Upcoming Community Meetings and Agendas</h2>
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -61,7 +61,7 @@ layout: page
       <td><a target="blank" href="https://github.com/patternfly/patternfly-react/wiki/PatternFly-React-Community-Meeting">View Agenda</a></td>
     </tr>
   </tbody>
-</table>
+</table> -->
 
 
 <h2>Prior Community Meeting's Recording and Slides</h2>
@@ -76,12 +76,24 @@ layout: page
   </thead>
 
   <tbody>
-  <tr>
-    <td>Angular-PatternFly</td>
-    <td>August 17, 2017</td>
-    <td><a href="https://github.com/patternfly/patternfly-design/blob/master/resources/community-meetings/angular-patternfly-community/angular-patternfly-community-meeting-08-2017.pdf">View Slides</a></td>
-    <td><a target="blank" href="https://bluejeans.com/s/sPZk/">View Recording</a></td>
-  </tr>
+    <tr>
+      <td>PatternFly-React</td>
+      <td>August 22, 2017</td>
+      <td><a href="https://www.dropbox.com/s/vfm3ra52zvuny46/PatternFly-React-2017-08.pdf?dl=0">View Slides</a></td>
+      <td><a target="blank" href="https://bluejeans.com/s/gvCY5">View Recording</a></td>
+    </tr>
+    <tr>
+      <td>PatternFly-ng</td>
+      <td>August 22, 2017</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Angular-PatternFly</td>
+      <td>August 17, 2017</td>
+      <td><a href="https://github.com/patternfly/patternfly-design/blob/master/resources/community-meetings/angular-patternfly-community/angular-patternfly-community-meeting-08-2017.pdf">View Slides</a></td>
+      <td><a target="blank" href="https://bluejeans.com/s/sPZk/">View Recording</a></td>
+    </tr>
     <tr>
       <td>PatternFly-ng</td>
       <td>August 2, 2017</td>


### PR DESCRIPTION
I moved meeting info for the PatternFly-ng and PatternFly-React meetings to the Prior Meetings section, and included a link to slides and recording for the React meeting.

I chatted with @catrobson about posting contents for the pf-ng meeting, and she will add that later, so I left those table cells empty for now.