### PR TITLE
Fixes in Form tab of design guidelines

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/usage-and-behavior/forms/design.md
+++ b/packages/patternfly-4/content/design-guidelines/usage-and-behavior/forms/design.md
@@ -12,17 +12,17 @@ Most forms will contain the following basic elements:
 *Form elements*
 ![Form elements](./img/form-elements.png)
 
-1. [Labels](#labeling) - Field labels can be aligned to the top or left of the field depending on the layout of your page and the amount of space you have to work with.
+1. [Labels](#labeling): Field labels can be aligned to the top or left of the field depending on the layout of your page and the amount of space you have to work with.
 
-2. [Text input/text area](/design-guidelines/usage-and-behavior/data-input) - provides an area for users to input free-form text.
+2. [Text input/text area](/design-guidelines/usage-and-behavior/data-input): Provides an area for users to input free-form text.
 
-3. [Data input](#choose-the-right-data-input) - provides a way for users to submit any information that is not free-form text.
+3. [Data input](#choose-the-right-data-input): Provides a way for users to submit any information that is not free-form text.
 
-4. [Help](#provide-the-right-kind-of-help) - provides contextual assistance like popovers, placeholder text, or helper text, in any area where the user might need additional information to provide the right input.
+4. [Help](#provide-the-right-kind-of-help): Provides contextual assistance like popovers, placeholder text, or helper text, in any area where the user might need additional information to provide the right input.
 
-5. [Errors and validation](#provide-errors-and-validation) - ensures that the correct information is collected before the form can be submitted to the system.
+5. [Errors and validation](#provide-errors-and-validation): Ensures that the correct information is collected before the form can be submitted to the system.
 
-6. Buttons - enable a user to submit or exit a form. Button placement depends on the type of form you're presenting to the user.
+6. Buttons: Enable a user to submit or exit a form. Button placement depends on the type of form you're presenting to the user.
 
 7. [Required field indicator](#indicating-required-fields)
 
@@ -43,6 +43,7 @@ Always provide labels for text and data input so users understand what informati
 * Whichever approach you use, we recommend that you maintain consistency throughout an application.
 
 **General guidelines**
+*  Use sentence-style capitalization for all text elements, **except**: product names and proper nouns. Sentence style capitalizes only the first word of each sentence and proper nouns, like names.
 * Always provide a label for input components.
 * Labels should clearly state the required input.
 * Do not use a colon after the label name.


### PR DESCRIPTION
1. Added note in General guidelines for labels to use sentence-style capitalization for all text elements
2. Fixed formatting in listed items (semi colon instead of -, and capitalized sentences after colon) for consistency. Had discussed this with Stacy last week.

Also note: do not have access to fixing the picture examples on the website
(so this fixes half of issue #1171 )