### PR TITLE
fix framework size and padding for documentation

### DIFF
--- a/packages/patternfly-4/src/components/_core/Documentation/index.js
+++ b/packages/patternfly-4/src/components/_core/Documentation/index.js
@@ -35,7 +35,7 @@ export default class Documentation extends React.Component {
     return !this.state.isFull ? (
       <Layout sideNav={<SideNav />}>
         <SEO title="React" />
-        <PageSection variant={PageSectionVariants.light} className="pf-u-pt-md pf-site-background-medium">
+        <PageSection variant={PageSectionVariants.light} className="pf-site-background-medium">
           <AutoLinkHeader size="md" is="h1" className="pf4-site-framework-title">HTML</AutoLinkHeader>
           <AutoLinkHeader size="4xl" is="h2" className="pf-u-mt-sm pf-u-mb-md">{heading}</AutoLinkHeader>
           {data.pageContext && data.pageContext.description &&

--- a/packages/patternfly-4/src/components/_react/Documentation/index.js
+++ b/packages/patternfly-4/src/components/_react/Documentation/index.js
@@ -73,7 +73,7 @@ class Documentation extends React.PureComponent {
           return (
             <Layout sideNav={<SideNav />} className="ws-documentation">
               <SEO title="React" />
-              <PageSection variant={PageSectionVariants.light} className="section-border pf-u-pt-md pf-site-background-medium">
+              <PageSection variant={PageSectionVariants.light} className="section-border pf-site-background-medium">
                 <AutoLinkHeader size="md" is="h1" className="pf4-site-framework-title">{componentType}</AutoLinkHeader>
                 <AutoLinkHeader size="4xl" is="h2" className="pf-u-mt-sm pf-u-mb-md">{title}</AutoLinkHeader>
                 {Boolean(description) && (

--- a/packages/patternfly-4/src/components/switcher/index.js
+++ b/packages/patternfly-4/src/components/switcher/index.js
@@ -27,7 +27,7 @@ const Switcher = ({ data }) => (
       const validCorePath = verifyPath(corePath, data.corePages) || '/documentation/core/components/aboutmodalbox';
       return (
         <Bullseye className="pf-site-switcher-group pf-u-ml-xl">
-          <Title size="lg" className="pf-site-switcher-group__title pf-u-mb-sm">FRAMEWORK</Title>
+          <Title className="pf-site-switcher-group__title pf-u-mb-sm">FRAMEWORK</Title>
           <div>
             <Link to={validReactPath}>
               <Button variant={activeReact ? 'primary' : 'tertiary'} className="pf-w-btn-left" isActive={activeReact}>React</Button>

--- a/packages/patternfly-4/src/components/switcher/styles.scss
+++ b/packages/patternfly-4/src/components/switcher/styles.scss
@@ -4,7 +4,9 @@
   align-items: flex-start !important;
   &__title {
     color: #06c;
-    font-weight: 700 !important;
+    margin-top: 24px;
+    font-weight: 600 !important;
+    font-size: 14px !important;
   }
 
   .pf-w-btn-left.pf-c-button,

--- a/packages/patternfly-4/src/templates/mdxPF4Template.js
+++ b/packages/patternfly-4/src/templates/mdxPF4Template.js
@@ -58,7 +58,7 @@ const MdxPF4Template = ({ data }) => {
   return (
     <Layout sideNav={<SideNav />} className="ws-documentation">
       <SEO title="React" />
-      <PageSection variant={PageSectionVariants.light} className="section-border pf-u-pt-md pf-site-background-medium">
+      <PageSection variant={PageSectionVariants.light} className="section-border pf-site-background-medium">
         <AutoLinkHeader size="md" is="h1" className="pf4-site-framework-title">React</AutoLinkHeader>
         <AutoLinkHeader size="4xl" is="h2" className="pf-u-mt-sm pf-u-mb-md">
           {data.mdx.frontmatter.title}

--- a/packages/patternfly-4/src/workspace.scss
+++ b/packages/patternfly-4/src/workspace.scss
@@ -34,6 +34,17 @@ $block: '.pf4';
   font-weight: 700 !important;
 }
 
+.pf-c-page__main-section {
+  padding-top: var(--pf-global--spacer--xl);
+  padding-right: var(--pf-global--spacer--2xl);
+  padding-bottom: var(--pf-global--spacer--2xl);
+  padding-left: var(--pf-global--spacer--2xl);
+
+  @media only screen and (max-width: 768px) {
+    padding: var(--pf-global--spacer--md);
+  }
+}
+
 .pf-c-page__main-section.pf-m-light {
   background-color: var(--pf-global--BackgroundColor--200);
 }


### PR DESCRIPTION
- fixes Framework title size and spacing from top
- override padding in the page main section

<img width="998" alt="Screen Shot 2019-05-01 at 5 08 43 PM" src="https://user-images.githubusercontent.com/20118816/57042873-f5886780-6c33-11e9-8e76-fa0234afc84a.png">
