### PR TITLE
fix for tables

### DIFF
--- a/packages/patternfly-4/src/components/_core/Documentation/styles.scss
+++ b/packages/patternfly-4/src/components/_core/Documentation/styles.scss
@@ -74,6 +74,10 @@
       vertical-align: top;
       border-top: var(--pf-global--BorderWidth--sm) solid #e0e0e0;
       border-bottom: var(--pf-global--BorderWidth--sm) solid #e0e0e0;
+
+      > code {
+        white-space: normal;
+      }
     }
   }
 

--- a/packages/patternfly-4/src/components/css-variables.js
+++ b/packages/patternfly-4/src/components/css-variables.js
@@ -155,7 +155,7 @@ class Tokens extends React.Component {
             onChange={this.handleSearchChange}
           />
         </Form>
-        <Table variant="compact" aria-label="CSS Variables" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={filteredRows}>
+        <Table className="pf-m-grid-xl" variant="compact" aria-label="CSS Variables" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={filteredRows}>
           <TableHeader />
           <TableBody />
         </Table>

--- a/packages/patternfly-4/src/templates/template.scss
+++ b/packages/patternfly-4/src/templates/template.scss
@@ -13,13 +13,6 @@
   }
 }
 
-.table-wrapper {
-  @media only screen and (max-width: 768px) {
-    max-width: 768px;
-    overflow-x: auto;
-  }
-}
-
 .markdown-body {
   h1 {
     font-size: 36px;

--- a/packages/patternfly-4/src/templates/template.scss
+++ b/packages/patternfly-4/src/templates/template.scss
@@ -13,6 +13,13 @@
   }
 }
 
+.table-wrapper {
+  @media only screen and (max-width: 768px) {
+    max-width: 768px;
+    overflow-x: auto;
+  }
+}
+
 .markdown-body {
   h1 {
     font-size: 36px;
@@ -33,10 +40,18 @@
     font-size: 14px;
     line-height: 21px;
     color: #151515;
+
+    @media only screen and (max-width: 992px) {
+      padding-left: 16px;
+    }
   }
   td {
     padding: 32px 16px 32px 32px;
     font-size: 16px;
+
+    @media only screen and (max-width: 992px) {
+      padding: 16px;
+    }
   }
   tr {
     height: 1px;


### PR DESCRIPTION
Close #863 close #989 close #955 close #969 close #937 close #935

- Quick update to styles to add `white-space: normal` to code blocks so that they break when inside of table data. 
- Add a modifier to the css variables table so that it breaks at a larger viewport. 
- update padding the for table at a medium viewport so that it is not as wide.



<img width="464" alt="Screen Shot 2019-05-01 at 4 31 15 PM" src="https://user-images.githubusercontent.com/20118816/57040857-ae4ba800-6c2e-11e9-9a0b-d9b64ca84254.png">
<img width="630" alt="Screen Shot 2019-05-01 at 4 31 43 PM" src="https://user-images.githubusercontent.com/20118816/57040858-aee43e80-6c2e-11e9-9651-f133ca0edbdc.png">
