### PR TITLE
fix(docs): hide version switcher on mobile

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -147,3 +147,18 @@
   border-top: none;
   border-bottom: 2px solid #fff;
 }
+
+/* Hide version switcher on mobile */
+@media screen and (max-width: 768px) {
+  .ws-page-header {
+      grid-template-columns: 3fr 1fr;
+  }
+      
+  .ws-page-header .pf-c-page__header-brand-link {
+      justify-content: center;
+  }
+  
+  .ws-page-header .pf-l-toolbar__item:first-child {
+    display: none;
+  }
+}


### PR DESCRIPTION
resolves #1650 