### PR TITLE
Fix property table documentation wrapping

### DIFF
--- a/packages/patternfly-4/src/components/_react/propsTable/propsTable.js
+++ b/packages/patternfly-4/src/components/_react/propsTable/propsTable.js
@@ -59,10 +59,10 @@ export const PropsTable = ({ name, description: preface, props }) => {
         <Body>
           {props.map(prop => (
             <Row key={prop.name}>
-              <TD>{prop.name}</TD>
-              <TD>{renderType(prop)}</TD>
+              <TD nowrap="nowrap">{prop.name}</TD>
+              <TD nowrap="nowrap">{renderType(prop)}</TD>
               <TD align="center">{prop.required && <ExclamationCircleIcon />}</TD>
-              <TD>{prop.defaultValue ? prop.defaultValue.value : ''}</TD>
+              <TD nowrap="nowrap">{prop.defaultValue ? prop.defaultValue.value : ''}</TD>
               <TD>{prop.description}</TD>
             </Row>
           ))}


### PR DESCRIPTION
This is a possible quick fix to the property table issue https://github.com/patternfly/patternfly-org/issues/1468 by preventing word wrapping on the 1st, 2nd, and 4th columns.


