### PR TITLE
Adding login page dev notes to patternfly-org

### DIFF
--- a/source/_includes/code/application-framework/login-page/code.md
+++ b/source/_includes/code/application-framework/login-page/code.md
@@ -5,6 +5,8 @@
 <p>
   <a href="https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/login-basic.html" target="_blank">View full page example</a>
 </p>
+<div class="code-doc">
+</div>
 <p class="reference-markup">
   <a class="collapse-toggle" data-toggle="collapse" aria-expanded="true" aria-controls="login-layout-markup" href="#login-layout-markup">Reference Markup</a>
 </p>

--- a/source/_includes/code/application-framework/login-page/doc.md
+++ b/source/_includes/code/application-framework/login-page/doc.md
@@ -1,0 +1,90 @@
+<table class="pforg-code-usage-table">
+  <thead>
+    <tr>
+      <th>Selector</th>
+      <th>.login-pf-page</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Applied to</td>
+    <td>page wrapper</td>
+  </tr>
+  <tr>
+    <td>Required</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Summary</td>
+    <td>Adds overall styling</td>
+  </tr>
+  </tbody>
+</table>
+
+<table class="pforg-code-usage-table">
+  <thead>
+    <tr>
+      <th>Selector</th>
+      <th>.login-pf-page-accounts</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Applied to</td>
+    <td><code>.login-pf-page</code> on page wrapper</td>
+  </tr>
+  <tr>
+    <td>Required</td>
+    <td><strong>No</strong></td>
+  </tr>
+  <tr>
+    <td>Summary</td>
+    <td>for login page with multiple account login options</td>
+  </tr>
+  </tbody>
+</table>
+<table class="pforg-code-usage-table">
+  <thead>
+    <tr>
+      <th>Selector</th>
+      <th>.login-pf-social-link-more</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Applied to</td>
+    <td>any <code>li</code> used in the <code>ul.login-pf-social</code></td>
+  </tr>
+  <tr>
+    <td>Required</td>
+    <td><strong>No</strong></td>
+  </tr>
+  <tr>
+    <td>Summary</td>
+    <td>hides <code>li</code> in a expandable container. </td>
+  </tr>
+  </tbody>
+</table>
+
+<table class="pforg-code-usage-table">
+  <thead>
+    <tr>
+      <th>Selector</th>
+      <th>.login-pf-socal-double-col</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Applied to</td>
+    <td>used with <code>login-pf-social</code></td>
+  </tr>
+  <tr>
+    <td>Required</td>
+    <td><strong>No</strong></td>
+  </tr>
+  <tr>
+    <td>Summary</td>
+    <td>Adds second column of list items</td>
+  </tr>
+  </tbody>
+</table>

--- a/source/_layouts/page-pattern.html
+++ b/source/_layouts/page-pattern.html
@@ -83,6 +83,15 @@ url-js-extra: ['']
             <h2 class="pforg-code__core-example-title">PatternFly Core Example</h2>
             {% endif %}
           </div>
+          <br>
+          <div class="pforg-code-doc">
+            {% if page.code_doc and page.code_html %}
+              <h2 class="pforg-code__core-example-title">Usage Notes</h2>
+              <p><strong>Disclaimer</strong>: Only classes that may be missed are highlighted.</p>
+              {% include {{page.code_doc}} %}
+            {% endif %}
+          </div>
+
           <div class="" id="html-css">
             {% if page.code_html %}
               {% include {{page.code_html}} %}

--- a/source/_less/patternfly-site.less
+++ b/source/_less/patternfly-site.less
@@ -1488,3 +1488,25 @@ th {
   max-width:820px;
   margin:50px auto 0 auto;
 }
+
+.pforg-code-usage-table {
+  width: 100%;
+  border: 1px solid #ccc;
+  &:last-of-type {margin-bottom: 50px;}
+  &:not(:last-of-type) {border-bottom:none;}
+  &:not(:first-of-type) {border-top:none;}
+  thead{
+    background: #f2f2f2;
+  }
+  th,td {
+    padding:5px 10px;
+  }
+  tr{
+    &:not(:last-of-type){border-bottom: 1px solid #f1f1f1;}
+    @media (min-width: @screen-md) {
+      td:first-of-type {
+        width:20rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the ability to add developer notes to patterns on patternfly-org when there is a code example present and contains a table with relevant usage information for that pattern. This PR is focused on adding developer notes to the Login page.

## Rawgit Link

[Login Page](https://rawgit.com/amarie401/patternfly-org/dev-docs-dist/_site/pattern-library/application-framework/login-page/#code)