### PR TITLE
Add template for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+A description of what is happening and why it is happening
+
+
+## Solution
+How the changes address the description from above
+
+
+## Related PRs
+List related PRs against other branches:
+
+
+## Related Issues
+List related issues:
+
+
+## Steps to reproduce
+List of steps to reproduce the bug or new functionality


### PR DESCRIPTION
## Description
PRs need more information to effectively understand the context
of the PR, and as a result they can be difficult to verify


## Solution
Adds a starter template for the body of all new PRs
