### PR TITLE
fix(search): adjust specificity for Search styling

### DIFF
--- a/packages/patternfly-4/src/components/layout.js
+++ b/packages/patternfly-4/src/components/layout.js
@@ -113,13 +113,15 @@ class Layout extends React.Component {
         <Toolbar>
           <ToolbarGroup>
             <ToolbarItem>
-              <Form className="ws-search" onSubmit={event => { event.preventDefault(); return false; }}>
+              <Form className="ws-search pf-site-search" onSubmit={event => { event.preventDefault(); return false; }}>
                 <TextInput
                   type="text"
                   id="global-search-input"
+                  className="pf-site-search-input"
                   name="global-search-input"
                   placeholder="Search"
                 />
+                <span className="search-icon"></span>
               </Form>
             </ToolbarItem>
           </ToolbarGroup>

--- a/packages/patternfly-4/src/workspace.scss
+++ b/packages/patternfly-4/src/workspace.scss
@@ -173,7 +173,7 @@ $block: '.pf4';
   right: 0;
 }
 
-.ws-search {
+.pf-site-search {
   padding-top: 0;
   padding-right: 0;
   padding-bottom: 2px;
@@ -195,7 +195,7 @@ $block: '.pf4';
   .pf-c-form__label {
     --pf-c-form__label--FontSize: var(--pf-global--FontSize--lg);
   }
-  input {
+  .pf-site-search-input {
     background: #151515;
     border: 0;
     color: #fff;


### PR DESCRIPTION
Adjust the specificity of the Search styling, as the styles from the Search in the navigation affected the search in other pages (not intended).

This will be improved with the existing PR https://github.com/patternfly/patternfly-org/pull/1099.