### PR TITLE
fix firefox imgs on homepage

### DIFF
--- a/packages/patternfly-4/src/pages/index.js
+++ b/packages/patternfly-4/src/pages/index.js
@@ -75,10 +75,10 @@ const IndexPage = () => (
               </TextContent>
             </GridItem>
             <GridItem sm={12} md={6}>
-              <object type="image/svg+xml" className="pf4-c-image__laptop" aria-label="laptop image">Laptop image</object>
-              <object type="image/svg+xml" className="pf4-c-image__phone" aria-label="phone image"></object>
-              <object type="image/svg+xml" className="pf4-c-image__screen" aria-label="screen image"></object>
-              <object type="image/svg+xml" className="pf4-c-image__desktop" aria-label="desktop image"></object>
+              <div type="image/svg+xml" className="pf4-c-image__laptop" aria-label="laptop image"></div>
+              <div type="image/svg+xml" className="pf4-c-image__phone" aria-label="phone image"></div>
+              <div type="image/svg+xml" className="pf4-c-image__screen" aria-label="screen image"></div>
+              <div type="image/svg+xml" className="pf4-c-image__desktop" aria-label="desktop image"></div>
             </GridItem>
           </Grid>
         </GridItem>


### PR DESCRIPTION
just needed to update the objects to divs because objects dont render in FF without proper capability.

<img width="1043" alt="Screen Shot 2019-05-02 at 3 41 36 PM" src="https://user-images.githubusercontent.com/20118816/57102160-cc79dc80-6cf0-11e9-9c7d-035f6ce7b659.png">
