### PR TITLE
fix(demos): fix typography on demo pages

### DIFF
--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
@@ -192,6 +192,7 @@ class PageLayoutDefaultNav extends React.Component {
           isManagedSidebar
           skipToContent={PageSkipToContent}
           breadcrumb={PageBreadcrumb}
+          className="pf4-site-demo-typography"
         >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
@@ -215,6 +215,7 @@ class PageLayoutExpandableNav extends React.Component {
           isManagedSidebar
           skipToContent={PageSkipToContent}
           breadcrumb={PageBreadcrumb}
+          className="pf4-site-demo-typography"
         >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
@@ -181,7 +181,7 @@ class PageLayoutGroupsNav extends React.Component {
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent}>
+        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent} className="pf4-site-demo-typography">
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
@@ -186,7 +186,7 @@ class PageLayoutHorizontalNav extends React.Component {
 
     return (
       <React.Fragment>
-        <Page header={Header} skipToContent={PageSkipToContent} breadcrumb={PageBreadcrumb}>
+        <Page header={Header} skipToContent={PageSkipToContent} breadcrumb={PageBreadcrumb} className="pf4-site-demo-typography">
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
@@ -203,7 +203,7 @@ class PageLayoutManualNav extends React.Component {
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize} skipToContent={PageSkipToContent}>
+        <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize} skipToContent={PageSkipToContent} className="pf4-site-demo-typography">
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
+++ b/packages/patternfly-4/_repos/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
@@ -173,7 +173,7 @@ class PageLayoutSimpleNav extends React.Component {
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent}>
+        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent} className="pf4-site-demo-typography">
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/src/templates/template.scss
+++ b/packages/patternfly-4/src/templates/template.scss
@@ -2,6 +2,12 @@
   font-family: var(--pf-global--FontFamily--sans-serif);
 }
 
+.pf4-site-demo-typography,
+.pf4-site-demo-typography *,
+.pf4-site-demo-typography .pf-c-content * {
+  font-family: var(--pf-global--FontFamily--sans-serif);
+}
+
 .pageSectionStyles {
   padding-top: 32px;
   padding-right: 64px;


### PR DESCRIPTION
Applies the Overpass font family from PatternFly to the demo pages.

This will be able to be removed once PatternFly utilizes Red Hat typography.

fixes issue https://github.com/patternfly/patternfly-org/issues/1080