### PR TITLE
make code consistent across site

### DIFF
--- a/packages/patternfly-4/src/pages/documentation/core/css-variables.js
+++ b/packages/patternfly-4/src/pages/documentation/core/css-variables.js
@@ -5,13 +5,14 @@ import Layout from '../../../components/layout';
 import SEO from '../../../components/seo';
 import Section from '../../../components/section';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
+import '../../../templates/template.scss';
 
 const CoreTokens = ({ location }) => (
   <Layout sideNav={<SideNav />}>
     <SEO title="Global CSS Variables" />
-    <PageSection variant={PageSectionVariants.light}>
+    <PageSection className="markdown-body" variant={PageSectionVariants.light}>
          <div className="pf-c-content">
-            <h2>About CSS variables</h2>
+            <h1>About CSS variables</h1>
             <p>The CSS variable system is a two-layer theming system where global variables inform component variables.</p>
 
             <h3>Global variables</h3>

--- a/packages/patternfly-4/src/pages/documentation/react/css-variables.js
+++ b/packages/patternfly-4/src/pages/documentation/react/css-variables.js
@@ -5,13 +5,14 @@ import Layout from '../../../components/layout';
 import SEO from '../../../components/seo';
 import Section from '../../../components/section';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
+import '../../../templates/template.scss';
 
 const ReactTokens = ({ location }) => (
   <Layout sideNav={<SideNav />}>
     <SEO title="Global CSS Variables" />
-    <PageSection variant={PageSectionVariants.light}>
+    <PageSection className="markdown-body" variant={PageSectionVariants.light}>
          <div className="pf-c-content">
-            <h2>About CSS variables</h2>
+            <h1>About CSS variables</h1>
             <p>The CSS variable system is a two-layer theming system where global variables inform component variables.</p>
 
             <h3>Global variables</h3>


### PR DESCRIPTION
close #1074 

@rachael-phillips I pulled in the markdown code styles into the CSS Variables file. Could you double check that the code styles should apply to all these words underneath too, they do have the `<code>` wrapper around them so they should be ok 

<img width="859" alt="Screen Shot 2019-05-24 at 1 49 41 PM" src="https://user-images.githubusercontent.com/20118816/58347321-94674480-7e2b-11e9-8754-04fde8c812ea.png">
