### PR TITLE
Forms text update

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/usage-and-behavior/forms/design.md
+++ b/packages/patternfly-4/content/design-guidelines/usage-and-behavior/forms/design.md
@@ -12,7 +12,7 @@ Most forms will contain the following basic elements:
 *Form elements*
 ![Form elements](img/form-elements.png)
 
-1. [Labels](#labeling) - Field labels can be aligned to the left or top of the field depending on the layout of your page and the amount of space you have to work with.
+1. [Labels](#labeling) - Field labels can be aligned to the top or left of the field depending on the layout of your page and the amount of space you have to work with.
 
 2. [Text input/text area](/design-guidelines/usage-and-behavior/data-input) - provides an area for users to input free-form text.
 


### PR DESCRIPTION
Fixes part of #966 

> CURRENT: Field labels can be aligned to the left or top of the field depending on the layout of your page and the amount of space you have to work with.
> CHANGE TO: Field labels can be aligned to the top or left of the field depending on the layout of your page and the amount of space you have to work with.