### PR TITLE
Updating the img path for the icon when no pf-core code available

### DIFF
--- a/source/_layouts/page-pattern.html
+++ b/source/_layouts/page-pattern.html
@@ -89,7 +89,7 @@ url-js-extra: ['']
             {% else %}
             <div class="pforg-no-code">
               <div class="pforg-no-code-icon">
-                <img src="/patternfly-org/assets/img/icon-code-clear.svg" alt="Code icon">
+                <img src="/assets/img/icon-code-clear.svg" alt="Code icon">
               </div>
               <h1>
                 PatternFly Core Example Not Available


### PR DESCRIPTION
Making a second update to change the image path from ```/img/icon-code-clear.svg"``` to ```/assets/img/icon-code-clear.svg"``` in order to show the icon for when there is no pf-core code available.

<img width="1388" alt="screen shot 2018-01-18 at 3 41 17 pm" src="https://user-images.githubusercontent.com/20052391/35165896-fdcc6b7a-fd1d-11e7-995e-c82fbd1dadf3.png">

Note:
#509 contained the wrong path needed to render the icon on to pf-org
