### PR TITLE
feature(docs): Property names are no longer wrapping. this looks allo…

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
@@ -34,7 +34,9 @@ export const PropsTable = props => {
       caption={props.caption}
       rows={props.rows.map(row => ({
         cells: [
-          row.name,
+          <div className='pf-m-fit-content'>
+            {row.name}
+          </div>,
           renderType(row),
           <div>
             {row.required ? 'Yes' : 'No'}


### PR DESCRIPTION
Before:
![Screen Shot 2020-01-27 at 2 56 18 PM](https://user-images.githubusercontent.com/57504257/73208953-51c1de80-4115-11ea-84d1-3b022b278902.png)

After:
![Screen Shot 2020-01-27 at 2 54 05 PM](https://user-images.githubusercontent.com/57504257/73208966-56869280-4115-11ea-99cc-6c4ab916849d.png)
