### PR TITLE
fix(search): update styling for Search

### DIFF
--- a/packages/patternfly-4/src/styles/_navigation.scss
+++ b/packages/patternfly-4/src/styles/_navigation.scss
@@ -1,5 +1,10 @@
 .pf-c-page__header {
   background-color: #151515;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr auto;
+  }
+
   .pf-c-page__header-brand {
     background-color: #151515;
   }
@@ -13,6 +18,7 @@
     display: none;
     @media (max-width: 768px) {
       display: block;
+      position: relative !important;
     }
   }
 }

--- a/packages/patternfly-4/src/styles/_search.scss
+++ b/packages/patternfly-4/src/styles/_search.scss
@@ -20,7 +20,7 @@
 
 /* Category (eg. Downloads) */
 .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
-  padding: 5px 0 !important;
+  padding: 10px 0 !important;
   &-text{
     margin-right: var(--pf-global--spacer--sm) !important;
     padding-right: var(--pf-global--spacer--sm) !important;
@@ -32,9 +32,19 @@
     font-weight: var(--pf-global--FontWeight--bold) !important;
   }
 }
+@media (min-width: 768px) {
+  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
+    margin-top: 5px;
+  }
+}
 
 /* Title (eg. Bootstrap CDN) */
 .algolia-autocomplete .algolia-docsearch-suggestion--title {
+  margin-top: 0 !important;
+  margin-right: 5px;
+  margin-left: 5px;
+  padding-top: 10px !important;
+  padding-bottom: 10px !important;
   font-weight: 400 !important;
   color: #151515;
 }
@@ -52,6 +62,18 @@
   }
 }
 
+.algolia-autocomplete .ds-dropdown-menu {
+  max-width: 1140px !important;
+  min-width: 455px !important;
+  width: 100% !important;
+}
+
+@media (min-width: 768px) {
+  .algolia-autocomplete .ds-dropdown-menu {
+    min-width: 500px !important;
+  }
+}
+
 .algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion:not(.suggestion-layout-simple) .algolia-docsearch-suggestion--content {
   background-color: #f5f5f5 !important;
 }
@@ -66,7 +88,7 @@
 
 @media (max-width: 768px) {
   .algolia-autocomplete .ds-dropdown-menu {
-    min-width: 0 !important;
+    // min-width: 0 !important;
     width: auto;
   }
   .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column:after {


### PR DESCRIPTION
Update the Search styling to closer match designs.
- Improve the usability on smaller viewports by expanding the display width of the results dropdown.
- Improve padding around the results to increase clickable area (from around 25px to around 40px in height).
- Improve contrast of the Input Placeholder
- Shrink footprint of the Search input (width) so that it fits better in the navigation and does not sit right next to the PatternFly logo.

fixes Issues https://github.com/patternfly/patternfly-org/issues/755 and https://github.com/patternfly/patternfly-org/issues/904

----

**Desktop**
![Screen Shot 2019-05-14 at 11 15 26 AM](https://user-images.githubusercontent.com/4032718/57709822-b4cc1d80-7639-11e9-8c3c-73ea967b169b.png)

**Mobile**
![Screen Shot 2019-05-14 at 11 21 30 AM](https://user-images.githubusercontent.com/4032718/57710218-71be7a00-763a-11e9-98ff-8b9e0136b8f6.png)

----

![PFSite_Search](https://user-images.githubusercontent.com/4032718/57709805-ac73e280-7639-11e9-8fb7-c94ede6dc69b.gif)
