### PR TITLE
feat(icons): add empty state component to the icons page

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/styles/icons.md
+++ b/packages/patternfly-4/content/design-guidelines/styles/icons.md
@@ -4,6 +4,7 @@ path: "/design-guidelines/styles/icons"
 import { Button, Grid, GridItem } from '@patternfly/react-core';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import Icons from '@content/icons';
+import { Title, EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, EmptyStateSecondaryActions } from '@patternfly/react-core';
 
 # Icons
  If you're a developer, [check out our getting started page](/get-started/developers#using-styles) to learn more about how to get and use our icon set.

--- a/packages/patternfly-4/content/design-guidelines/styles/icons.md
+++ b/packages/patternfly-4/content/design-guidelines/styles/icons.md
@@ -4,7 +4,6 @@ path: "/design-guidelines/styles/icons"
 import { Button, Grid, GridItem } from '@patternfly/react-core';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import Icons from '@content/icons';
-import { Title, EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, EmptyStateSecondaryActions } from '@patternfly/react-core';
 
 # Icons
  If you're a developer, [check out our getting started page](/get-started/developers#using-styles) to learn more about how to get and use our icon set.

--- a/packages/patternfly-4/src/components/content/icons.js
+++ b/packages/patternfly-4/src/components/content/icons.js
@@ -62,10 +62,10 @@ class Icons extends React.Component {
         {filteredIcons.length == 0 &&  <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon icon={SearchIcon}/>
           <Title headingLevel="h5" size="2xl">
-            Sorry there are no icons found for "{ searchValue }".
+            No results found for "{ searchValue }".
           </Title>
           <EmptyStateBody>
-            We could not find the icon that you searched for. Try searching for another icon.
+            We couldn't find any icons that matched your search. Try entering a new search term to find what you're looking for.
           </EmptyStateBody>
           <Button component="a" variant="primary" href="#primaryIconsSearch">Search Again</Button>
         </EmptyState>

--- a/packages/patternfly-4/src/components/content/icons.js
+++ b/packages/patternfly-4/src/components/content/icons.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Gallery, Form, TextInput } from '@patternfly/react-core';
+import { Gallery, Form, TextInput, Button, Title, EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody } from '@patternfly/react-core';
 import * as icons from '@patternfly/react-icons';
 import IconCard from './iconCard';
 import paramCase from 'param-case';
@@ -7,6 +7,7 @@ import coreIcons from '../../../_repos/core/src/icons/definitions/pf-icons.json'
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import './icons.scss';
+import { CubesIcon } from '@patternfly/react-icons';
 
 const allIcons = Object.entries(icons).filter(([name]) => name.endsWith('Icon'));
 let commonIcons = allIcons.filter(([name]) => {
@@ -40,6 +41,11 @@ class Icons extends React.Component {
     const filteredIcons = commonIcons.filter(c => {
       return searchRE.test(c[0]);
     });
+    // function isEmpty (filteredIcons) {
+    //   if (this.state.filteredIcons && this.statefilteredIcons.length == null) {
+
+    //   }
+    // };
     return (
       <>
         <Form className="search-icons ws-search " onSubmit={event => { event.preventDefault(); return false; }}>
@@ -58,6 +64,20 @@ class Icons extends React.Component {
           return <IconCard key={id} id={id} icon={Icon} name={name} />;
         })}
         </Gallery>
+        <EmptyState variant={EmptyStateVariant.full}>
+          { filteredIcons.length == 0 && 
+            <div>
+              <EmptyStateIcon icon={CubesIcon}/>
+              <Title headingLevel="h5" size="2xl">
+                Sorry there are no icons found for "{ searchValue }"
+              </Title>
+              <EmptyStateBody>
+                Sorry we could not find the icon that you searched for. Try searching for another icon.
+              </EmptyStateBody>
+              <Button component="a" variant="primary" href="#primaryIconsSearch">Search Again</Button>
+            </div>
+            }
+        </EmptyState>
     </>
   );
   }

--- a/packages/patternfly-4/src/components/content/icons.js
+++ b/packages/patternfly-4/src/components/content/icons.js
@@ -7,7 +7,7 @@ import coreIcons from '../../../_repos/core/src/icons/definitions/pf-icons.json'
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import './icons.scss';
-import { CubesIcon } from '@patternfly/react-icons';
+import { SearchIcon } from '@patternfly/react-icons';
 
 const allIcons = Object.entries(icons).filter(([name]) => name.endsWith('Icon'));
 let commonIcons = allIcons.filter(([name]) => {
@@ -59,20 +59,17 @@ class Icons extends React.Component {
           return <IconCard key={id} id={id} icon={Icon} name={name} />;
         })}
         </Gallery>
-        <EmptyState variant={EmptyStateVariant.full}>
-          { filteredIcons.length == 0 && 
-            <div>
-              <EmptyStateIcon icon={CubesIcon}/>
-              <Title headingLevel="h5" size="2xl">
-                Sorry there are no icons found for "{ searchValue }"
-              </Title>
-              <EmptyStateBody>
-                Sorry we could not find the icon that you searched for. Try searching for another icon.
-              </EmptyStateBody>
-              <Button component="a" variant="primary" href="#primaryIconsSearch">Search Again</Button>
-            </div>
-            }
+        {filteredIcons.length == 0 &&  <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon icon={SearchIcon}/>
+          <Title headingLevel="h5" size="2xl">
+            Sorry there are no icons found for "{ searchValue }".
+          </Title>
+          <EmptyStateBody>
+            We could not find the icon that you searched for. Try searching for another icon.
+          </EmptyStateBody>
+          <Button component="a" variant="primary" href="#primaryIconsSearch">Search Again</Button>
         </EmptyState>
+        }
     </>
   );
   }

--- a/packages/patternfly-4/src/components/content/icons.js
+++ b/packages/patternfly-4/src/components/content/icons.js
@@ -7,7 +7,6 @@ import coreIcons from '../../../_repos/core/src/icons/definitions/pf-icons.json'
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import './icons.scss';
-import { SearchIcon } from '@patternfly/react-icons';
 
 const allIcons = Object.entries(icons).filter(([name]) => name.endsWith('Icon'));
 let commonIcons = allIcons.filter(([name]) => {
@@ -60,7 +59,7 @@ class Icons extends React.Component {
         })}
         </Gallery>
         {filteredIcons.length == 0 &&  <EmptyState variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={SearchIcon}/>
+          <EmptyStateIcon icon={icons.SearchIcon}/>
           <Title headingLevel="h5" size="2xl">
             No results found for "{ searchValue }".
           </Title>

--- a/packages/patternfly-4/src/components/content/icons.js
+++ b/packages/patternfly-4/src/components/content/icons.js
@@ -41,11 +41,6 @@ class Icons extends React.Component {
     const filteredIcons = commonIcons.filter(c => {
       return searchRE.test(c[0]);
     });
-    // function isEmpty (filteredIcons) {
-    //   if (this.state.filteredIcons && this.statefilteredIcons.length == null) {
-
-    //   }
-    // };
     return (
       <>
         <Form className="search-icons ws-search " onSubmit={event => { event.preventDefault(); return false; }}>


### PR DESCRIPTION
closes #872 

@rachael-phillips @stacymcauliffe could you double check the copy and also the icon? The button links to the search input. 

<img width="1119" alt="Screen Shot 2019-05-29 at 2 11 11 PM" src="https://user-images.githubusercontent.com/20118816/58580841-0bca1900-821c-11e9-8364-dd2628a96432.png">
