### PR TITLE
updated community page text and link

### DIFF
--- a/source/get-started/community/index.md
+++ b/source/get-started/community/index.md
@@ -12,16 +12,16 @@ PatternFly adheres to the [Contributor Covenant Code of Conduct][1]. As a Patter
 - [Follow us on Twitter][3]
 - [Read our blog][4]
 - [Subscribe to our mailing list][5] to participate in or follow a variety of discussions on both technical and design topics. This is also a good place to ask questions, gather requirements, or join forces with other community members. Older threads can be found in the [archive][6].
-- Check out the [PatternFly YouTube channel][7] to view live meetings or prior meeting recordings. Announcements about upcoming meetings are sent to the mailing list. You can also reach out to us on our mailing list to be added directly to our community invite. 
+- Check out the [PatternFly YouTube channel][7] to view the most recent meeting recordings. Announcements about upcoming meetings are sent to the mailing list and posted on the [community meeting page][8]. You can also reach out to us on our mailing list to be added directly to our community invite. 
 
 
 ## Contribute
 
 ### File an Issue
-Before filing an issue, check the list of open issues against [our GitHub repositories][8]. When you create an issue, include as many details as possible, use a clear and descriptive title, and remember that an image is worth a thousand words, so try to add images and links when possible.
+Before filing an issue, check the list of open issues against [our GitHub repositories][9]. When you create an issue, include as many details as possible, use a clear and descriptive title, and remember that an image is worth a thousand words, so try to add images and links when possible.
 
 ### Proposing or Modifying a Design
-Propose a new pattern, add an enhancement to an existing pattern, or help us fix  existing documentation issues. All design and documentation changes are submitted and managed through our [Design Repo][9]. Visit [How to Contribute to PatternFly Design][10] for more information. 
+Propose a new pattern, add an enhancement to an existing pattern, or help us fix  existing documentation issues. All design and documentation changes are submitted and managed through our [Design Repo][10]. Visit [How to Contribute to PatternFly Design][11] for more information. 
 
 ### Contributing code
 Both developers and designers review PRs, so if you are committing a new design or modifying an existing design, be sure to add a link to a graphic or a working version on rawgit so that designers can preview the request.
@@ -35,6 +35,7 @@ Whenever possible, provide a link to the design documentation or specification t
  [5]: https://www.redhat.com/mailman/listinfo/patternfly
  [6]: https://www.redhat.com/archives/patternfly/
  [7]: https://www.youtube.com/channel/UCqLT0IEvYmb8z__9IFLSVyQ
- [8]: http://www.patternfly.org/get-started/repositories/
- [9]: https://github.com/patternfly/patternfly-design
- [10]: https://github.com/patternfly/patternfly-design/blob/master/CONTRIBUTING.md
+ [8]: http://www.patternfly.org/community/monthly-community-meeting/
+ [9]: http://www.patternfly.org/get-started/repositories/
+ [10]: https://github.com/patternfly/patternfly-design
+ [11]: https://github.com/patternfly/patternfly-design/blob/master/CONTRIBUTING.md

--- a/source/get-started/index.html
+++ b/source/get-started/index.html
@@ -87,7 +87,7 @@ layout: page
             Interested in getting involved in the PatternFly community?  Find out how you can connect or collaborate with us by visiting our Community page.
           </p>
           <p>
-            <a href="{{site.baseurl}}/community/">View our Community page</a>
+            <a href="{{site.baseurl}}/get-started/community/">View our Community page</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Community page has been updated this fixes #565 

##  Changes
- update text to include link to the community meeting page
- update community link under get-started page to fix broken page. 