### PR TITLE
fix(react-core): fullscreen previews

### DIFF
--- a/packages/patternfly-4/_repos/react-core/src/components/BackgroundImage/BackgroundImage.md
+++ b/packages/patternfly-4/_repos/react-core/src/components/BackgroundImage/BackgroundImage.md
@@ -5,7 +5,7 @@ cssPrefix: 'pf-c-background-image'
 import { BackgroundImage, BackgroundImageSrc } from '@patternfly/react-core';
 
 ## Simple Background Image
-```js
+```nolive
 import React from 'react';
 import { BackgroundImage, BackgroundImageSrc } from '@patternfly/react-core';
 

--- a/packages/patternfly-4/_repos/react-core/src/components/LoginPage/LoginPage.md
+++ b/packages/patternfly-4/_repos/react-core/src/components/LoginPage/LoginPage.md
@@ -17,7 +17,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-```js
+```nolive
 import React from 'react';
 import brandImgColor from './examples/brandImgColor.svg';
 import {

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/PageLayout.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/PageLayout.md
@@ -2,20 +2,35 @@
 title: 'Page Layout'
 section: 'demos'
 ---
+import LinkPreview from '@content/../LinkPreview';
+
+All but the last example set the isManagedSidebar prop on the Page component to have the sidebar automatically close for smaller screen widths. You can also manually control this behavior by not adding the isManagedSidebar prop and instead:
+
+- Add an onNavToggle callback to PageHeader
+- Pass in a boolean into the isNavOpen prop to PageSidebar
+
+The last example demonstrates this.
+
 ## Using simple navigation
-<a href="pagelayoutsimplenav" target="_blank">Popout example</a>
+
+<LinkPreview name="Simple Nav" path="/documentation/react/demos/pagelayout/pagelayoutsimplenav" />
 
 ## Using default navigation
-<a href="pagelayoutdefaultnav" target="_blank">Popout example</a>
+
+<LinkPreview name="Default Nav" path="/documentation/react/demos/pagelayout/pagelayoutdefaultnav" />
 
 ## Using expandable navigation
-<a href="pagelayoutexpandablenav" target="_blank">Popout example</a>
+
+<LinkPreview name="Expandable Nav" path="/documentation/react/demos/pagelayout/pagelayoutexpandablenav" />
 
 ## Using grouped navigation
-<a href="pagelayoutgroupsnav" target="_blank">Popout example</a>
+
+<LinkPreview name="Grouped Nav" path="/documentation/react/demos/pagelayout/pagelayoutgroupsnav" />
 
 ## Using horizontal navigation
-<a href="pagelayouthorizontalnav" target="_blank">Popout example</a>
+
+<LinkPreview name="Horizontal Nav" path="/documentation/react/demos/pagelayout/pagelayouthorizontalnav" />
 
 ## Programmatically toggle the sidebar
-<a href="pagelayoutmanualnav" target="_blank">Popout example</a>
+
+<LinkPreview name="Manual Nav" path="/documentation/react/demos/pagelayout/pagelayoutmanualnav" />

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.md
@@ -4,6 +4,6 @@ section: 'demos'
 fullscreen: true
 ---
 
-import ExamplePage from './PageLayoutDefaultNav';
+import PageLayoutDefaultNav from './PageLayoutDefaultNav';
 
-<ExamplePage />
+<PageLayoutDefaultNav />

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.md
@@ -4,6 +4,6 @@ section: 'demos'
 fullscreen: true
 ---
 
-import ExamplePage from './PageLayoutExpandableNav';
+import PageLayoutExpandableNav from './PageLayoutExpandableNav';
 
-<ExamplePage />
+<PageLayoutExpandableNav />

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.md
@@ -4,6 +4,6 @@ section: 'demos'
 fullscreen: true
 ---
 
-import ExamplePage from './PageLayoutGroupsNav';
+import PageLayoutGroupsNav from './PageLayoutGroupsNav';
 
-<ExamplePage />
+<PageLayoutGroupsNav />

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.md
@@ -4,6 +4,6 @@ section: 'demos'
 fullscreen: true
 ---
 
-import ExamplePage from './PageLayoutHorizontalNav';
+import PageLayoutHorizontalNav from './PageLayoutHorizontalNav';
 
-<ExamplePage />
+<PageLayoutHorizontalNav />

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.md
@@ -4,6 +4,6 @@ section: 'demos'
 fullscreen: true
 ---
 
-import ExamplePage from './PageLayoutManualNav';
+import PageLayoutManualNav from './PageLayoutManualNav';
 
-<ExamplePage />
+<PageLayoutManualNav />

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.md
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.md
@@ -4,6 +4,6 @@ section: 'demos'
 fullscreen: true
 ---
 
-import ExamplePage from './PageLayoutSimpleNav';
+import PageLayoutSimpleNav from './PageLayoutSimpleNav';
 
-<ExamplePage />
+<PageLayoutSimpleNav />


### PR DESCRIPTION
There now seems to be a problem loading the styles for the login and background image pages. The actual components are rendering, though. Not sure what started causing this.