### PR TITLE
fix(link): link now working

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/usage-and-behavior/alerts-and-notifications/design.md
+++ b/packages/patternfly-4/content/design-guidelines/usage-and-behavior/alerts-and-notifications/design.md
@@ -95,7 +95,7 @@ When a condition occurs that requires immediate action, a modal message dialog i
 
 ![modal notification](./img/modal-notification.png)
 
-For more information about designing modal messages see the [message dialog design guidelines](/design-guidelines/usage-and-behavior/message-dialogs).
+For more information about designing modal messages see the [message dialog design guidelines](/design-guidelines/usage-and-behavior/modal).
 
 ## Content guidelines
 Message text should be succinct and clearly state what the issue or problem is. Embedded links should navigate the user to the location where they can take action.


### PR DESCRIPTION
Fixed the 404 error when clicking on the "message dialog design guidelines" link. Now directs to the Modal Dialogs page. 