### PR TITLE
fix dead link for download page and replace with new repositories page

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -31,12 +31,12 @@ url-js-extra: ['components/wowjs/dist/wow.min.js', 'components/jquery.scrollto/j
     <p>PatternFly is a community project that promotes design commonality and improved user experience. Its offerings include open source code, patterns, style guides, and an active community that helps support it all.</p>
     <div class="row">
       <div class="col-xs-6 col-sm-3 col-md-3">
-        <a href="{{ site.baseurl}}/download/">
+        <a href="{{ site.baseurl }}/get-started/repositories/">
           <img src="{{ site.baseurl}}/assets/img/icon-code.svg" alt="Code icon" />
         </a>
         <h3>Code</h3>
         <p>
-          <a href="{{ site.baseurl}}/download/">Download</a>
+          <a href="{{ site.baseurl }}/get-started/repositories/">Repositories</a>
         </p>
       </div>
       <div class="col-xs-6 col-sm-3 col-md-3">


### PR DESCRIPTION
## Description

This PR introduces a fix to the dead link/404 page error for the downloads page and replaces it with a new path to repositories page.

Related to this issue: #560 