### PR TITLE
fix(code): code now breaks responsively

### DIFF
--- a/packages/patternfly-4/content/get-started/getstarted-dev.md
+++ b/packages/patternfly-4/content/get-started/getstarted-dev.md
@@ -77,10 +77,10 @@ If you need to overwrite any elements, we recommend extending the variables foun
 
 When you install PatternFly 4, the package includes:
 
-  * A single file for the entire compiled library: `node_modules/@patternfly/patternfly/patternfly.css`
-  * Individual files with each component compiled separately: `node_modules/@patternfly/patternfly/<ComponentName>/styles.css`
-  * A single file for the entire library's source (Sass): `node_modules/@patternfly/patternfly/patternfly.scss`
-  * Individual files for each component's source (Sass): `node_modules/@patternfly/patternfly/<ComponentName>/styles.scss`
+  * A single file for the entire compiled library: ```node_modules/@patternfly/patternfly/patternfly.css```
+  * Individual files with each component compiled separately: ```node_modules/@patternfly/patternfly/<ComponentName>/styles.css```
+  * A single file for the entire library's source (Sass): ```node_modules/@patternfly/patternfly/patternfly.scss```
+  * Individual files for each component's source (Sass): ```node_modules/@patternfly/patternfly/<ComponentName>/styles.scss```
 
 Use these files to consume the library. The recommended consumption approach will vary from project to project.
 

--- a/packages/patternfly-4/src/components/_core/Documentation/styles.scss
+++ b/packages/patternfly-4/src/components/_core/Documentation/styles.scss
@@ -61,7 +61,7 @@
 
   code {
     color: #282d33;
-    white-space: nowrap;
+    white-space: normal;
   }
 
   mark {
@@ -82,6 +82,7 @@
 
       > code {
         white-space: normal;
+        word-break: break-all;
       }
     }
   }

--- a/packages/patternfly-4/src/components/_core/Example/styles.scss
+++ b/packages/patternfly-4/src/components/_core/Example/styles.scss
@@ -41,6 +41,8 @@
   }
 
   code {
+    display: inline-block;
+    word-break: break-all;
     min-width: 32px;
     padding: 4px 8px;
     background-color: var(--pf-global--primary-color--100);
@@ -49,7 +51,7 @@
     font-size: 12px;
     font-weight: 600;
     line-height: 18px;
-    white-space: nowrap;
+    white-space: normal;
     a {
       color: #fff;
       text-decoration: none;

--- a/packages/patternfly-4/src/templates/template.scss
+++ b/packages/patternfly-4/src/templates/template.scss
@@ -26,6 +26,8 @@
     padding-bottom: 1px;
     padding-left: 8px;
     border: 1px solid #ededed;
+    white-space: normal;
+    word-break: break-all;
   }
   table {
     margin: 0;


### PR DESCRIPTION
Fix #1147 

<img width="340" alt="Screen Shot 2019-06-03 at 11 37 27 AM" src="https://user-images.githubusercontent.com/20118816/58815658-0262f700-85f6-11e9-8782-9ce93a1f72a4.png">
<img width="303" alt="Screen Shot 2019-06-03 at 11 49 49 AM" src="https://user-images.githubusercontent.com/20118816/58815660-02fb8d80-85f6-11e9-98e1-014dcd55b678.png">
