### PR TITLE
fix(colors): adjust mobile alignments for colors page

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/styles/colors.mdx
+++ b/packages/patternfly-4/content/design-guidelines/styles/colors.mdx
@@ -13,36 +13,36 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Primary default</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-primary-100"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#0066CC</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--primary-color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-four">
+  <GridItem span={12} lg={7} className="grid-modifier-third">
+    <Grid>
+      <GridItem span={4} xl={3}>
+        <div className="colors-theme--color-primary-200"></div>
+      </GridItem>
+      <GridItem span={8}>
+        <h3>#00659C</h3>
+        <p>Global CSS variable</p>
+        <code>--pf-global--primary-color--200</code>
+      </GridItem>
+    </Grid>
+  </GridItem>
+  <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
         <button class="pf-c-button pf-m-primary pf-u-mt-sm pf-u-mb-md">See what's possible</button>
         <p>This call-to-action uses default PatternFly 4 colors. The active state button takes --pf-global--primary-color--100. On a hover, the color adjusts to --pf-global--primary-color--200.</p>
-      </GridItem>
-    </Grid>
-  </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
-    <Grid>
-      <GridItem span={6} xl={3}>
-        <div className="colors-theme--color-primary-200"></div>
-      </GridItem>
-      <GridItem span={6}>
-        <h3>#00659C</h3>
-        <p>Global CSS variable</p>
-        <code>--pf-global--primary-color--200</code>
       </GridItem>
     </Grid>
   </GridItem>
@@ -52,19 +52,19 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Secondary default</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-secondary-100"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#72767B</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--secondary-color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} sm={6} rowSpan={2} className="grid-modifier-four">
+  <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -96,48 +96,49 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Text</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-text-100"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#151515</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--Color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-four">
-    <Grid className="colors-in-context">
-      <GridItem span={12}>
-        <h3>Colors in context</h3>
-        <h2>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h2>
-        <p>Body text should be Overpass Regular at 16px. It should have leading of 24px because of it’s relative line-height of 1.5.</p>
-      </GridItem>
-    </Grid>
-  </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
+
+  <GridItem span={12} lg={7} className="grid-modifier-third">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-text-200"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#72767B</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--Color--200</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-second">
+  <GridItem span={12} lg={7} className="grid-modifier-second">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-text-300"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#393F44</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--Color--300</code>
+      </GridItem>
+    </Grid>
+  </GridItem>
+    <GridItem xs={12} lg={5} rowSpan={2} className="grid-modifier-four">
+    <Grid className="colors-in-context">
+      <GridItem span={12}>
+        <h3>Colors in context</h3>
+        <h2>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h2>
+        <p>Body text should be Overpass Regular at 16px. It should have leading of 24px because of it’s relative line-height of 1.5.</p>
       </GridItem>
     </Grid>
   </GridItem>
@@ -150,36 +151,36 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Links</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-link-text"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#0066CC</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--link--Color</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} lg={7} className="grid-modifier-third">
+    <Grid>
+      <GridItem span={4} xl={3}>
+        <div className="colors-theme--color-link-hover"></div>
+      </GridItem>
+      <GridItem span={8}>
+        <h3>#004080</h3>
+        <p>Global CSS variable</p>
+        <code>--pf-global--link--Color--hover</code>
+      </GridItem>
+    </Grid>
+  </GridItem>
+    <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
         <p>Body text should be Overpass Regular at 16px. <a className="pf-m-link">This is a link in-content</a>. It should have leading of 24px because of its relative line-height of 1.5.
         </p>
-      </GridItem>
-    </Grid>
-  </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
-    <Grid>
-      <GridItem span={6} xl={3}>
-        <div className="colors-theme--color-link-hover"></div>
-      </GridItem>
-      <GridItem span={6}>
-        <h3>#004080</h3>
-        <p>Global CSS variable</p>
-        <code>--pf-global--link--Color--hover</code>
       </GridItem>
     </Grid>
   </GridItem>
@@ -189,19 +190,19 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Icons</h3>
   </GridItem>
-  <GridItem span={12} sm={6} classNme="grid-modifier-first">
+  <GridItem span={12} lg={7} classNme="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-icons"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#72767B</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--icon--Color--light</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} className="grid-modifier-second">
+  <GridItem span={12} lg={5} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -220,19 +221,31 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Success</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-alerts--success"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#92D400</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--success-color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} lg={7} className="grid-modifier-third">
+    <Grid>
+      <GridItem span={4} xl={3}>
+        <div className="colors-theme--color-alerts--success-icon"></div>
+      </GridItem>
+      <GridItem span={8}>
+        <h3>#486B00</h3>
+        <p>Global CSS variable</p>
+        <code>--pf-global--success-color--200</code>
+      </GridItem>
+    </Grid>
+  </GridItem>
+  <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -246,37 +259,37 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
-    <Grid>
-      <GridItem span={6} xl={3}>
-        <div className="colors-theme--color-alerts--success-icon"></div>
-      </GridItem>
-      <GridItem span={6}>
-        <h3>#486B00</h3>
-        <p>Global CSS variable</p>
-        <code>--pf-global--success-color--200</code>
-      </GridItem>
-    </Grid>
-  </GridItem>
 </Grid>
 
 <Grid className="colors-theme--light grid-modifier" gutter="md" style={{marginTop: '24px'}}>
   <GridItem xs={12}>
     <h3>Information</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-alerts--info"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#73BCF7</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--info-color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} lg={7} className="grid-modifier-third">
