### PR TITLE
feat(icons) consume icons.json from patternfly-design

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,6 +91,12 @@ module.exports = function (grunt) {
             cwd: 'repos/patternfly-design/styles',
             src: ['**/!(*.md)'],
             dest: '<%= config.build %>/styles'
+          },
+          {
+            expand: true,
+            cwd: 'repos/patternfly-design/styles/icons',
+            src: ['icons.json'],
+            dest: '<%= config.build %>/_data'
           }
         ]
       },


### PR DESCRIPTION
I've refactored the icon table in patternfly-design (patternfly/patternfly-design#677), this will be required for it to take effect if the PR gets merged.