### PR TITLE
fix(a11y): fix navigation system link

### DIFF
--- a/packages/patternfly-4/content/design-guidelines/usage-and-behavior/navigation-system/design.md
+++ b/packages/patternfly-4/content/design-guidelines/usage-and-behavior/navigation-system/design.md
@@ -16,7 +16,7 @@ Navigation is used to organize an application’s structure and content, making 
 3. [**Horizontal navigation**](#horizontal-navigation)
 4. **Menu icon button:** Provides a way for users to toggle vertical navigation
 5. [**Vertical navigation**](#vertical-navigation)
-6. [**Local navigation**](#Local-navigation---Tabs)
+6. [**Local navigation**](#local-navigation---tabs)
 7. [**Breadcrumbs**](#breadcrumbs)
 
 ## Usage


### PR DESCRIPTION
fix #1300 

The anchor link was pointing to an invalid ID

<img width="1423" alt="Screen Shot 2019-07-23 at 10 38 24 AM" src="https://user-images.githubusercontent.com/20118816/61721231-24474300-ad36-11e9-8b4a-be55971660b0.png">
