### PR TITLE
Add Empty State to nav

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/design-guidelines-navigation.json
+++ b/packages/patternfly-4/content/design-guidelines/design-guidelines-navigation.json
@@ -34,6 +34,10 @@
         "path": "/design-guidelines/usage-and-behavior/data-input"
       },
       {
+        "text": "Empty state",
+        "path": "/design-guidelines/usage-and-behavior/empty-state"
+      },
+      {
         "text": "Filters",
         "path": "/design-guidelines/usage-and-behavior/filters"
       },


### PR DESCRIPTION
Updating 'design-guidelines-navigation.json' to add Empty state documentation recently merged.