### PR TITLE
fix(highlights): fix highlight specificity for navigation

### DIFF
--- a/packages/patternfly-4/src/components/_core/Documentation/styles.scss
+++ b/packages/patternfly-4/src/components/_core/Documentation/styles.scss
@@ -20,6 +20,35 @@
       }
     }
   }
+  .pf-c-nav__list {
+    .pf-m-current.pf-c-nav__link,
+    .pf-m-current > .pf-c-nav__link {
+      font-size: var(--pf-global--FontSize--md);
+      font-weight: var(--pf-global--FontWeight--normal);
+      color: #151515;
+      &.pf-m-current {
+        color: #151515;
+      }
+    }
+    .pf-c-nav__link.pf-m-hover,
+    .pf-c-nav__link:hover {
+      color: #151515;
+    }
+    & > .pf-c-nav__item > .pf-c-nav__link {
+      font-size: var(--pf-global--FontSize--lg);
+      font-weight: var(--pf-global--FontWeight--semi-bold);
+      color: #252527;
+      &:hover::after {
+        background-color: transparent;
+      }
+      &::after {
+        background-color: transparent !important;
+      }
+    }
+    & > .pf-c-nav__item.pf-m-expanded.pf-m-current::after {
+      background-color: transparent;
+    }
+  }
 }
 
 .pf-site-background-medium {

--- a/packages/patternfly-4/src/styles/_navigation.scss
+++ b/packages/patternfly-4/src/styles/_navigation.scss
@@ -88,55 +88,6 @@
     border-left-color: #06c;
   }
 }
-.pf-c-nav__list {
-  .pf-m-current.pf-c-nav__link,
-  .pf-m-current > .pf-c-nav__link {
-    font-size: var(--pf-global--FontSize--md);
-    font-weight: var(--pf-global--FontWeight--normal);
-    color: #151515;
-    &.pf-m-current {
-      color: #151515;
-    }
-    padding-top: var(--pf-global--spacer--sm) !important;
-    border-left: 4px solid transparent;
-    &:active,
-    &:hover {
-      background-color: #f8f8f8;
-      border-left-color: #06c;
-      font-weight: var(--pf-global--FontWeight--normal);
-    }
-    &.pf-m-current {
-      background-color: #f8f8f8;
-      border-left-color: #06c;
-    }
-  }
-  .pf-c-nav__link.pf-m-hover,
-  .pf-c-nav__link:hover {
-    color: #151515;
-  }
-  & > .pf-c-nav__item > .pf-c-nav__link {
-    font-size: var(--pf-global--FontSize--lg);
-    font-weight: var(--pf-global--FontWeight--semi-bold);
-    color: #252527;
-    padding-top: var(--pf-global--spacer--sm) !important;
-    border-left: 4px solid transparent;
-    &:active,
-    &:hover {
-      background-color: #f8f8f8;
-      border-left-color: #06c;
-      font-weight: var(--pf-global--FontWeight--normal);
-    }
-    &:hover::after {
-      background-color: transparent;
-    }
-    &::after {
-      background-color: transparent !important;
-    }
-  }
-  & > .pf-c-nav__item.pf-m-expanded.pf-m-current::after {
-    background-color: transparent;
-  }
-}
 
 .pf4-site-switcher-group {
   display: flex;
@@ -148,9 +99,8 @@
   }
 }
 
-
-
-.pf-site-md-nav {
+.pf-site-md-nav,
+.pf-site-vertical-navigation {
   margin-top: 16px;
 
   .pf-c-nav__link {
@@ -165,6 +115,35 @@
     &.pf-m-current {
       background-color: #f8f8f8;
       border-left-color: #06c;
+    }
+  }
+  .pf-c-nav__list {
+    .pf-m-current.pf-c-nav__link,
+    .pf-m-current > .pf-c-nav__link {
+      font-size: var(--pf-global--FontSize--md);
+      font-weight: var(--pf-global--FontWeight--normal);
+      color: #151515;
+      &.pf-m-current {
+        color: #151515;
+      }
+    }
+    .pf-c-nav__link.pf-m-hover,
+    .pf-c-nav__link:hover {
+      color: #151515;
+    }
+    & > .pf-c-nav__item > .pf-c-nav__link {
+      font-size: var(--pf-global--FontSize--lg);
+      font-weight: var(--pf-global--FontWeight--semi-bold);
+      color: #252527;
+      &:hover::after {
+        background-color: transparent;
+      }
+      &::after {
+        background-color: transparent !important;
+      }
+    }
+    & > .pf-c-nav__item.pf-m-expanded.pf-m-current::after {
+      background-color: transparent;
     }
   }
 }


### PR DESCRIPTION
This PR fixes the highlight specificity issues that were accidentally introduced with PR https://github.com/patternfly/patternfly-org/pull/1002, where the footer links inherited styling from the vertical navigation. This PR contains the vertical navigation highlights within their respective wrappers.

**Broken Footer**
![footer_broken](https://user-images.githubusercontent.com/4032718/56988080-2e094200-6b5d-11e9-91f0-2d8150304bcc.gif)

**Fixed Footer**
![footer_fixed](https://user-images.githubusercontent.com/4032718/56988092-3497b980-6b5d-11e9-92bf-1d79ba29593f.gif)
