### PR TITLE
Attempt to find matching component page when switching frameworks

### DIFF
--- a/packages/patternfly-4/src/components/switcher/index.js
+++ b/packages/patternfly-4/src/components/switcher/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { graphql, StaticQuery } from 'gatsby';
 import {
   Button,
   Bullseye,
@@ -8,21 +9,30 @@ import { Link } from 'gatsby';
 import { Location } from '@reach/router';
 import './styles.scss';
 
-const Switcher = () => (
+const trimTrailingSlash = str => str.replace(/\/$/, '');
+const verifyPath = (path, pages) =>
+  pages.edges
+    .map(edge => trimTrailingSlash(edge.node.path))
+    .find(queryPath => queryPath === trimTrailingSlash(path));
+
+const Switcher = ({ data }) => (
   <Location>
     {({ location }) => {
-      // console.log(location);
       const currentPath = location.pathname;
       const activeReact = currentPath.indexOf('/documentation/react') > -1;
       const activeCore = currentPath.indexOf('/documentation/core') > -1;
+      const reactPath = activeReact ? currentPath : currentPath.replace('core', 'react');
+      const corePath = activeCore ? currentPath : currentPath.replace('react', 'core');
+      const validReactPath = verifyPath(reactPath, data.reactPages) || '/documentation/react/components/aboutmodal';
+      const validCorePath = verifyPath(corePath, data.corePages) || '/documentation/core/components/aboutmodalbox';
       return (
         <Bullseye className="pf-site-switcher-group pf-u-ml-xl">
           <Title size="lg" className="pf-site-switcher-group__title pf-u-mb-sm">FRAMEWORK</Title>
           <div>
-            <Link to="/documentation/react/components/aboutmodal">
+            <Link to={validReactPath}>
               <Button variant={activeReact ? 'primary' : 'tertiary'} className="pf-w-btn-left" isActive={activeReact}>React</Button>
             </Link>
-            <Link to="/documentation/core/components/aboutmodalbox">
+            <Link to={validCorePath}>
               <Button variant={activeCore ? 'primary' : 'tertiary'} className="pf-w-btn-right" isActive={activeCore}>HTML</Button>
             </Link>
           </div>
@@ -32,4 +42,32 @@ const Switcher = () => (
   </Location>
 );
 
-export default Switcher;
+export default props => (
+  <StaticQuery
+    query={graphql`
+      query IndexForSwitcher {
+        corePages: allSitePage(
+          filter: { path: { glob: "/documentation/core/**" } },
+          sort: { fields: path }
+        ) {
+          edges {
+            node {
+              path
+            }
+          }
+        }
+        reactPages: allSitePage(
+          filter: { path: { glob: "/documentation/react/**" } },
+          sort: { fields: path }
+        ) {
+          edges {
+            node {
+              path
+            }
+          }
+        }
+      }
+    `}
+    render={data => <Switcher data={data} {...props} />}
+  />
+);


### PR DESCRIPTION
Fixes #812 
Fixes #965
(Duplicate issues)

This PR changes the framework switcher so that when it is rendered, it takes the current path and replaces `/core/` with `/react/` or vice versa, then checks to see if the result is a valid path. If so, the rendered link will take the user to the page matching their current component, otherwise it will still take them to the about modal page.

As long as the paths to our react and core component pages are consistently named, this should result in an intuitive framework toggle that can switch between frameworks without switching components.

![4nZIOF4onR](https://user-images.githubusercontent.com/811963/56928203-1752e480-6aa4-11e9-9c43-bb999d2877b3.gif)
