### PR TITLE
fix clipboard copy styling

### DIFF
--- a/packages/patternfly-4/src/workspace.scss
+++ b/packages/patternfly-4/src/workspace.scss
@@ -121,9 +121,11 @@ $block: '.pf4';
     will-change: opacity;
   }
   .messageText {
-    background: black;
-    color: var(--pf-global--Color--light-100);
-    padding: 3px 5px;
+    background: white;
+    color: black;
+    padding: 10px;
+    font-family: RedHatText;
+    font-weight: 400;
   }
   .messageShow {
     opacity: 1;


### PR DESCRIPTION
Close #857

New style:

<img width="577" alt="Screen Shot 2019-04-30 at 2 19 37 PM" src="https://user-images.githubusercontent.com/20118816/56984356-d0bcc300-6b53-11e9-9fd7-44f3ca358a4a.png">
