### PR TITLE
Experimental beta

### DIFF
--- a/packages/patternfly-4/gatsby-config.js
+++ b/packages/patternfly-4/gatsby-config.js
@@ -24,14 +24,14 @@ module.exports = {
             { section: 'layouts' },
             { section: 'utilities' },
             { section: 'demos' },
-            { section: 'experimental' },
+            { section: 'beta' },
           ],
           react: [
             { section: 'overview' },
             { section: 'charts' },
             { section: 'components' },
             { section: 'demos' },
-            { section: 'experimental' },
+            { section: 'beta' },
             { section: 'layouts' },
           ],
           get_started: [
@@ -228,7 +228,7 @@ module.exports = {
               siteUrl
             }
           }
-        
+
           allSitePage(filter: {context: {isFullscreen: {ne: true}}}) {
             edges {
               node {

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
@@ -24,7 +24,6 @@ export const PropsTable = props => {
   const columns = [
     { title: 'Name' },
     { title: 'Type' },
-    { title: 'Beta' },
     { title: 'Required' },
     { title: 'Default' },
     { title: 'Description' }
@@ -42,12 +41,10 @@ export const PropsTable = props => {
           cells: [
             <div className='pf-m-fit-content'>
               {row.deprecated && 'Deprecated: '}
+              {row.beta && 'Beta: '}
               {row.name}
             </div>,
             renderType(row),
-            <div>
-              {row.beta ? 'Beta' : ''}
-            </div>,
             <div>
               {row.required ? 'Yes' : 'No'}
             </div>,

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
@@ -24,6 +24,7 @@ export const PropsTable = props => {
   const columns = [
     { title: 'Name' },
     { title: 'Type' },
+    { title: 'Beta' },
     { title: 'Required' },
     { title: 'Default' },
     { title: 'Description' }
@@ -44,6 +45,9 @@ export const PropsTable = props => {
               {row.name}
             </div>,
             renderType(row),
+            <div>
+              {row.beta ? 'Beta' : ''}
+            </div>,
             <div>
               {row.required ? 'Yes' : 'No'}
             </div>,

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/index.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/index.js
@@ -9,7 +9,7 @@ exports.mdxTypeDefs = `
     cssPrefix: String
     hideTOC: Boolean
     optIn: String
-    experimentalStage: String
+    beta: Boolean
     propComponents: [String]
     hideDarkMode: Boolean
     reactComponentName: String
@@ -40,6 +40,7 @@ exports.mdxTypeDefs = `
     value: String
   }
   type PropsType @dontInfer {
+    beta: Boolean
     name: String!
     description: String
     required: Boolean

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/templates/mdx.js
@@ -20,23 +20,6 @@ import { getId , slugger, capitalize} from '../helpers';
 import versions from '../versions.json';
 import './mdx.css';
 
-const getExperimentalWarning = (state, componentName) => {
-  switch(state) {
-    case 'promoted':
-      return (
-        <p>
-          This experimental feature has been promoted to a <Link href={`../../components/${componentName}`}>production-level component</Link> and will be removed in a future release.
-          Use the production-ready version of this feature instead.
-        </p>
-      );
-    case 'deprecated':
-      return 'This experimental feature has been deprecated and will be removed in a future release. We recommend you avoid or move away from using this feature in your projects.';
-    case 'early':
-    default:
-      return "This is an experimental feature in the early stages of testing. It's not intended for production use.";
-  }
-}
-
 const getSourceTitle = source => {
   switch(source) {
     case 'core':
@@ -57,7 +40,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
         katacodaId={location.state.katacodaId} />
     );
   }
-  const { cssPrefix, hideTOC, experimentalStage, optIn, hideDarkMode, showTitle, releaseNoteTOC } = data.doc.frontmatter;
+  const { cssPrefix, hideTOC, beta, optIn, hideDarkMode, showTitle, releaseNoteTOC } = data.doc.frontmatter;
   const { componentName, navSection } = data.doc.fields;
   const { title, source, tableOfContents, htmlExamples, propComponents = [''], showBanner } = pageContext;
   const props = data.props && data.props.nodes && propComponents
@@ -73,9 +56,9 @@ const MDXTemplate = ({ data, location, pageContext }) => {
       })
       .filter(Boolean)
     : [];
-  
+
   let parityComponent = undefined;
-  if (data.designDoc && ['components', 'experimental', 'utilities'].includes(navSection)) {
+  if (data.designDoc && ['components', 'beta', 'utilities'].includes(navSection)) {
     const { reactComponentName, coreComponentName } = data.designDoc.frontmatter;
     if (source === 'core' && reactComponentName) {
       parityComponent = `${navSection}/${reactComponentName}`;
@@ -119,15 +102,15 @@ const MDXTemplate = ({ data, location, pageContext }) => {
               {optIn}
             </Alert>
           )}
-          {experimentalStage && (
+          {beta && (
             <Alert
-              variant={experimentalStage === 'early' ? 'info' : 'warning'}
-              title="Experimental feature"
+              variant={'info'}
+              title="Beta"
               className="pf-u-my-md"
               style={{ marginBottom: '1rem' }}
               isInline
             >
-              {getExperimentalWarning(experimentalStage)}
+              This is a beta feature, it is not yet intended for production use. Beta features may require minor adjustments as we receive feedback on them.
             </Alert>
           )}
           {data.designDoc && (
@@ -164,7 +147,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
                           )}
                         </CardHeader>
                         <CardBody>
-                          Released on {releaseDate}. 
+                          Released on {releaseDate}.
                         </CardBody>
                       </Card>
                     </GridItem>
@@ -280,7 +263,7 @@ export const pageQuery = graphql`
         cssPrefix
         hideTOC
         optIn
-        experimentalStage
+        beta
         hideDarkMode
         showTitle
         releaseNoteTOC
@@ -309,6 +292,7 @@ export const pageQuery = graphql`
       nodes {
         name
         props {
+          beta
           name
           required
           description

--- a/packages/patternfly-4/gatsby-transformer-react-docgen-typescript/gatsby-node.js
+++ b/packages/patternfly-4/gatsby-transformer-react-docgen-typescript/gatsby-node.js
@@ -52,6 +52,11 @@ const annotations = [
     type: 'Boolean'
   },
   {
+    regex: /@beta/,
+    name: 'beta',
+    type: 'Boolean'
+  },
+  {
     regex: /@propType (\w+|['"](.+)['"])\s*/,
     name: 'annotatedType',
     type: 'String'
@@ -60,6 +65,7 @@ const annotations = [
 
 function addAnnotations(prop) {
   // Prop looks like this: {
+  //   "beta": null,
   //   "required": false,
   //   "name": "className",
   //   "description": "Additional css classes",
@@ -139,6 +145,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       value: String
     }
     type PropsType @noInfer {
+      beta: Boolean
       name: String!
       description: String
       required: Boolean

--- a/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/bulk-selection/bulk-selection.md
+++ b/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/bulk-selection/bulk-selection.md
@@ -7,7 +7,7 @@ showTitle: true
 
 
 
-Use a bulk selection pattern when you want to select or deselect multiple items in a content view (list, table, or card grid). The bulk selector uses a [Split button](/documentation/react/components/dropdown#split-button) component to control selection from the [Toolbar](/documentation/react/experimental/datatoolbar). Besides controlling selection, the bulk selector reflects the selection status of the related component (partially selected, all items selected, or no items selected).
+Use a bulk selection pattern when you want to select or deselect multiple items in a content view (list, table, or card grid). The bulk selector uses a [Split button](/documentation/react/components/dropdown#split-button) component to control selection from the [Toolbar](/documentation/react/beta/datatoolbar). Besides controlling selection, the bulk selector reflects the selection status of the related component (partially selected, all items selected, or no items selected).
 
 ## Bulk selector
 The bulk selector is created using a Split button and is always located as the leftmost item in a toolbar.
@@ -55,9 +55,9 @@ Note: To hide integrated bulk selection and enable selection control from the to
 
 ### Core HTML/CSS
 * [Split button](/documentation/core/components/dropdown#split-button)
-* [Data toolbar (experimental)](/documentation/core/experimental/datatoolbar)
+* [Data toolbar (beta)](/documentation/core/beta/datatoolbar)
 
 ### React
 * [Split button](/documentation/react/components/dropdown#split-button)
-* [Data toolbar (experimental)](/documentation/core/experimental/datatoolbar)
+* [Data toolbar (beta)](/documentation/core/beta/datatoolbar)
 * [Bulk select table demo](/documentation/react/demos/bulkselecttable)

--- a/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/data-loading/data-loading.md
+++ b/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/data-loading/data-loading.md
@@ -42,7 +42,7 @@ Spinners are centered within the container AND the viewport by default in all us
 
 ## Related components and demos
 **HTML/CSS**
-* [Spinner](/documentation/core/experimental/spinner)
+* [Spinner](/documentation/core/beta/spinner)
 
 **React**
-* [Spinner](/documentation/react/experimental/spinner)
+* [Spinner](/documentation/react/beta/spinner)

--- a/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/filters/filters.md
+++ b/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/filters/filters.md
@@ -219,9 +219,9 @@ The option to clear all filters will be displayed after the last filter chip. It
 * [Input group](/documentation/core/components/inputgroup)
 * [Options menus](/documentation/core/components/optionsmenu)
 * [Select](/documentation/core/components/select)
-* [Data Toolbar (experimental)](/documentation/core/experimental/toolbar)
+* [Data Toolbar (beta)](/documentation/core/beta/toolbar)
 
 **React**
 * [Badges](/documentation/react/components/badge)
 * [Chip group](/documentation/react/components/chipgroup)
-* [Data Toolbar (experimental)](/documentation/react/experimental/toolbar)
+* [Data Toolbar (beta)](/documentation/react/beta/toolbar)

--- a/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/toolbar/toolbar.md
+++ b/packages/patternfly-4/src/content/design-guidelines/usage-and-behavior/toolbar/toolbar.md
@@ -142,14 +142,14 @@ The toolbar adapts to smaller viewport sizes by collapsing or hiding elements th
 
 ## Related components and demos
 **Core HTML/CSS**
-* [Data Toolbar (experimental)](/documentation/core/experimental/datatoolbar)
-* [Overflow menu (experimental)](/documentation/core/experimental/overflowmenu)
+* [Data Toolbar (beta)](/documentation/core/beta/datatoolbar)
+* [Overflow menu (beta)](/documentation/core/beta/overflowmenu)
 * [Chip](/documentation/core/components/chip)
 * [Chip group](/documentation/core/components/chipgroup)
 * [Pagination](/documentation/core/components/pagination)
 
 **React**
-* [Data Toolbar (experimental)](/documentation/react/experimental/datatoolbar)
-* [Overflow menu (experimental)](/documentation/react/experimental/overflowmenu)
+* [Data Toolbar (beta)](/documentation/react/beta/datatoolbar)
+* [Overflow menu (beta)](/documentation/react/beta/overflowmenu)
 * [Chip group](/documentation/react/components/chipgroup)
 * [Pagination](/documentation/react/components/pagination)

--- a/packages/patternfly-4/src/pages/index.js
+++ b/packages/patternfly-4/src/pages/index.js
@@ -37,7 +37,7 @@ const IndexPage = ({ location }) => {
             <Title size="4xl" className="pf-m-white pf4-site-c-hero fadeIn animated fadeInTwo">
               Build better experiences with repeatable, scalable design.
             </Title>
-            <Title size="xl" className="pf-m-white pf-u-mb-md pf-u-mb-3xl-on-md fadeInUp animated fadeInThree">
+            <Title size="xl" headingLevel="h2" className="pf-m-white pf-u-mb-md pf-u-mb-3xl-on-md fadeInUp animated fadeInThree">
               PatternFly is an open source design system built to drive consistency and unify teams.
             </Title>
             <div className="pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column pf-u-flex-direction-row-on-md">


### PR DESCRIPTION
This PR updates the docs to refer to what was previously "experimental" components/properties as "beta" components/properties. These changes go along with and are dependent upon https://github.com/patternfly/patternfly-next/pull/2680 and https://github.com/patternfly/patternfly-react/pull/3663.