### PR TITLE
fix(link): link now working(1159)

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/usage-and-behavior/modal/design.md
+++ b/packages/patternfly-4/content/design-guidelines/usage-and-behavior/modal/design.md
@@ -80,7 +80,7 @@ Sometimes users may need to provide additional input in order to complete an act
 
 * If the modal needs to convey the importance of information visually, icons can be added.
 
-See our [content guidelines](/design-guidelines/content/) for additional guidance.
+See our [content guidelines](/design-guidelines/content/writing) for additional guidance.
 
 #### Icon use in modal dialogs
 


### PR DESCRIPTION
Fixed 404 error when clicking on the "content guidelines" link in Modal Dialog. Now directs to the writing section of Content. 