### PR TITLE
fix(homepage): remove grey from section background

### DIFF
--- a/packages/patternfly-4/src/pages/index.js
+++ b/packages/patternfly-4/src/pages/index.js
@@ -34,7 +34,7 @@ const IndexPage = () => (
         </GridItem>
       </Grid>
     </PageSection>
-    <PageSection variant={PageSectionVariants.light}>
+    <PageSection className="pf4-m-background-white">
       <Grid>
         <GridItem sm={12} md={6} mdOffset={3} className="pf-u-py-2xl pf-u-text-align-center">
           <Title size="4xl" id="AboutPatternFly4" className="pf-u-mb-md">About PatternFly 4</Title>

--- a/packages/patternfly-4/src/styles/_homepage.scss
+++ b/packages/patternfly-4/src/styles/_homepage.scss
@@ -104,6 +104,10 @@ $block: '.pf4';
   }
 }
 
+#{$block}-m-background-white {
+  background-color: #fff;
+}
+
 #{$block}-c-background-lines {
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
Remove the grey background from the 'About PatternFly' section on the home page.

Fixes issue https://github.com/patternfly/patternfly-org/issues/931

![Screen Shot 2019-04-30 at 12 08 29 PM](https://user-images.githubusercontent.com/4032718/56976320-b3cac480-6b40-11e9-8424-406b16790f84.png)
