### PR TITLE
fix(nav): sync highlights over expanded nav

### DIFF
--- a/packages/patternfly-4/src/components/_react/Documentation/styles.scss
+++ b/packages/patternfly-4/src/components/_react/Documentation/styles.scss
@@ -6,6 +6,22 @@
     max-height: 100% !important;
     font-size: var(--pf-global--FontSize--md);
   }
+
+  .pf-c-nav__item {
+    padding-top: var(--pf-global--spacer--sm) !important;
+    border-left: 4px solid transparent;
+    &:active,
+    &:hover {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+      font-weight: var(--pf-global--FontWeight--normal);
+    }
+    &.pf-m-current {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+    }
+  }
+
   .pf-c-nav__subnav {
     a.pf-c-nav__link {
       border-left: 5px solid var(--pf-global--Color--light-100);

--- a/packages/patternfly-4/src/styles/_navigation.scss
+++ b/packages/patternfly-4/src/styles/_navigation.scss
@@ -97,6 +97,18 @@
     &.pf-m-current {
       color: #151515;
     }
+    padding-top: var(--pf-global--spacer--sm) !important;
+    border-left: 4px solid transparent;
+    &:active,
+    &:hover {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+      font-weight: var(--pf-global--FontWeight--normal);
+    }
+    &.pf-m-current {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+    }
   }
   .pf-c-nav__link.pf-m-hover,
   .pf-c-nav__link:hover {
@@ -106,6 +118,14 @@
     font-size: var(--pf-global--FontSize--lg);
     font-weight: var(--pf-global--FontWeight--semi-bold);
     color: #252527;
+    padding-top: var(--pf-global--spacer--sm) !important;
+    border-left: 4px solid transparent;
+    &:active,
+    &:hover {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+      font-weight: var(--pf-global--FontWeight--normal);
+    }
     &:hover::after {
       background-color: transparent;
     }
@@ -125,5 +145,26 @@
   &__title {
     color: #06c;
     font-weight: 700 !important;
+  }
+}
+
+
+
+.pf-site-md-nav {
+  margin-top: 16px;
+
+  .pf-c-nav__link {
+    padding-top: var(--pf-global--spacer--sm) !important;
+    border-left: 4px solid transparent;
+    &:active,
+    &:hover {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+      font-weight: var(--pf-global--FontWeight--normal);
+    }
+    &.pf-m-current {
+      background-color: #f8f8f8;
+      border-left-color: #06c;
+    }
   }
 }

--- a/packages/patternfly-4/src/templates/template.scss
+++ b/packages/patternfly-4/src/templates/template.scss
@@ -1,25 +1,5 @@
-// @import '~@patternfly/patternfly/components/Table/table.scss';
-
 .pf4-site-typography-grid {
   font-family: var(--pf-global--FontFamily--sans-serif);
-}
-.pf-site-md-nav {
-  margin-top: 16px;
-
-  .pf-c-nav__link {
-    padding-top: var(--pf-global--spacer--sm) !important;
-    border-left: 4px solid transparent;
-    &:active,
-    &:hover {
-      background-color: #f8f8f8;
-      border-left-color: #06c;
-      font-weight: var(--pf-global--FontWeight--normal);
-    }
-    &.pf-m-current {
-      background-color: #f8f8f8;
-      border-left-color: #06c;
-    }
-  }
 }
 
 .pageSectionStyles {


### PR DESCRIPTION
Sync the highlight styling of the expanded navigation between the Get started, Design guidelines, and Documentation sections.

Fixes issue https://github.com/patternfly/patternfly-org/issues/967

![navHighlight](https://user-images.githubusercontent.com/4032718/56972564-38194980-6b39-11e9-82b0-6a7ffedb2bbc.gif)

![navHighlightMobile](https://user-images.githubusercontent.com/4032718/56972645-554e1800-6b39-11e9-8db2-46d2ca069d7b.gif)
