### PR TITLE
fix(navigation): update navigations to match designs

### DIFF
--- a/packages/patternfly-4/src/components/_core/Documentation/SideNav.js
+++ b/packages/patternfly-4/src/components/_core/Documentation/SideNav.js
@@ -65,10 +65,10 @@ class CoreSideNav extends React.Component {
           // console.log(location);
           const currentPath = location.pathname;
           return (
-            <Nav aria-label="Nav">
+            <Nav className="pf4-site-vertical-navigation" aria-label="Nav">
               <Switcher />
               <NavList>
-              <Form className={css(styles.search)} onSubmit={event => { event.preventDefault(); return false; }}>
+              {/* <Form className={css(styles.search)} onSubmit={event => { event.preventDefault(); return false; }}>
                 <TextInput
                   type="text"
                   id="primaryComponentSearch"
@@ -77,10 +77,10 @@ class CoreSideNav extends React.Component {
                   value={searchValue}
                   onChange={this.handleSearchChange}
                 />
-              </Form>
-                <NavExpandable 
-                  title="Components" 
-                  isExpanded={currentPath.indexOf('/components/') > -1 || (searchValue && filteredComponents.length > 0) || false} 
+              </Form> */}
+                <NavExpandable
+                  title="Components"
+                  isExpanded={currentPath.indexOf('/components/') > -1 || (searchValue && filteredComponents.length > 0) || false}
                   isActive={currentPath.indexOf(/components/) > -1}
                 >
                   {filteredComponents.map(navItem => {
@@ -102,9 +102,9 @@ class CoreSideNav extends React.Component {
                     </NavItem>
                   )})}
               </NavExpandable>
-              <NavExpandable 
-                title="Layouts" 
-                isExpanded={currentPath.indexOf('/layouts/') > -1 || (searchValue && filteredLayouts.length > 0) || false} 
+              <NavExpandable
+                title="Layouts"
+                isExpanded={currentPath.indexOf('/layouts/') > -1 || (searchValue && filteredLayouts.length > 0) || false}
                 isActive={currentPath.indexOf(/layouts/) > -1}
               >
                 {filteredLayouts.map(navItem => {
@@ -126,9 +126,9 @@ class CoreSideNav extends React.Component {
                     </NavItem>
                   )})}
               </NavExpandable>
-              <NavExpandable 
-                title="Utilities" 
-                isExpanded={currentPath.indexOf('/utilities/') > -1 || (searchValue && filteredUtilities.length > 0) || false} 
+              <NavExpandable
+                title="Utilities"
+                isExpanded={currentPath.indexOf('/utilities/') > -1 || (searchValue && filteredUtilities.length > 0) || false}
                 isActive={currentPath.indexOf(/utilities/) > -1}
               >
                 {filteredUtilities.map(navItem => {
@@ -150,9 +150,9 @@ class CoreSideNav extends React.Component {
                     </NavItem>
                   )})}
               </NavExpandable>
-              <NavExpandable 
-                title="Demos" 
-                isExpanded={currentPath.indexOf('/demos/') > -1 || (searchValue && filteredDemos.length > 0) || false} 
+              <NavExpandable
+                title="Demos"
+                isExpanded={currentPath.indexOf('/demos/') > -1 || (searchValue && filteredDemos.length > 0) || false}
                 isActive={currentPath.indexOf(/demos/) > -1}
               >
                 {filteredDemos.map(navItem => {
@@ -174,9 +174,9 @@ class CoreSideNav extends React.Component {
                       </NavItem>
                   )})}
               </NavExpandable>
-              <NavExpandable 
-                title="Upgrade Examples" 
-                isExpanded={currentPath.indexOf('/upgrade-examples/') > -1 || (searchValue && filteredUpgradeExamples.length > 0) || false} 
+              <NavExpandable
+                title="Upgrade Examples"
+                isExpanded={currentPath.indexOf('/upgrade-examples/') > -1 || (searchValue && filteredUpgradeExamples.length > 0) || false}
                 isActive={currentPath.indexOf(/upgrade-examples/) > -1}
               >
                 {filteredUpgradeExamples.map(navItem => {

--- a/packages/patternfly-4/src/components/_react/Documentation/SideNav.js
+++ b/packages/patternfly-4/src/components/_react/Documentation/SideNav.js
@@ -90,9 +90,9 @@ class SideNav extends React.Component {
         // console.log(location);
         const currentPath = location.pathname;
         return (
-          <Nav aria-label="Nav">
+          <Nav className="pf4-site-vertical-navigation" aria-label="Nav">
             <Switcher />
-            <Form className={css(styles.search)} onSubmit={event => { event.preventDefault(); return false; }}>
+            {/* <Form className={css(styles.search)} onSubmit={event => { event.preventDefault(); return false; }}>
               <TextInput
                 type="text"
                 id="primaryComponentSearch"
@@ -101,11 +101,11 @@ class SideNav extends React.Component {
                 value={searchValue}
                 onChange={this.handleSearchChange}
               />
-            </Form>
+            </Form> */}
             <NavList>
-              <NavExpandable 
-                title="Components" 
-                isExpanded={currentPath.indexOf('/components/') > -1 || Boolean(searchValue && filteredComponentRoutes.length > 0)} 
+              <NavExpandable
+                title="Components"
+                isExpanded={currentPath.indexOf('/components/') > -1 || Boolean(searchValue && filteredComponentRoutes.length > 0)}
                 isActive={currentPath.indexOf(/components/) > -1}
               >
                 {filteredComponentRoutes.map(item => (
@@ -119,9 +119,9 @@ class SideNav extends React.Component {
                   </NavItem>
                 ))}
               </NavExpandable>
-              <NavExpandable 
-                title="Layouts" 
-                isExpanded={currentPath.indexOf('/layouts/') > -1 || Boolean(searchValue && filteredLayoutRoutes.length > 0)} 
+              <NavExpandable
+                title="Layouts"
+                isExpanded={currentPath.indexOf('/layouts/') > -1 || Boolean(searchValue && filteredLayoutRoutes.length > 0)}
                 isActive={currentPath.indexOf(/layouts/) > -1}
               >
                 {filteredLayoutRoutes.map(item => (
@@ -135,9 +135,9 @@ class SideNav extends React.Component {
                   </NavItem>
                 ))}
               </NavExpandable>
-              <NavExpandable 
-                title="Demos" 
-                isExpanded={currentPath.indexOf('/demos/') > -1 || Boolean(searchValue && filteredDemoRoutes.length > 0)} 
+              <NavExpandable
+                title="Demos"
+                isExpanded={currentPath.indexOf('/demos/') > -1 || Boolean(searchValue && filteredDemoRoutes.length > 0)}
                 isActive={currentPath.indexOf(/demos/) > -1}
               >
                 {filteredDemoRoutes.map(item => (

--- a/packages/patternfly-4/src/components/layout.js
+++ b/packages/patternfly-4/src/components/layout.js
@@ -90,14 +90,14 @@ class Layout extends React.Component {
         <Toolbar>
           <ToolbarGroup>
             <ToolbarItem>
-            <Form className="ws-search" onSubmit={event => { event.preventDefault(); return false; }}>
-              <TextInput
-                    type="text"
-                    id="global-search-input"
-                    name="global-search-input"
-                    placeholder="Search"
-                  />
-            </Form>
+              <Form className="ws-search" onSubmit={event => { event.preventDefault(); return false; }}>
+                <TextInput
+                      type="text"
+                      id="global-search-input"
+                      name="global-search-input"
+                      placeholder="Search"
+                    />
+              </Form>
             </ToolbarItem>
           </ToolbarGroup>
         </Toolbar>

--- a/packages/patternfly-4/src/components/switcher/index.js
+++ b/packages/patternfly-4/src/components/switcher/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import {
   Button,
-  Bullseye
+  Bullseye,
+  Title
 } from '@patternfly/react-core';
 import { Link } from 'gatsby';
 import { Location } from '@reach/router';
@@ -15,13 +16,16 @@ const Switcher = () => (
       const activeReact = currentPath.indexOf('/documentation/react') > -1;
       const activeCore = currentPath.indexOf('/documentation/core') > -1;
       return (
-        <Bullseye className="ws-switcher-group">
-          <Link to="/documentation/react/components/aboutmodal">
-            <Button variant={activeReact ? 'primary' : 'tertiary'} className="pf-w-btn-left" isActive={activeReact}>React</Button>
-          </Link>
-          <Link to="/documentation/core/components/aboutmodalbox">
-            <Button variant={activeCore ? 'primary' : 'tertiary'} className="pf-w-btn-right" isActive={activeCore}>HTML</Button>
-          </Link>
+        <Bullseye className="pf4-site-switcher-group pf-u-ml-xl">
+          <Title size="md" className="pf4-site-switcher-group__title pf-u-pb-sm">FRAMEWORK</Title>
+          <div>
+            <Link to="/documentation/react/components/aboutmodal">
+              <Button variant={activeReact ? 'primary' : 'tertiary'} className="pf-w-btn-left" isActive={activeReact}>React</Button>
+            </Link>
+            <Link to="/documentation/core/components/aboutmodalbox">
+              <Button variant={activeCore ? 'primary' : 'tertiary'} className="pf-w-btn-right" isActive={activeCore}>HTML</Button>
+            </Link>
+          </div>
         </Bullseye>
       )
     }}

--- a/packages/patternfly-4/src/pages/index.js
+++ b/packages/patternfly-4/src/pages/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '../components/layout';
-import './styles.scss';
 import SEO from '../components/seo';
 import {
   Grid,

--- a/packages/patternfly-4/src/styles/_animation.scss
+++ b/packages/patternfly-4/src/styles/_animation.scss
@@ -1,0 +1,121 @@
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.fadeIn {
+  -webkit-animation-name: fadeIn;
+  animation-name: fadeIn;
+}
+
+@-webkit-keyframes fadeInDown {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0, -100%, 0);
+    transform: translate3d(0, -100%, 0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0, -100%, 0);
+    transform: translate3d(0, -100%, 0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.fadeInDown {
+  -webkit-animation-name: fadeInDown;
+  animation-name: fadeInDown;
+}
+
+@-webkit-keyframes fadeInUp {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0, 100%, 0);
+    transform: translate3d(0, 100%, 0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0, 100%, 0);
+    transform: translate3d(0, 100%, 0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.fadeInUp {
+  -webkit-animation-name: fadeInUp;
+  animation-name: fadeInUp;
+}
+
+.animated {
+  -webkit-animation-duration: 1s;
+  animation-duration: 1s;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
+}
+
+.fadeInOne {
+  -webkit-animation-delay: .2s;
+  -moz-animation-delay: .2s;
+  animation-delay: .2s;
+}
+
+.fadeInTwo {
+  -webkit-animation-delay: .6s;
+  -moz-animation-delay: .6s;
+  animation-delay: .6s;
+}
+
+.fadeInThree {
+  -webkit-animation-delay: 1s;
+  -moz-animation-delay: 1s;
+  animation-delay: 1s;
+}
+
+.fadeInFour {
+  -webkit-animation-delay: 1.4s;
+  -moz-animation-delay: 1.4s;
+  animation-delay: 1.4s;
+}

--- a/packages/patternfly-4/src/styles/_homepage.scss
+++ b/packages/patternfly-4/src/styles/_homepage.scss
@@ -1,7 +1,5 @@
 @import '../../../../node_modules/@patternfly/patternfly/sass-utilities/all.scss';
 
-@import '../workspace.scss';
-
 $block: '.pf4';
 
 .pf-m-white,
@@ -41,7 +39,7 @@ $block: '.pf4';
 }
 
 #{$block}-c-background-image {
-  --pf4-c-image--Background: url("../images/homeHeroLines.svg");
+  --pf4-c-image--Background: url("./images/homeHeroLines.svg");
 
   width: 100%;
   max-width: 100%;
@@ -58,13 +56,12 @@ $block: '.pf4';
 
   @media (min-width: $pf-global--breakpoint--sm) {
     background-size: contain;
-    background-image: url("../images/aboutPF4Lines.svg"), linear-gradient(to bottom, #065e8e 0%, #0469a8 25%, #048bc1 75%, #03b9e4 100%);
-    background-position: top right, right;
+    background-image: url("./images/aboutPF4Lines.svg"), linear-gradient(to bottom, #065e8e 0%, #0469a8 25%, #048bc1 75%, #03b9e4 100%);
   }
 
   @media (min-width: $pf-global--breakpoint--sm) and (-webkit-min-device-pixel-ratio: 2),
     (min-width: $pf-global--breakpoint--sm) and (min-resolution: 192dpi) {
-    background-image: url("../images/aboutPF4Lines.svg"), linear-gradient(to bottom, #065e8e 0%, #0469a8 25%, #048bc1 75%, #03b9e4 100%);
+    background-image: url("./images/aboutPF4Lines.svg"), linear-gradient(to bottom, #065e8e 0%, #0469a8 25%, #048bc1 75%, #03b9e4 100%);
     background-size: cover;
     background-position: top right, right;
   }
@@ -80,7 +77,7 @@ $block: '.pf4';
 #{$block}-c-background-image-principles {
   width: 100%;
   max-width: 100%;
-  background-image: url("../images/PF4PrinciplesLines.svg"), linear-gradient(to bottom, #03b9e4, #2767b2);
+  background-image: url("./images/PF4PrinciplesLines.svg"), linear-gradient(to bottom, #03b9e4, #2767b2);
   background-repeat: no-repeat, no-repeat;
   background-position: top right, right;
 
@@ -92,7 +89,7 @@ $block: '.pf4';
 #{$block}-c-background-lines {
   width: 100%;
   max-width: 100%;
-  background-image: url("../images/aboutPF4Lines.svg"), linear-gradient(to bottom, #fff, #fff);
+  background-image: url("./images/aboutPF4Lines.svg"), linear-gradient(to bottom, #fff, #fff);
   background-repeat: no-repeat, no-repeat;
   background-position: top right, right;
 
@@ -112,7 +109,7 @@ $block: '.pf4';
 #{$block}-c-image__laptop {
   height: 40%;
   width: 100%;
-  background-image: url("../images/laptop.svg");
+  background-image: url("./images/laptop.svg");
   background-repeat: no-repeat;
   background-position: center;
   @media (max-width: $pf-global--breakpoint--sm) {
@@ -131,7 +128,7 @@ $block: '.pf4';
   top: -120px;
   height: 25%;
   width: 100%;
-  background-image: url("../images/phone.svg");
+  background-image: url("./images/phone.svg");
   background-repeat: no-repeat;
   background-position: 32%;
   @media (max-width: $pf-global--breakpoint--sm) {
@@ -151,7 +148,7 @@ $block: '.pf4';
   top: -225px;
   height: 25%;
   width: 100%;
-  background-image: url("../images/screen.svg");
+  background-image: url("./images/screen.svg");
   background-repeat: no-repeat;
   background-position: 60%;
   z-index: 2;
@@ -171,7 +168,7 @@ $block: '.pf4';
   top: -300px;
   height: 42%;
   width: 100%;
-  background-image: url("../images/desktop.svg");
+  background-image: url("./images/desktop.svg");
   background-repeat: no-repeat;
   background-position: 42%;
   @media (max-width: $pf-global--breakpoint--sm) {
@@ -182,126 +179,4 @@ $block: '.pf4';
     top: -145px;
     height: 220px;
   }
-}
-
-@-webkit-keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-.fadeIn {
-  -webkit-animation-name: fadeIn;
-  animation-name: fadeIn;
-}
-
-@-webkit-keyframes fadeInDown {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, -100%, 0);
-    transform: translate3d(0, -100%, 0);
-  }
-
-  to {
-    opacity: 1;
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes fadeInDown {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, -100%, 0);
-    transform: translate3d(0, -100%, 0);
-  }
-
-  to {
-    opacity: 1;
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-.fadeInDown {
-  -webkit-animation-name: fadeInDown;
-  animation-name: fadeInDown;
-}
-
-@-webkit-keyframes fadeInUp {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, 100%, 0);
-    transform: translate3d(0, 100%, 0);
-  }
-
-  to {
-    opacity: 1;
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, 100%, 0);
-    transform: translate3d(0, 100%, 0);
-  }
-
-  to {
-    opacity: 1;
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-.fadeInUp {
-  -webkit-animation-name: fadeInUp;
-  animation-name: fadeInUp;
-}
-
-.animated {
-  -webkit-animation-duration: 1s;
-  animation-duration: 1s;
-  -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-}
-
-.fadeInOne {
-  -webkit-animation-delay: .2s;
-  -moz-animation-delay: .2s;
-  animation-delay: .2s;
-}
-
-.fadeInTwo {
-  -webkit-animation-delay: .6s;
-  -moz-animation-delay: .6s;
-  animation-delay: .6s;
-}
-
-.fadeInThree {
-  -webkit-animation-delay: 1s;
-  -moz-animation-delay: 1s;
-  animation-delay: 1s;
-}
-
-.fadeInFour {
-  -webkit-animation-delay: 1.4s;
-  -moz-animation-delay: 1.4s;
-  animation-delay: 1.4s;
 }

--- a/packages/patternfly-4/src/styles/_navigation.scss
+++ b/packages/patternfly-4/src/styles/_navigation.scss
@@ -1,0 +1,121 @@
+.pf-c-page__header {
+  background-color: #151515;
+  .pf-c-page__header-brand {
+    background-color: #151515;
+  }
+  &-brand-toggle {
+    display: none;
+    @media (max-width: 768px) {
+      display: block;
+    }
+  }
+}
+.pf4-site-header {
+  .pf-c-nav__horizontal-list {
+    .pf-c-nav__link {
+      padding-top: 28px;
+      @media (max-width: 1024px) {
+        padding-top: var(--pf-global--spacer--md);
+      }
+      padding-right: var(--pf-global--spacer--md);
+      padding-left: var(--pf-global--spacer--md);
+      color: var(--pf-global--Color--light-100);
+      &::after {
+        top: 0 !important;
+        height: 4px;
+      }
+      &:active,
+      &:hover {
+        background-color: var(--pf-global--BackgroundColor--light-100);
+        color: #151515 !important;
+        font-weight: var(--pf-global--FontWeight--normal);
+        transition: .5s;
+      }
+      &.pf-m-current {
+        background-color: var(--pf-global--BackgroundColor--light-100);
+        color: #151515 !important;
+        font-weight: var(--pf-global--FontWeight--normal);
+      }
+    }
+  }
+  li a {
+    &::after {
+      content: '';
+      position: absolute;
+      left: 50% !important;
+      bottom: 0;
+      transform: translateX(-50%) scaleX(0);
+      transform-origin: 50% 50%;
+      width: 100%;
+      height: 1px;
+      background-color: var(--pf-global--BackgroundColor--light-100);
+      color: #151515 !important;
+      transition: transform 250ms;
+    }
+  }
+  li a:hover {
+    &::after {
+      transform: translateX(-50%) scaleX(1);
+    }
+  }
+  li a.pf-m-current {
+    &::after {
+      left: 0 !important;
+      transform: none;
+    }
+  }
+}
+
+.pf-c-nav__simple-list .pf-c-nav__link {
+  margin-left: var(--pf-global--spacer--xs);
+  border-left: 4px solid transparent;
+  &:active,
+  &:hover {
+    background-color: #f8f8f8;
+    border-left-color: #06c;
+    font-weight: var(--pf-global--FontWeight--normal);
+  }
+  &.pf-m-current {
+    background-color: #f8f8f8;
+    border-left-color: #06c;
+  }
+}
+.pf-c-nav__list {
+  .pf-m-current.pf-c-nav__link,
+  .pf-m-current > .pf-c-nav__link {
+    font-size: var(--pf-global--FontSize--md);
+    font-weight: var(--pf-global--FontWeight--normal);
+    color: #151515;
+    &.pf-m-current {
+      color: #151515;
+    }
+  }
+  .pf-c-nav__link.pf-m-hover,
+  .pf-c-nav__link:hover {
+    color: #151515;
+  }
+  & > .pf-c-nav__item > .pf-c-nav__link {
+    font-size: var(--pf-global--FontSize--lg);
+    font-weight: var(--pf-global--FontWeight--semi-bold);
+    color: #252527;
+    &:hover::after {
+      background-color: transparent;
+    }
+    &::after {
+      background-color: transparent !important;
+    }
+  }
+  & > .pf-c-nav__item.pf-m-expanded.pf-m-current::after {
+    background-color: transparent;
+  }
+}
+
+.pf4-site-switcher-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start !important;
+  &__title {
+    color: #06c;
+    font-weight: 700 !important;
+  }
+}

--- a/packages/patternfly-4/src/styles/_variables.scss
+++ b/packages/patternfly-4/src/styles/_variables.scss
@@ -1,0 +1,18 @@
+%call-to-action-text {
+  font-weight: var(--pf-global--FontWeight--bold);
+  font-size: var(--pf-global--FontSize--md);
+  line-height: var(--pf-global--LineHeight--md);
+}
+
+%cross-link-text {
+  font-weight: var(--pf-global--FontWeight--bold);
+  font-size: var(--pf-global--FontSize--lg);
+  line-height: var(--pf-global--LineHeight--md);
+}
+
+%btn-call-to-action {
+  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
+  border-radius: var(--pf-global--BorderRadius--sm);
+  border: var(--pf-global--BorderWidth--sm) solid;
+}
+

--- a/packages/patternfly-4/src/workspace.scss
+++ b/packages/patternfly-4/src/workspace.scss
@@ -1,65 +1,16 @@
+@import './styles/variables.scss';
+@import './styles/animation.scss';
+@import './styles/navigation.scss';
+
+@import './styles/homepage.scss';
+
 #___gatsby {
   height: 100%;
 }
 
-%call-to-action-text {
-  font-weight: var(--pf-global--FontWeight--bold);
-  font-size: var(--pf-global--FontSize--md);
-  line-height: var(--pf-global--LineHeight--md);
-}
-
-%cross-link-text {
-  font-weight: var(--pf-global--FontWeight--bold);
-  font-size: var(--pf-global--FontSize--lg);
-  line-height: var(--pf-global--LineHeight--md);
-}
-
-%btn-call-to-action {
-  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
-  border-radius: var(--pf-global--BorderRadius--sm);
-  border: var(--pf-global--BorderWidth--sm) solid;
-}
-
-$block: '.pf4';
-
-.pf-c-page__header {
-  background-color: #151515;
-  .pf-c-page__header-brand {
-    background-color: #151515;
-  }
-}
-
-#{$block}-site-c-hero {
-  max-width: 600px;
-  margin: 0 auto !important;
-}
-
-#{$block}-site-header {
-  li a {
-    &::after {
-      content: '';
-      position: absolute;
-      left: 50% !important;
-      bottom: 0;
-      transform: translateX(-50%) scaleX(0);
-      transform-origin: 50% 50%;
-      width: 100%;
-      height: 1px;
-      background-color: var(--pf-c-nav__horizontal-list-link--m-current--after--BackgroundColor);
-      transition: transform 250ms;
-    }
-  }
-  li a:hover {
-    &::after {
-      transform: translateX(-50%) scaleX(1);
-    }
-  }
-  li a.pf-m-current {
-    &::after {
-      left: 0 !important;
-      transform: none;
-    }
-  }
+.pf4-site-framework-title {
+  color: #06c;
+  font-weight: 700 !important;
 }
 
 .ws-documentation {


### PR DESCRIPTION
Update the horizontal and vertical navigations to match the latest designs. Changes include:

- change active/hover/focus styling of navigation items
- add extra margin/spacing to elements in order to improve readability
- update font weights and sizes to improve readability
- remove hamburger menu on screen sizes above 768px, add back in when screen is below 768px wide

**Desktop**
<img width="1280" alt="Screen Shot 2019-03-28 at 8 20 30 PM" src="https://user-images.githubusercontent.com/4032718/55201031-71a41100-5197-11e9-9101-d1dc165ef7cb.png">

**Mobile (nav closed)**
<img width="358" alt="Screen Shot 2019-03-28 at 8 20 47 PM" src="https://user-images.githubusercontent.com/4032718/55201035-7a94e280-5197-11e9-8ec0-ddefd25119f2.png">

**Mobile (nav open)**
<img width="364" alt="Screen Shot 2019-03-28 at 8 20 53 PM" src="https://user-images.githubusercontent.com/4032718/55201044-8385b400-5197-11e9-865d-6a071970ee38.png">
