### PR TITLE
fix(a11y): fix css variables search box (iss1302)

### DIFF
--- a/packages/patternfly-4/src/components/css-variables.js
+++ b/packages/patternfly-4/src/components/css-variables.js
@@ -150,6 +150,7 @@ class Tokens extends React.Component {
             type="text"
             id="primaryIconsSearch"
             name="primaryIconsSearch"
+            aria-label="Search CSS Variables"
             placeholder="Search CSS Variables"
             value={searchValue}
             onChange={this.handleSearchChange}

--- a/packages/patternfly-4/src/components/css-variables.scss
+++ b/packages/patternfly-4/src/components/css-variables.scss
@@ -13,7 +13,7 @@
       color: #151515;
     }
 
-    border: 1px solid #ededed;
+    border: 1px solid #4d5258;
   }
   .pf-c-form__label {
     --pf-c-form__label--FontSize: var(--pf-global--FontSize--lg);


### PR DESCRIPTION
Fixed CSS variable search box a11y issues by adding label and changing color of border. closes #1302 

<img width="1204" alt="Screen Shot 2019-07-23 at 1 56 42 PM" src="https://user-images.githubusercontent.com/50547577/61735576-3e8f1a00-ad52-11e9-848d-e1aab1154662.png">
