### PR TITLE
Update package.json of bootstrap-select to lock in version 1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "bootstrap": "^3.3.7",
     "bootstrap-combobox": "^1.0.2",
     "bootstrap-datepicker": "^1.6.4",
-    "bootstrap-select": "^1.12.2",
+    "bootstrap-select": "1.12.2",
     "clipboard": "^1.6.0",
     "datatables": "^1.10.13",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
## Description
* This PR updates the package.json of bootstrap-select to lock in version 1.12.2. The patternfly-org build updated the version to 1.13.1 even though the package.json is using 1.12.2 which was causing issues with the styling and breaking. 

This will fix the styling/breaking issues for the bootstrap select, context-selector, and other example components that are using bootstrap-select as a dependency.

Since core is currently using version 1.12.2 it will be better not to update to 1.13.1 at this time for consistency.

Fixes #555 

## Changes
* package.json