### PR TITLE
change color of border to match background

### DIFF
--- a/packages/patternfly-4/src/components/css-variables.js
+++ b/packages/patternfly-4/src/components/css-variables.js
@@ -155,10 +155,12 @@ class Tokens extends React.Component {
             onChange={this.handleSearchChange}
           />
         </Form>
-        <Table className="pf-m-grid-2xl" variant="compact" aria-label="CSS Variables" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={filteredRows}>
-          <TableHeader />
-          <TableBody />
-        </Table>
+        <div className="table-container">
+          <Table className="table-css-vars pf-m-grid-2xl" variant="compact" aria-label="CSS Variables" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={filteredRows}>
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </div>
       </>
     );
   }

--- a/packages/patternfly-4/src/components/css-variables.js
+++ b/packages/patternfly-4/src/components/css-variables.js
@@ -155,12 +155,10 @@ class Tokens extends React.Component {
             onChange={this.handleSearchChange}
           />
         </Form>
-        <div className="table-container">
-          <Table className="table-css-vars pf-m-grid-2xl" variant="compact" aria-label="CSS Variables" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={filteredRows}>
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </div>
+        <Table className="table-css-vars pf-m-grid-2xl" variant="compact" aria-label="CSS Variables" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={filteredRows}>
+          <TableHeader />
+          <TableBody />
+        </Table>
       </>
     );
   }

--- a/packages/patternfly-4/src/components/css-variables.scss
+++ b/packages/patternfly-4/src/components/css-variables.scss
@@ -19,3 +19,17 @@
     --pf-c-form__label--FontSize: var(--pf-global--FontSize--lg);
   }
 }
+
+.table-css-vars {
+  tbody:first-of-type {
+    @media only screen and (max-width: 1450px) {
+      border-color: #f8f8f8 !important;
+    }
+  }
+
+  tr:not(.pf-c-table__expandable-row) {
+    @media only screen and (max-width: 1450px) {
+      border-bottom-color: #f8f8f8 !important;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1021 

Updates the table to break earlier using the new 2xl breakpoint from Core. Also changes the border colors on mobile to match the background-color, after speaking with Kyle

<img width="748" alt="Screen Shot 2019-06-10 at 4 24 54 PM" src="https://user-images.githubusercontent.com/20118816/59224659-eda9d480-8b9c-11e9-97a4-f878ea1e72b6.png">
