### PR TITLE
Populating pf-org overview page with design status page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,6 +183,14 @@ module.exports = function (grunt) {
         }
       }
     },
+    http: {
+      pattern_status: {
+        options: {
+           url: 'https://www.patternfly.org/patternfly-design/status/pattern-status.json'
+        },
+        dest: '_build/_data/pattern-status.json'
+      }
+    },
     jekyll: {
       options: {
         dest: '<%= config.site %>',
@@ -309,6 +317,7 @@ module.exports = function (grunt) {
     grunt.task.run([
       'clean',
       'reposUpdate',
+      'http:pattern_status',
       'copy:components',
       'sync:patternflyDist',
       'cname:' + target,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-uglify": "~0.3.2",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-css-count": "^0.3.0",
+    "grunt-http": "^2.2.0",
     "grunt-jekyll": "^0.4.2",
     "grunt-jslint": "^1.1.14",
     "grunt-sync": "^0.6.2",

--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -1479,3 +1479,12 @@ th {
     width: 6%;
   }
 }
+
+#patternTable tbody > tr td:first-child {
+  color: @color-pf-blue-400;
+}
+
+.pattern-status-wrapper {
+  max-width:820px;
+  margin:50px auto 0 auto;
+}

--- a/source/pattern-library/index.md
+++ b/source/pattern-library/index.md
@@ -1,6 +1,6 @@
 ---
 title: Pattern Library Overview
-author: dlabrecq
+author: amieelo
 layout: page
 ---
 <p>The PatternFly library is a collection of UI design patterns. Design patterns are recurring solutions that solve
@@ -13,427 +13,120 @@ visual design specifications. Patterns that have gone through usability testing 
 where relevant findings are described in more detail. Many patterns also include the code you can use to build the
 example. The library is continually being updated with new patterns or code samples for existing patterns. Stay current
 with these updates by checking out “What’s New” on the <a href="https://blog.patternfly.org" target="_blank">PatternFly blog</a></p>
-<div class="pattern-section" id="application-framework">
-  <h2>Application Framework</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Launcher</p>
-       <a href="{{ site.baseurl }}/pattern-library/application-framework/launcher">
-         <img src="{{site.baseurl}}/assets/img/thumbnails/Launcher.jpg" alt="launcher"/>
-       </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Login Page</p>
-       <a href="{{ site.baseurl }}/pattern-library/application-framework/login-page">
-         <img src="{{site.baseurl}}/assets/img/thumbnails/Login.png" alt="login"/>
-       </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Masthead</p>
-       <a href="{{ site.baseurl }}/pattern-library/application-framework/masthead">
-         <img src="{{site.baseurl}}/assets/img/thumbnails/Masthead.jpg" alt="masthead"/>
-       </a>
+
+<!-- Textbox Filter -->
+<div class="pattern-status-wrapper">
+  <div class="pattern-status-search">
+    <div style="width: 300px;">
+      <div class="filter-pf">
+        <div class="filter-pf-fields">
+          <div class="input-group form-group">
+            <div class="input-group-btn">
+              <div class="dropdown btn-group">
+                <button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Name
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                  <li class="selected"><a href="#">Name</a></li>
+                </ul>
+              </div>
+            </div>
+            <input id="inputText" type="text" class="form-control">
+          </div>
+        </div>
       </div>
     </div>
   </div>
+
+  <!-- Table HTML -->
+  <table class="table table-striped table-bordered pattern-status-table" id="patternTable">
+    <thead>
+      <tr>
+        <th>Pattern</th>
+        <th>Pattern Category</th>
+        <th>Patternfly Core</th>
+        <th>Angular Patternfly</th>
+        <th>Patternfly NG</th>
+        <th>Patternfly React</th>
+      </tr>
+    </thead>
+  </table>
 </div>
-<div class="pattern-section" id="cards">
-  <h2>Cards</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Aggregate Status Card</p>
-        <a href="{{ site.baseurl }}/pattern-library/cards/aggregate-status-card">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Agg-Card.png" alt="aggregate-status-card"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Base Card</p>
-       <a href="{{ site.baseurl }}/pattern-library/cards/base-card">
-         <img src="{{site.baseurl}}/assets/img/thumbnails/Base-Card.png" alt="base-card"/>
-       </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Trend Card</p>
-       <a href="{{ site.baseurl }}/pattern-library/cards/trend-card">
-         <img src="{{site.baseurl}}/assets/img/thumbnails/Trend-Card.png" alt="trend-card"/>
-       </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Utilization Bar Card</p>
-        <a href="{{ site.baseurl }}/pattern-library/cards/utilization-bar-card">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Util-Bar-Card.png" alt="utilization-bar-card"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Utilization Trend Card</p>
-        <a href="{{ site.baseurl }}/pattern-library/cards/utilization-trend-card">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Util-Trend-Card.png" alt="cards/utilization-trend-card"/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="pattern-section" id="communication">
-  <h2>Communication</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>About Modal</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/about-modal">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/About-Modal.png" alt="About-Modal"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Empty State</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/empty-state">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Empty-State.png" alt="empty-state"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Inline Notifications</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/inline-notifications">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Inline-Notif.png" alt="inline-notifications"/>
-        </a>
-      </div>
-    </div>
-     <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Notification Drawer</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/notification-drawer">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Notification-Drawer.png" alt="Notification Drawer"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Toast Notifications</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/toast-notifications">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Toast.png" alt="toast-notifications"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Tour</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/tour">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Tour.jpg" alt="tour"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Wizard</p>
-        <a href="{{ site.baseurl }}/pattern-library/communication/wizard">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Wizard.png" alt="Wizard"/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="pattern-section" id="content-views">
-  <h2>Content Views</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Canvas View</p>
-        <a href="{{ site.baseurl }}/pattern-library/content-views/canvas-view">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Canvas-view.jpg" alt="canvas-view"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Card View</p>
-        <a href="{{ site.baseurl }}/pattern-library/content-views/card-view">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/card-view.png" alt="card-view"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>List View</p>
-        <a href="{{ site.baseurl }}/pattern-library/content-views/list-view">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/List-View.png" alt="list-view"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Table View</p>
-        <a href="{{ site.baseurl }}/pattern-library/content-views/table-view">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Table.png" alt="table-view"/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="pattern-section" id="dashboard">
-  <h2>Dashboard</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Dashboard Layout</p>
-        <a href="{{ site.baseurl }}/pattern-library/dashboard/dashboard-layout">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Dash-Layout.png" alt="dashboard-layout"/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="pattern-section" id="data-visualization">
-  <h2>Data Visualization</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-       <p>Area Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/area-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Area-Chart.png" alt="area-chart"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Bar Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/bar-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Bar-Chart.png" alt="bar-chart"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Bullet Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/bullet-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Bullet-Chart.jpg" alt="bullet-chart"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Donut Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/donut-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Donut-Chart.png" alt="donut-chart"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Heat Map</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/heat-map">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Heat-Chart.png" alt="heat-map"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Line Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/line-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Line-Chart.png" alt="line-chart"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Pie Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/pie-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Pie-Chart.png" alt="pie-chart"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Sparkline Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/sparkline">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Sparkline.png" alt="sparkline"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Timeline</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/timeline">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Timeline.jpg" alt="timeline"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Utilization Bar Chart</p>
-        <a href="{{ site.baseurl }}/pattern-library/data-visualization/utilization-bar-chart">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Util-Bar-Chart.png" alt="utilization-bar-chart "/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="pattern-section" id="forms-and-controls">
-  <h2>Forms and Controls</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Buttons On Forms</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/buttons-on-forms">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Buttons-on-Forms.jpg" alt="buttons-on-forms"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Data Input</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/data-input">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Data-Input.png" alt="data-input"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Datepicker</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/datepicker">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Datepicker.png" alt="datepicker"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Drag and Drop</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/drag-and-drop">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Drag-and-Drop.jpg" alt="drag-and-drop"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Errors and Validation</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/errors-and-validation">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Errors-and-Validation.png" alt="errors-and-validation"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Expand Collapse Section</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/expand-collapse-section">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Expand-Collapse-Section.png" alt="expand-collapse-section"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Field Labeling</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/field-labeling">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Field-Labeling.png" alt="field-labeling"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Filter</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/filter">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Filter.png" alt="filter"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Find</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/find">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Search.png" alt="find"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Inline Edit</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/inline-edit">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/In-Line-Edit.png" alt="inline-edit"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Language Selector</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/language-selector">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Language-Selector.png" alt="language-selector"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Progressive Disclosure</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/progressive-disclosure">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Progressive-Disclosure.png" alt="progressive-disclosure"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Sort</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/sort">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Sort.png" alt="sort"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Toolbar</p>
-        <a href="{{ site.baseurl }}/pattern-library/forms-and-controls/toolbar">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Toolbar.png" alt="toolbar"/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="pattern-section" id="navigation">
-  <h2>Navigation</h2>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Breadcrumbs</p>
-        <a href="{{ site.baseurl }}/pattern-library/navigation/breadcrumbs">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Breadcrumbs.png" alt="breadcrumbs"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Horizontal Navigation</p>
-        <a href="{{ site.baseurl }}/pattern-library/navigation/horizontal-navigation">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Horizontal-Navigation.png" alt="horizontal-navigation"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Pagination</p>
-        <a href="{{ site.baseurl }}/pattern-library/navigation/pagination">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Pagination.png" alt="pagination"/>
-        </a>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-3">
-      <div class="pattern-thumbnail">
-        <p>Vertical Navigation</p>
-        <a href="{{ site.baseurl }}/pattern-library/navigation/vertical-navigation">
-          <img src="{{site.baseurl}}/assets/img/thumbnails/Vert-Nav.png" alt="vertical-navigation"/>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
+
+<script>
+$(document).ready(function() {
+
+  var patternData = [];
+
+  $.getJSON('https://www.patternfly.org/patternfly-design/status/pattern-status.json', function (data) {
+
+    data.forEach(function (parentValue, index) {
+
+        var designPatterns = parentValue.patterns.map(function(childVal, i) {
+
+          var patternLinks;
+          var patternflyCoreLink;
+          var angularPatternflyLink;
+          var patternflyNgLink;
+          var patternflyReactLink;
+      
+          try {
+              patternLinks = childVal.files.site.frontmatter;
+              
+              patternflyCoreLink = patternLinks.impl_jquery ? `<a href="${patternLinks.impl_jquery}">view</a>` : "n/a";
+
+              angularPatternflyLink = patternLinks.impl_angular ? `<a href="${patternLinks.impl_angular}">view</a>` : "n/a";
+
+              patternflyNgLink = patternLinks.impl_ng ? `<a href="${patternLinks.impl_ng}">view</a>` : "n/a";
+
+              patternflyReactLink = patternLinks.impl_react ? `<a href="${patternLinks.impl_react}">view</a>` : "n/a";                   
+          
+          } catch (err) {
+            patternflyCoreLink = "n/a";
+            angularPatternflyLink = "n/a";
+            patternflyNgLink = "n/a";
+            patternflyReactLink = "n/a";
+          }
+        
+          return {
+            patternName: childVal.name,
+            patternCategory: parentValue.name,
+            patternflyCore: patternflyCoreLink,
+            angularPatternfly: angularPatternflyLink,
+            patternflyNg: patternflyNgLink,
+            patternflyReact: patternflyReactLink
+          };
+        });
+
+        patternData = patternData.concat(designPatterns);
+    });
+
+    loadDataTable(patternData);
+});
+
+// Load DataTable
+function loadDataTable(designStatusData) {
+    var table = $("#patternTable").DataTable({
+      "paging": false,
+      "searching": true,
+      columns: [
+        { data: "patternName" },
+        { data: "patternCategory"},
+        { data: "patternflyCore"},
+        { data: "angularPatternfly"},
+        { data: "patternflyNg"},
+        { data: "patternflyReact"}
+      ],
+      data: designStatusData,
+      dom: "t",
+      language: {
+      zeroRecords: "No patterns found"
+       },
+    });
+    $('#inputText').keyup( function (){
+      table.search($(this).val()).draw() 
+    });
+  }
+});
+</script>


### PR DESCRIPTION
##  Purpose

Populating the Pattern Library Overview page with the design status page table. 

## Related/PR/JIRA
https://patternfly.atlassian.net/browse/PTNFLY-2669 and fixes: #489 based off the design.

## Rawgit
[view here](https://rawgit.com/amarie401/patternfly-org/design-status-overview-dist/_site/pattern-library/)

## Changes

* fetching data from design-status.json
* populating jquery data table with `design-status.json`
* searching data table for pattern name
* modifying css for table

### Notes: 

Tried to match the design as closely as I could. In the design, the table and search are centered on the page, was having some trouble replicating that in css. Was able to center the table but not the search input. Any idea on how I can go about centering everything from a css standpoint or if I need to restructure my html @matthewcarleton ?  

Is it a priority to have the table and search input centered or is my current implementation okay? thoughts? @LHinson 