+    <Grid>
+      <GridItem span={4} xl={3}>
+        <div className="colors-theme--color-alerts--info-icon"></div>
+      </GridItem>
+      <GridItem span={8}>
+        <h3>#004368</h3>
+        <p>Global CSS variable</p>
+        <code>--pf-global--info-color--200</code>
+      </GridItem>
+    </Grid>
+  </GridItem>
+  <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -290,37 +303,25 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
-    <Grid>
-      <GridItem span={6} xl={3}>
-        <div className="colors-theme--color-alerts--info-icon"></div>
-      </GridItem>
-      <GridItem span={6}>
-        <h3>#004368</h3>
-        <p>Global CSS variable</p>
-        <code>--pf-global--info-color--200</code>
-      </GridItem>
-    </Grid>
-  </GridItem>
 </Grid>
 
 <Grid className="colors-theme--light grid-modifier" gutter="md" style={{marginTop: '24px'}}>
   <GridItem xs={12}>
     <h3>Warning</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-alerts--warning"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#f0AB00</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--warning-color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -334,12 +335,12 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
+  <GridItem span={12} lg={7} className="grid-modifier-third">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-alerts--warning-icon"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#795600</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--warning-color--200</code>
@@ -352,19 +353,19 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Danger</h3>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} lg={7} className="grid-modifier-first">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-alerts--danger"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#C9190B</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--danger-color--100</code>
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} lg={5} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -378,12 +379,12 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem span={12} sm={6} className="grid-modifier-third">
+  <GridItem span={12} lg={7} className="grid-modifier-third">
     <Grid>
-      <GridItem span={6} xl={3}>
+      <GridItem span={4} xl={3}>
         <div className="colors-theme--color-alerts--danger-icon"></div>
       </GridItem>
-      <GridItem span={6}>
+      <GridItem span={8}>
         <h3>#A30000</h3>
         <p>Global CSS variable</p>
         <code>--pf-global--danger-color--200</code>

--- a/packages/patternfly-4/content/design-guidelines/styles/colors.mdx
+++ b/packages/patternfly-4/content/design-guidelines/styles/colors.mdx
@@ -13,7 +13,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Primary default</h3>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-primary-100"></div>
@@ -25,7 +25,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-four">
+  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -34,7 +34,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-primary-200"></div>
@@ -52,7 +52,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Secondary default</h3>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-secondary-100"></div>
@@ -64,7 +64,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-four">
+  <GridItem span={12} sm={6} rowSpan={2} className="grid-modifier-four">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -96,7 +96,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Text</h3>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-text-100"></div>
@@ -117,7 +117,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-text-200"></div>
@@ -129,7 +129,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-second">
+  <GridItem span={12} sm={6} className="grid-modifier-second">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-text-300"></div>
@@ -150,7 +150,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Links</h3>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-link-text"></div>
@@ -162,7 +162,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -171,7 +171,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} span={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-link-hover"></div>
@@ -189,7 +189,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Icons</h3>
   </GridItem>
-  <GridItem xs={12} span={6} classNme="grid-modifier-first">
+  <GridItem span={12} sm={6} classNme="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-icons"></div>
@@ -201,7 +201,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} className="grid-modifier-second">
+  <GridItem span={12} md={6} className="grid-modifier-second">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -220,7 +220,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Success</h3>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--success"></div>
@@ -232,7 +232,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -246,7 +246,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--success-icon"></div>
@@ -264,7 +264,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Information</h3>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--info"></div>
@@ -276,7 +276,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -290,7 +290,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--info-icon"></div>
@@ -308,7 +308,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Warning</h3>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--warning"></div>
@@ -320,7 +320,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -334,7 +334,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--warning-icon"></div>
@@ -352,7 +352,7 @@ import { Link } from 'gatsby';
   <GridItem xs={12}>
     <h3>Danger</h3>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-first">
+  <GridItem span={12} sm={6} className="grid-modifier-first">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--danger"></div>
@@ -364,7 +364,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} md={6} rowSpan={2} className="grid-modifier-second">
+  <GridItem span={12} md={6} rowSpan={2} className="grid-modifier-second">
     <Grid className="colors-in-context">
       <GridItem span={12}>
         <h3>Colors in context</h3>
@@ -378,7 +378,7 @@ import { Link } from 'gatsby';
       </GridItem>
     </Grid>
   </GridItem>
