### PR TITLE
turn off shadow dom with url param

### DIFF
--- a/packages/patternfly-4/package.json
+++ b/packages/patternfly-4/package.json
@@ -69,6 +69,7 @@
     "pascal-case": "2.0.1",
     "pretty": "^2.0.0",
     "prop-types": "15.7.2",
+    "query-string": "^6.8.1",
     "react": "~16.8.6",
     "react-dom": "~16.8.6",
     "react-helmet": "5.2.0",

--- a/packages/patternfly-4/src/components/ShadowDomPreview.js
+++ b/packages/patternfly-4/src/components/ShadowDomPreview.js
@@ -3,6 +3,7 @@ import ShadowDOM from 'react-shadow';
 import PropTypes from 'prop-types';
 import exampleStyles from '!raw!../../_repos/example-styles.css';
 import { Location } from '@reach/router';
+import queryString from 'query-string';
 
 const styles = `
   .ws-example { 
@@ -28,6 +29,7 @@ const ShadowDomPreview = ({ children, className, isReact, isFull, ...props }) =>
   return (
     <Location>
         {({ location }) => {
+          const params = location.search ? queryString.parse(location.search, { parseBooleans: true }) : '';
           const currentPath = location.pathname;
           // TODO: Update dependency of tippy in react-core as newer version supports shadow dom
           // Don't shadow dom paths that use tooltip until that is done
@@ -38,6 +40,10 @@ const ShadowDomPreview = ({ children, className, isReact, isFull, ...props }) =>
             currentPath.indexOf('/documentation/react/components/chipgroup') > -1 ||
             currentPath.indexOf('/documentation/react/components/clipboardcopy') > -1
           ) {
+            return children;
+          }
+          // turn off shadow-dom if ?shadow=false is passed into the URL
+          if (params.shadow === false) {
             return children;
           }
           return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -15341,6 +15341,15 @@ query-string@^6.1.0:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
+query-string@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.1.tgz#62c54a7ef37d01b538c8fd56f95740c81d438a26"
+  integrity sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"


### PR DESCRIPTION
Fixes: https://github.com/patternfly/patternfly-react/issues/2335
`?shadow=false` appended to a URL turns off shadow DOM encapsulation for the examples.