### PR TITLE
dropdown misspelling and space around "Widgets" in left nav

### DIFF
--- a/source/_includes/code/navigation/horizontal-navigation/code.md
+++ b/source/_includes/code/navigation/horizontal-navigation/code.md
@@ -1,4 +1,4 @@
-<p>Jump to <a href="#example-code-1">Standard Horizontal Navigation</a>, <a href="#example-code-2">Single-Level Menu Bar</a>, <a href="#example-code-3">Two-Level Menu Bar</a>, or <a href="#example-code-4">Menu Bar with Drop-Downs</a></p>
+<p>Jump to <a href="#example-code-1">Standard Horizontal Navigation</a>, <a href="#example-code-2">Single-Level Menu Bar</a>, <a href="#example-code-3">Two-Level Menu Bar</a>, or <a href="#example-code-4">Menu Bar with Dropdowns</a></p>
 <h2 id="example-code-1">Standard Horizontal Navigation</h2>
 <div class="example-pf">
   <iframe src="{{ site.baseurl}}/pattern-library/navigation/horizontal-navigation/horizontal-navigation.html"
@@ -48,7 +48,7 @@ $().setupVerticalNavigation(true);
 <div class="collapse in" id="markup-3">
   <pre class="prettyprint">{% capture markup_include %}{% include widgets/navigation/horizontal-persistent-secondary-tertiary.html %}{% endcapture %}{{ markup_include | xml_escape }}</pre>
 </div>
-<h2 id="example-code-4">Menu Bar with Drop-Downs</h2>
+<h2 id="example-code-4">Menu Bar with Dropdowns</h2>
 <div class="example-pf example-navbar">
   {% include widgets/navigation/horizontal-multi-level.html %}
 </div>

--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -120,7 +120,9 @@
               {% endfor %}
 
               <li {% if secondary == 'widgets' %} class="active"{% endif %}>
-              <a class="{% if secondary == 'widgets' %}{% else %}collapsed{% endif %}" role="button" data-toggle="collapse" href="#widgets-secondary" aria-expanded="{% if secondary == 'widgets' %}true{% else %}false{% endif %}" aria-controls="widgets-secondary">Widgets</a>
+              <a class="{% if secondary == 'widgets' %}{% else %}collapsed{% endif %}" role="button" data-toggle="collapse" href="#widgets-secondary" aria-expanded="{% if secondary == 'widgets' %}true{% else %}false{% endif %}" aria-controls="widgets-secondary">
+                Widgets
+              </a>
               <ul class="collapse {% if secondary == 'widgets' %}in{% endif %}" id="widgets-secondary">
                 <li {% if tertiary == 'overview' %} class="active"{% endif %}>
                 <a href="{{ site.baseurl }}/pattern-library/widgets/">Overview</a>


### PR DESCRIPTION
* normalize spelling of "dropdown"
* add white space to "Widgets" in the left/burger menu so it aligns with the rest of the links