### PR TITLE
Adding content about header alignment

### DIFF
--- a/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/lists-and-tables/design.md
+++ b/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/lists-and-tables/design.md
@@ -77,7 +77,7 @@ Two variants are available for Data Tables.
 
 1. **[Toolbar:](../toolbar/design.md)** The toolbar sits above the list and contains controls for manipulating table data. Common actions include filtering, sorting, and pagination.
 2. **Select all:** When present, selects all items in a table. If pagination is being used, this will only select items on the current page.
-3. **Column headers:** If the user is able to sort on a column, the first click on the header will sort the content of the table on the content in that column. Subsequent clicks will toggle the direction of the sort. Table data can only be sorted on one column at a time.
+3. **Column headers:** Headers should align with the content they contain. If the user is able to sort on a column, the first click on the header will sort the content of the table on the content in that column. Subsequent clicks will toggle the direction of the sort. Table data can only be sorted on one column at a time.
 4. **Select checkbox:** Select this row.
 5. **Global actions:** These actions apply to all selected items.
 6. **Inline actions:** These actions apply only to the current row/item.


### PR DESCRIPTION
As per a question that came up, I added a sentence describing that column headers should align with the content (aka if your content is center aligned, center align the header as well). 
Open to suggestions of where it could go - I didn't include a lot of detail because there was already a lot going on in that list item.