### PR TITLE
fix nav buttons

### DIFF
--- a/packages/patternfly-4/src/styles/_navigation.scss
+++ b/packages/patternfly-4/src/styles/_navigation.scss
@@ -26,11 +26,16 @@
   box-shadow: none !important;
 }
 .pf4-site-header {
+  .pf-c-nav__scroll-button {
+    outline-offset: -4px;
+    height: 100%;
+    top: 0;
+  }
   .pf-c-nav__horizontal-list {
     .pf-c-nav__link {
-      padding-top: 28px;
-      @media (max-width: 1024px) {
-        padding-top: var(--pf-global--spacer--md);
+      padding-top: 22px;
+      @media (max-width: 991px) {
+        padding-top: 10px;
       }
       padding-right: var(--pf-global--spacer--md);
       padding-left: var(--pf-global--spacer--md);


### PR DESCRIPTION
close #1207 

Makes the nav buttons 100% height and overrides the top assignment to 0. Also change the padding in the nav link items so that the text inside aligns with the arrows in the tab scroll buttons.

<img width="603" alt="Screen Shot 2019-06-11 at 10 54 21 AM" src="https://user-images.githubusercontent.com/20118816/59284429-3c597c00-8c3a-11e9-96e4-8cadea708ef6.png">
<img width="1062" alt="Screen Shot 2019-06-11 at 10 54 34 AM" src="https://user-images.githubusercontent.com/20118816/59284430-3c597c00-8c3a-11e9-840d-89cfb0fa46e9.png">
<img width="512" alt="Screen Shot 2019-06-11 at 10 54 42 AM" src="https://user-images.githubusercontent.com/20118816/59284431-3c597c00-8c3a-11e9-922e-17bb5b6327c3.png">
