### PR TITLE
fix(markdownTable): remove word break on code elements

### DIFF
--- a/packages/patternfly-4/src/templates/template.scss
+++ b/packages/patternfly-4/src/templates/template.scss
@@ -27,7 +27,6 @@
     padding-left: 8px;
     border: 1px solid #ededed;
     white-space: normal;
-    word-break: break-all;
   }
   table {
     margin: 0;


### PR DESCRIPTION
fixes #1369 

<img width="810" alt="Screen Shot 2019-08-27 at 11 16 26 AM" src="https://user-images.githubusercontent.com/20118816/63785180-e6ea4e00-c8bd-11e9-8a00-7efbc88f4972.png">
