### PR TITLE
fix 404 broken link to get-started/repositories

### DIFF
--- a/source/get-started/index.html
+++ b/source/get-started/index.html
@@ -47,7 +47,7 @@ layout: page
         <div class="col-sm-8 col-md-9 col-lg-9">
           <h2>Code</h2>
           <p>
-            PatternFly is built on top of <a href="https://getbootstrap.com">Bootstrap 3</a> and is licensed <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>. Additionally, there are a number of <a href="{{ site.baseurl }}/get-started/our-repos/">PatternFly JS framework implementations</a> available. We perform cross-browser testing with <a href="https://www.browserstack.com/">BrowserStack</a>.          </p>
+            PatternFly is built on top of <a href="https://getbootstrap.com">Bootstrap 3</a> and is licensed <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>. Additionally, there are a number of <a href="{{ site.baseurl }}/get-started/repositories/">PatternFly JS framework implementations</a> available. We perform cross-browser testing with <a href="https://www.browserstack.com/">BrowserStack</a>.          </p>
           <ul class="list-unstyled">
             <li>
               <a href="https://github.com/patternfly/">View PatternFly on Github</a>


### PR DESCRIPTION
**Current result:**
```html
there are a number of 
<a href="https://www.patternfly.org/get-started/our-repos/">
    PatternFly JS framework implementations</a> 
available.
```

**Expected result:**
Link should point to https://www.patternfly.org/get-started/repositories/
