### PR TITLE
Update meeting page for recent pf-r meeting

### DIFF
--- a/source/community/monthly-community-meeting/index.md
+++ b/source/community/monthly-community-meeting/index.md
@@ -26,7 +26,7 @@ layout: page
 <li>Patternfly Web Components: Patrick Riley </li>
 </ul>
 
-<h2>Upcoming Community Meetings and Agendas</h2>
+<!-- <h2>Upcoming Community Meetings and Agendas</h2>
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -47,7 +47,7 @@ layout: page
       <td><a target="blank" href="https://github.com/patternfly/patternfly-react/wiki/PatternFly-React-Community-Meeting">View Agenda</a></td>
     </tr>
   </tbody>
-</table>
+</table> -->
 
 
 <h2>Prior Community Meeting's Recording and Slides</h2>
@@ -62,6 +62,12 @@ layout: page
   </thead>
 
   <tbody>
+    <tr>
+      <td>PatternFly-React</td>
+      <td>January 10, 2018</td>
+      <td><a href="https://www.dropbox.com/s/s2n3u98wk38hcg1/PatternFly-React-2018-01.pdf?dl=0">View Slides</a></td>
+      <td><a target="blank" href="https://bluejeans.com/s/r2TX1/">View Recording</a></td>
+    </tr>
     <tr>
       <td>PatternFly-React</td>
       <td>December 7, 2017</td>


### PR DESCRIPTION
I updated the community meeting page to include links to slides and the recording for the Jan 2018 patternfly-react community meeting.