### PR TITLE
Added links to the showcase implementations

### DIFF
--- a/source/_layouts/page-pattern.html
+++ b/source/_layouts/page-pattern.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+url-js-extra: ['']
 ---
 <div id="main" class="col-md-12 clearfix" role="main">
   <article class="post">
@@ -40,31 +41,55 @@ layout: default
               {% if page.impl_angular %}
                 <li class="pforg-code__showcase-link-item">
                   <a href="{{ page.impl_angular }}" target="patternfly_showcase">
-                    <button><i class="fa fa-external-link" aria-hidden="true"></i> Angular PatternFly</button>
+                    <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Pattern implementation in angular-patternfly">
+                      <i class="fa fa-external-link" aria-hidden="true"></i>
+                      Angular PatternFly
+                    </button>
                   </a>
                 </li>
               {% else %}
-                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled"><button><i class="fa fa-external-link" aria-hidden="true"></i> Angular PatternFly</button></a></li>
+                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled">
+                  <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for angular-patternfly">
+                    <i class="fa fa-external-link" aria-hidden="true"></i>
+                    Angular PatternFly
+                  </button>
+                </li>
               {% endif %}
 
               {% if page.impl_ng %}
                 <li class="pforg-code__showcase-link-item">
                   <a href="{{ page.impl_ng }}" target="patternfly_showcase">
-                    <button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly Ng</button>
+                    <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Pattern implementation in patternfly-ng">
+                      <i class="fa fa-external-link" aria-hidden="true"></i>
+                      PatternFly Ng
+                    </button>
                   </a>
                 </li>
               {% else %}
-                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled"><button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly Ng</button></a></li>
+                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled disabled">
+                  <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for patternfly-ng">
+                    <i class="fa fa-external-link" aria-hidden="true"></i>
+                    PatternFly Ng
+                  </button></a>
+                </li>
               {% endif %}
 
               {% if page.impl_react %}
                 <li class="pforg-code__showcase-link-item">
                   <a href="{{ page.impl_react }}" target="patternfly_showcase">
-                    <button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly React</button>
+                    <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Pattern implementation in patternfly-react">
+                      <i class="fa fa-external-link" aria-hidden="true"></i>
+                      PatternFly React
+                    </button>
                   </a>
                 </li>
               {% else %}
-                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled"><button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly React</button></a></li>
+                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled disabled">
+                  <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for patternfly-react">
+                    <i class="fa fa-external-link" aria-hidden="true"></i>
+                    PatternFly React
+                  </button>
+                </li>
               {% endif %}
             </ul>
           </div>
@@ -89,4 +114,11 @@ layout: default
       h1.style.display = 'none';
     });
   }
+  // Initialize Tooltip
+  $(document).ready(function() {
+    $('#code').tooltip({
+      selector: "[data-toggle=tooltip]",
+      container: "body"
+    });
+  });
 </script>

--- a/source/_layouts/page-pattern.html
+++ b/source/_layouts/page-pattern.html
@@ -41,7 +41,7 @@ url-js-extra: ['']
               {% if page.impl_angular %}
                 <li class="pforg-code__showcase-link-item">
                   <a href="{{ page.impl_angular }}" target="patternfly_showcase">
-                    <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Pattern implementation in angular-patternfly">
+                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Pattern implementation in angular-patternfly">
                       <i class="fa fa-external-link" aria-hidden="true"></i>
                       Angular PatternFly
                     </button>
@@ -49,7 +49,7 @@ url-js-extra: ['']
                 </li>
               {% else %}
                 <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled">
-                  <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for angular-patternfly">
+                  <button type="button" class="btn btn-default disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for angular-patternfly">
                     <i class="fa fa-external-link" aria-hidden="true"></i>
                     Angular PatternFly
                   </button>
@@ -59,7 +59,7 @@ url-js-extra: ['']
               {% if page.impl_ng %}
                 <li class="pforg-code__showcase-link-item">
                   <a href="{{ page.impl_ng }}" target="patternfly_showcase">
-                    <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Pattern implementation in patternfly-ng">
+                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Pattern implementation in patternfly-ng">
                       <i class="fa fa-external-link" aria-hidden="true"></i>
                       PatternFly Ng
                     </button>
@@ -67,7 +67,7 @@ url-js-extra: ['']
                 </li>
               {% else %}
                 <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled disabled">
-                  <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for patternfly-ng">
+                  <button type="button" class="btn btn-default disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for patternfly-ng">
                     <i class="fa fa-external-link" aria-hidden="true"></i>
                     PatternFly Ng
                   </button></a>
@@ -77,7 +77,7 @@ url-js-extra: ['']
               {% if page.impl_react %}
                 <li class="pforg-code__showcase-link-item">
                   <a href="{{ page.impl_react }}" target="patternfly_showcase">
-                    <button type="button" class="btn" data-toggle="tooltip" data-placement="top" title="Pattern implementation in patternfly-react">
+                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Pattern implementation in patternfly-react">
                       <i class="fa fa-external-link" aria-hidden="true"></i>
                       PatternFly React
                     </button>
