### PR TITLE
Fix PatternFly JS URL in setup page

### DIFF
--- a/source/get-started/setup/index.md
+++ b/source/get-started/setup/index.md
@@ -37,7 +37,7 @@ layout: page
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/css/patternfly.min.css"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.24.0/js/patternfly.min.js"></script>
 </body>
 </html>
 {% endescape_html %}</code>


### PR DESCRIPTION
I found a tiny typo in Setting Up PatternFly page. It's a trivial but beginners may stumble at this by their copy&paste first trial.

Thank you!