### PR TITLE
Updating image path to show code icon for when no core code available

### DIFF
--- a/source/_layouts/page-pattern.html
+++ b/source/_layouts/page-pattern.html
@@ -89,7 +89,7 @@ url-js-extra: ['']
             {% else %}
             <div class="pforg-no-code">
               <div class="pforg-no-code-icon">
-                <img src="/patternfly-org/assets/img/icon-code-clear.svg" alt="Code icon">
+                <img src="/img/icon-code-clear.svg" alt="Code icon">
               </div>
               <h1>
                 PatternFly Core Example Not Available


### PR DESCRIPTION
Updating the image path to show code icon. Closes #508 