### PR TITLE
Adding url hash when clicking overview/design/code tabs

### DIFF
--- a/source/_includes/nav-tabs-pattern.html
+++ b/source/_includes/nav-tabs-pattern.html
@@ -25,4 +25,17 @@
             $(document).fireEvent('onresize');
         }
     });
+
+    $(function () {
+        // updates and adds url hash to tab
+        var hash = window.location.hash;
+        hash && $('ul.nav a[href="' + hash + '"]').tab('show');
+
+        // scroll to the top when clicking the tab rather than to the id
+        $('.nav-tabs a').click(function () {
+            var scroll = $('body').scrollTop() || $('html').scrollTop();
+            window.location.hash = this.hash;
+            $('html,body').scrollTop(scroll);
+        });
+    });
 </script>


### PR DESCRIPTION
Updating url hash when clicking tabs to reflect the panel that it is clicked on. This will allow the browser to have a shareable link.

This would resolve and close #511 