### PR TITLE
fix(info tip): Info tip .navbar-toggle also toggles the site's navbar

### DIFF
--- a/source/assets/js/patternfly-site.js
+++ b/source/assets/js/patternfly-site.js
@@ -94,7 +94,7 @@ jQuery( document ).ready(function() {
   //jQuery('.navbar-toggle-sidebar').on('click', function (e) {
     //jQuery('.navbar-sidebar').toggleClass('open');
   //});
-  jQuery('.navbar-toggle').on('click', function (e) {
+  jQuery('.navbar-fixed-top .navbar-toggle').on('click', function (e) {
     jQuery('.navbar-sidebar').toggleClass('open');
   });
 


### PR DESCRIPTION
This PR is targeted to fix issue - https://github.com/patternfly/patternfly-org/issues/474

Please review the [Demo page](https://rawgit.com/dabeng/patternfly-org/info-tip-dist/_site/pattern-library/widgets/#info-tip) to confirm conflict resolution.