-  <GridItem xs={12} sm={6} className="grid-modifier-third">
+  <GridItem span={12} sm={6} className="grid-modifier-third">
     <Grid>
       <GridItem span={6} xl={3}>
         <div className="colors-theme--color-alerts--danger-icon"></div>
@@ -421,7 +421,7 @@ import { Link } from 'gatsby';
       </GalleryItem>
     </Gallery>
   </GridItem>
-  <GridItem span={4} rowSpan={6} className="pf-u-display-none-on-sm pf-u-display-block-on-md">
+  <GridItem span={4} rowSpan={6} className="pf-u-display-none pf-u-display-block-on-md">
     <Grid>
       <GridItem offset={1} span={8}>
         <h3>Sample pie chart</h3>

--- a/packages/patternfly-4/src/styles/content/colors.scss
+++ b/packages/patternfly-4/src/styles/content/colors.scss
@@ -273,7 +273,7 @@ $gallery-colors: (
 }
 
 .grid-modifier {
-  @media screen and (max-width: 768px) {
+  @media screen and (min-width: 997px) {
      .grid-modifier-first {
        order: 1;
        margin-top: 31px;
@@ -287,7 +287,7 @@ $gallery-colors: (
        margin-top: 31px;
      }
      .grid-modifier-four {
-       order: 4;
+       order: 1;
        margin-top: 31px;
      }
      .grid-modifier-five {

--- a/packages/patternfly-4/src/workspace.scss
+++ b/packages/patternfly-4/src/workspace.scss
@@ -168,9 +168,72 @@ $block: '.pf4';
   background-color: #282d33 !important;
 }
 
+.pf-c-page__header-brand-toggle {
+  position: absolute;
+  right: 0;
+}
+
 .ws-search {
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 2px;
+  padding-left: 0;
+  width: 150px;
+  background: transparent;
+  transition: 250ms;
+
+  @media (max-width: 768px) {
+    width: 100px;
+  }
+
+  &:focus-within {
+    background: #fff;
+    .search-icon {
+      color: darken(#d2d3d5, 15%);
+    }
+  }
   .pf-c-form__label {
     --pf-c-form__label--FontSize: var(--pf-global--FontSize--lg);
+  }
+  input {
+    background: #151515;
+    border: 0;
+    color: #fff;
+    padding-left: 25px;
+    &:focus {
+      outline-offset: 2px;
+    }
+    &::placeholder {
+      color: #d2d3d5;
+    }
+    &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+      color: #d2d3d5;
+    }
+    &::-moz-placeholder { /* Firefox 19+ */
+      color: #d2d3d5;
+    }
+    &:-ms-input-placeholder { /* IE 10+ */
+      color: #d2d3d5;
+    }
+    &:-moz-placeholder { /* Firefox 18- */
+      color: #d2d3d5;
+    }
+  }
+  .search-icon {
+    position: absolute;
+    display: inline-block;
+    color: #d2d3d5;
+    &:before {
+      margin-top: 6px;
+      font-family: "Font Awesome 5 Free";
+      content: "\f002";
+      font-weight: 900;
+      display: inline-block;
+      font-style: normal;
+      font-variant: normal;
+      text-rendering: auto;
+      -webkit-font-smooth: antialiased;
+    }
   }
 }
 


### PR DESCRIPTION
Update the Colors page to properly render on mobile devices (smaller viewports). Set the column widths to be 12 columns on smaller screens, fixing the text/color block overlaps to occurred.

This PR also fixes the issue where the Sample Chart image appeared on smaller screens, injecting itself in the middle of the Chart Colors sample area.

fixes issue https://github.com/patternfly/patternfly-org/issues/983

Old screenshot | New screenshot
--- | ---
![Screen Shot 2019-05-08 at 12 12 25 PM](https://user-images.githubusercontent.com/4032718/57390672-ea30c100-718a-11e9-8865-d8f4f3ed9f85.png) | ![Screen Shot 2019-05-08 at 12 08 26 PM](https://user-images.githubusercontent.com/4032718/57390439-5959e580-718a-11e9-874a-5e4eaf483883.png)
![Screen Shot 2019-05-08 at 12 12 40 PM](https://user-images.githubusercontent.com/4032718/57390770-12b8bb00-718b-11e9-92b0-0f89c62be16c.png) | ![Screen Shot 2019-05-08 at 12 08 34 PM](https://user-images.githubusercontent.com/4032718/57390800-2401c780-718b-11e9-8ef8-a6f85688307c.png)
![Screen Shot 2019-05-08 at 12 12 54 PM](https://user-images.githubusercontent.com/4032718/57390868-4a276780-718b-11e9-8769-a9f6dc8ae8c4.png) | ![Screen Shot 2019-05-08 at 12 08 48 PM](https://user-images.githubusercontent.com/4032718/57390876-4e538500-718b-11e9-9e4d-a885700e77ce.png)
