### PR TITLE
export example className methods

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/example/example.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/example/example.js
@@ -4,7 +4,7 @@ import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { ExampleToolbar } from './exampleToolbar';
 import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
 import { getParameters } from 'codesandbox/lib/api/define';
-import { slugger, transformCode, getStaticParams, getReactParams } from '../../helpers';
+import { slugger, transformCode, getStaticParams, getReactParams, getExampleClassName, getExampleId } from '../../helpers';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism-coy.css';
 import './example.css';
@@ -59,8 +59,8 @@ export const Example = props => {
     ? getStaticParams(props.title, html)
     : getReactParams(props.title, editorCode, scope));
 
-  const className = `ws-${props.source}-${navSection[0]}-${componentName}`;
-  const id = `${className}-${slugger(title)}`;
+  const className = getExampleClassName(props.source, navSection[0], componentName);
+  const id = getExampleId(props.source, navSection[0], componentName, title);
 
   // https://reactjs.org/docs/hooks-effect.html
   if (isFullscreen) {

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/helpers/extractExamples.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/helpers/extractExamples.js
@@ -1,6 +1,15 @@
 const visit = require('unist-util-visit');
-var { render } = require('html-formatter');
+const { render } = require('html-formatter');
 const { getId } = require('./getId');
+const { slugger } = require('./slugger');
+
+function getExampleClassName(source, componentType, componentName) {
+  return `ws-${source}-${componentType}-${componentName}`;
+}
+
+function getExampleId(source, componentType, componentName, exampleTitle) {
+  return `ws-${source}-${componentType}-${componentName}-${slugger(exampleTitle)}`;
+}
 
 module.exports = {
   // Map example page urls to HTML
@@ -42,6 +51,8 @@ module.exports = {
 
     return examples;
   },
+  getExampleClassName,
+  getExampleId
 }
 
 // TODO: Write some tests for example MDXAsts

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/helpers/extractExamples.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/helpers/extractExamples.js
@@ -3,10 +3,12 @@ const { render } = require('html-formatter');
 const { getId } = require('./getId');
 const { slugger } = require('./slugger');
 
+// Used in core's dev:lite
 function getExampleClassName(source, componentType, componentName) {
   return `ws-${source}-${componentType}-${componentName}`;
 }
 
+// Used in core's dev:lite
 function getExampleId(source, componentType, componentName, exampleTitle) {
   return `ws-${source}-${componentType}-${componentName}-${slugger(exampleTitle)}`;
 }

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/helpers/index.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/helpers/index.js
@@ -4,3 +4,4 @@ export * from './copy';
 export * from './getId';
 export * from './slugger';
 export * from './transformCode';
+export { getExampleClassName, getExampleId } from './extractExamples';


### PR DESCRIPTION
To make https://github.com/patternfly/patternfly-next/pull/2665 clean.