### PR TITLE
Adding context selector example to pf-org

### DIFF
--- a/source/_includes/code/navigation/context-selector/code.md
+++ b/source/_includes/code/navigation/context-selector/code.md
@@ -1,0 +1,12 @@
+<h2 id="example-code-1">Example</h2>
+<div class="example-pf">
+    <iframe src="{{ site.baseurl}}/pattern-library/navigation/context-selector/context-selector-vertical-nav.html"
+      width="100%" height="650px;" scrolling="no" seamless></iframe>
+</div>
+<p>
+  <a href="https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/context-selector-vertical-nav.html" target="_blank">View full page example</a>
+</p>
+<p class="reference-markup"><a class="collapse-toggle" data-toggle="collapse" aria-expanded="true" aria-controls="markup-1" href="#markup-1">Reference Markup</a></p>
+<div class="collapse in" id="markup-1">
+  <pre class="prettyprint">{% capture markup_include %}{% include widgets/framework/context-selector.html %}{% endcapture %}{{ markup_include | xml_escape }}</pre>
+</div>

--- a/source/pattern-library/navigation/context-selector/context-selector-vertical-nav.html
+++ b/source/pattern-library/navigation/context-selector/context-selector-vertical-nav.html
@@ -1,0 +1,11 @@
+---
+title: Context Selector for Vertical Navigation
+author: amieelo
+css-extra: false
+resource: true
+layout: layout-fixed
+contextselector: true
+submenus: true
+url-js-extra: ['https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.2/jquery.matchHeight-min.js', 'https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js', 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js', 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/js/bootstrap-select.min.js']
+---
+{% include widgets/navigation/vertical-navigation.html %}


### PR DESCRIPTION
Related to this jira story: https://patternfly.atlassian.net/browse/PTNFLY-2786
and this issue: https://github.com/patternfly/patternfly-design/issues/589

Changes introduced:

1. ~~Creating a `doc.md` file for dev notes (which will also need to be included as a variable (`code_doc` in the design repo in a separate PR)~~ Dev notes can be added in a separate PR.
2. Include `contextselector: true` to the current vertical navigation on patternfly and add that to `code.md` file example as an iframe.

* [Preview](https://rawgit.com/amarie401/patternfly-org/context-selector-example-dist/_site/pattern-library/navigation/context-selector/#code)

Issues/Questions: 

1. The navbar brand logo for pf disappears when `contextselector:true` is present. I think it may have something to with this part of the code in [patternfly](https://github.com/patternfly/patternfly/blob/master/tests/pages/_includes/widgets/layouts/navbar-vertical.html#L11). Is this okay for the site?

2. In the prettyprint reference markup I tried including patternfly's `vertical-navigation.html` for the code snippet but the code doesn't contain the relevant context selector classes that are added. Not sure if it's okay to keep it this way or if there needs to be another file added into pf core that org can consume with the relevant classes already added to the vertical navigation.

Thoughts? @matthewcarleton @dgutride @cliffpyles @dabeng 