### PR TITLE
Fix broken links on Lists and Tables page

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/usage-and-behavior/lists-and-tables/design.md
+++ b/packages/patternfly-4/content/design-guidelines/usage-and-behavior/lists-and-tables/design.md
@@ -135,9 +135,9 @@ In this example, a data table is positioned in the body of a page in a card.
 ## Components and demos used
 
 **HTML/CSS**
-* [Data list](/documentation/core/components/DataList)
-* [Data table](/documentation/core/components/DataTable)
+* [Data list](/documentation/core/components/datalist)
+* [Data table](/documentation/core/components/datatable)
 
 **React**
-* [Data list](/documentation/react/components/DataList)
-* [Data table](/documentation/react/components/DataTable)
+* [Data list](/documentation/react/components/datalist)
+* [Data table](/documentation/react/components/datatable)


### PR DESCRIPTION
The related Components and demos links on https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/lists-and-tables are broken. This change sets the destination page name to all lower case.