@@ -85,7 +85,7 @@ url-js-extra: ['']
                 </li>
               {% else %}
                 <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled disabled">
-                  <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for patternfly-react">
+                  <button type="button" class="btn btn-default disabled" data-toggle="tooltip" data-placement="top" title="Pattern implementation not available for patternfly-react">
                     <i class="fa fa-external-link" aria-hidden="true"></i>
                     PatternFly React
                   </button>

--- a/source/_layouts/page-pattern.html
+++ b/source/_layouts/page-pattern.html
@@ -34,29 +34,45 @@ layout: default
           {% endif %}
         </div>
         <div role="tabpanel" class="tab-pane" id="code">
-          {% if page.code_html == false and page.code_angular != false %}
-            {% include nav-tabs-code.html html=false %}
-          {% elsif page.code_html != false and page.code_angular == false %}
-            {% include nav-tabs-code.html angular=false %}
-          {% elsif page.code_html == false and page.code_angular == false %}
-            {% include nav-tabs-code.html html=false angular=false %}
-          {% else %}
-            {% include nav-tabs-code.html %}
-          {% endif %}
-          <div class="tab-content">
-            <div role="tabpanel" class="tab-pane nested{% if page.code_html %} active{% endif %}" id="html-css">
-              {% if page.code_html %}
-                {% include {{page.code_html}} %}
+          <div class="pforg-code__title-row">
+            <h2 class="pforg-code__core-example-title">PatternFly Core Example</h2>
+            <ul class="pforg-code__showcase-link-list">
+              {% if page.impl_angular %}
+                <li class="pforg-code__showcase-link-item">
+                  <a href="{{ page.impl_angular }}" target="patternfly_showcase">
+                    <button><i class="fa fa-external-link" aria-hidden="true"></i> Angular PatternFly</button>
+                  </a>
+                </li>
+              {% else %}
+                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled"><button><i class="fa fa-external-link" aria-hidden="true"></i> Angular PatternFly</button></a></li>
               {% endif %}
-            </div>
-            <div role="tabpanel" class="tab-pane nested{% if page.code_html == nil or page.code_html == false %} active{% endif %}" id="angular">
-              <div ng-app="docsApp" ng-controller="DocsController" class="content">
-                {% if page.code_angular %}
-                  <div ng-include src="'{{site.baseurl}}{{page.code_angular}}'"></div>
-                {% endif %}
-                <!-- % include {{page.code}} % -->
-              </div>
-            </div>
+
+              {% if page.impl_ng %}
+                <li class="pforg-code__showcase-link-item">
+                  <a href="{{ page.impl_ng }}" target="patternfly_showcase">
+                    <button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly Ng</button>
+                  </a>
+                </li>
+              {% else %}
+                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled"><button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly Ng</button></a></li>
+              {% endif %}
+
+              {% if page.impl_react %}
+                <li class="pforg-code__showcase-link-item">
+                  <a href="{{ page.impl_react }}" target="patternfly_showcase">
+                    <button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly React</button>
+                  </a>
+                </li>
+              {% else %}
+                <li class="pforg-code__showcase-link-item pforg-code__showcase-link-item__disabled"><button><i class="fa fa-external-link" aria-hidden="true"></i> PatternFly React</button></a></li>
+              {% endif %}
+            </ul>
+          </div>
+          <div class="" id="html-css">
+            {% if page.code_html %}
+              {% include {{page.code_html}} %}
+            {% endif %}
+          </div>
           </div>
         </div>
       </div>

--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -1442,3 +1442,32 @@ th {
     }
   }
 }
+
+.pforg-code__title-row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.pforg-code__core-example-title {
+  margin: 0;
+  padding: 0;
+}
+
+.pforg-code__showcase-link-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.pforg-code__showcase-link-item {
+  display: block;
+  padding-left: 2rem;
+  a {
+    color: @color-pf-black-900;
+  }
+}
+
+.pforg-code__showcase-link-item__disabled {
+  color: @color-pf-black-500;
+}

--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -1463,7 +1463,4 @@ th {
 .pforg-code__showcase-link-item {
   display: block;
   padding-left: 2rem;
-  a {
-    color: @color-pf-black-900;
-  }
 }

--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -1467,7 +1467,3 @@ th {
     color: @color-pf-black-900;
   }
 }
-
-.pforg-code__showcase-link-item__disabled {
-  color: @color-pf-black-500;
-}


### PR DESCRIPTION
This resolves a portion of [PTNFLY-2599](https://patternfly.atlassian.net/browse/PTNFLY-2599)

I have staged the site built with this PR, you can see the result here:
https://bleathem.github.io/patternfly-org/stage/showcase-links/pattern-library/communication/inline-notifications/#code

Some pages do not have a HTML/CSS (jQuery) example, and so end up looking a little odd:
https://bleathem.github.io/patternfly-org/stage/showcase-links/pattern-library/data-visualization/heat-map/#code