### PR TITLE
Properly handle prefixed paths in framework switcher

### DIFF
--- a/packages/patternfly-4/src/components/switcher/index.js
+++ b/packages/patternfly-4/src/components/switcher/index.js
@@ -12,8 +12,8 @@ import './styles.scss';
 const trimTrailingSlash = str => str.replace(/\/$/, '');
 const verifyPath = (path, pages) =>
   pages.edges
-    .map(edge => trimTrailingSlash(edge.node.path))
-    .find(queryPath => queryPath === trimTrailingSlash(path));
+    .map(edge => edge.node.path)
+    .find(queryPath => path.indexOf(trimTrailingSlash(queryPath)) > -1);
 
 const Switcher = ({ data }) => (
   <Location>
@@ -47,7 +47,7 @@ export default props => (
     query={graphql`
       query IndexForSwitcher {
         corePages: allSitePage(
-          filter: { path: { glob: "/documentation/core/**" } },
+          filter: { path: { glob: "/documentation/core/*/**" } },
           sort: { fields: path }
         ) {
           edges {
@@ -57,7 +57,7 @@ export default props => (
           }
         }
         reactPages: allSitePage(
-          filter: { path: { glob: "/documentation/react/**" } },
+          filter: { path: { glob: "/documentation/react/*/**" } },
           sort: { fields: path }
         ) {
           edges {


### PR DESCRIPTION
A lesson learned: always test your fix in a real build... whoops.

In https://github.com/patternfly/patternfly-org/pull/992 I didn't properly handle gatsby's prefixed paths, so it only worked in a dev server and not in a production build of the site. The graphql query returns paths like `/documentation/core/components/button` but the current path looks like `/v4/documentation/core/components/button`, so because of that `/v4/` nothing was ever matching and the `validReactPath` / `validCorePath` would always fall back to `aboutmodal`.

With this change, the path being verified must contain (rather than equal) the matching path from the query. I also changed the `glob` in the query to exclude `/documentation/core` and `/documentation/react` root paths, because otherwise every path would always match those.