### PR TITLE
fix(login): Update login docs

### DIFF
--- a/source/_includes/code/application-framework/login-page/doc.md
+++ b/source/_includes/code/application-framework/login-page/doc.md
@@ -2,6 +2,25 @@
   <thead>
     <tr>
       <th>Selector</th>
+      <th>.login-pf</th>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Applied to</td>
+    <td><code>body</code></td>
+  </tr>
+  <tr>
+    <td>Required</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Summary</td>
+    <td>Adds background image and styling</td>
+  </tr>
+  </tbody>
+  <thead>
+    <tr>
+      <th>Selector</th>
       <th>.login-pf-page</th>
     </tr>
   </thead>


### PR DESCRIPTION
Update the login docs to account for the use of `.login-pf` and applying it to a page's `<body>` element

fixes https://github.com/patternfly/patternfly-org/issues/553