### PR TITLE
comment out broken link

### DIFF
--- a/packages/patternfly-4/content/documentation/avatar.md
+++ b/packages/patternfly-4/content/documentation/avatar.md
@@ -2,4 +2,4 @@
 reactUrl: 'avatar'
 htmlUrl: 'avatar'
 ---
-The **avatar** is used to represent a user. It may contain an image that represents the user or a placeholder graphic in the absence of an image. Typical usage is to represent the current user in the masthead. Related design guidelines: [Masthead](/design-guidelines/usage-and-behavior/masthead)
+The **avatar** is used to represent a user. It may contain an image that represents the user or a placeholder graphic in the absence of an image. Typical usage is to represent the current user in the masthead. <!-- Related design guidelines: [Masthead](/design-guidelines/usage-and-behavior/masthead) -->


### PR DESCRIPTION
Close #1130 

Commented out the Link to the Masthead as that page doesnt exist right now. Wondering if it should link to the "page" or "nav" components as they are probably closest to the masthead? cc: @stacymcauliffe 