### PR TITLE
fix(a11y): fixed a11y issues in get-started/dev (iss1301)

### DIFF
--- a/packages/patternfly-4/src/content/get-started/developers.md
+++ b/packages/patternfly-4/src/content/get-started/developers.md
@@ -13,7 +13,7 @@ Before you begin, check out our [overview of PatternFly](/get-started/about) to 
 * [Use npm](https://nodejs.org/en/download)
 * [Use Yarn](https://yarnpkg.com/en/docs/getting-started)
 
-### Get started with:
+**Get started with:**
 
 * [React](#react)
 * [HTML/CSS](#htmlcss)


### PR DESCRIPTION
fixed a11y issue: heading levels should only increase by one. closes #1301 

<img width="1141" alt="Screen Shot 2019-08-16 at 10 50 58 AM" src="https://user-images.githubusercontent.com/50547577/63176484-ff33b080-c013-11e9-8fce-be630c716902.png">
