### PR TITLE
feat(beta): add badge support for beta properties and examples

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/autoLinkHeader/autoLinkHeader.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/autoLinkHeader/autoLinkHeader.js
@@ -19,6 +19,7 @@ export const AutoLinkHeader = ({
   size,
   headingLevel,
   children,
+  metaText,
   ...props
 }) => {
   const slug = slugger(children);
@@ -32,7 +33,7 @@ export const AutoLinkHeader = ({
       <a href={`#${slug}`} className="ws-heading-anchor" tabIndex="-1"  aria-hidden>
         <LinkIcon style={{ height: '0.5em', width: '0.5em', verticalAlign: 'middle' }} />
       </a>
-      {children}
+      {children} {metaText}
     </Title>
   )
 };

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/example/example.css
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/example/example.css
@@ -78,3 +78,8 @@
   color: rgba(255,255,255,.4);
 }
 
+.pf-c-badge.ws-beta-badge {
+  --pf-c-badge--m-unread--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-badge--m-unread--Color: var(--pf-global--primary-color--100);
+  border: 1px solid var(--pf-global--primary-color--100);
+}

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/example/example.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/example/example.js
@@ -1,5 +1,6 @@
 import React, { useLayoutEffect } from 'react';
 import { LiveProvider, LiveEditor, LivePreview, LiveError } from 'react-live';
+import { Badge } from '@patternfly/react-core';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
 import { ExampleToolbar } from './exampleToolbar';
 import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
@@ -29,7 +30,7 @@ export const Example = props => {
   const supportedLangs = getSupportedLanguages(props.className);
   const initialLang = supportedLangs[0];
   const initialCode = props.children.toString();
-  const { noLive, title = 'no title', isFullscreen = false, location, children, navSection, componentName } = props;
+  const { noLive, title = 'no title', isFullscreen = false, isBeta = false, location, children, navSection, componentName } = props;
 
   // https://reactjs.org/docs/hooks-overview.html#state-hook
   const [editorCode, setEditorCode] = React.useState(initialLang === 'html' ? html : initialCode);
@@ -97,7 +98,7 @@ export const Example = props => {
 
   return (
     <div className="ws-example">
-      <AutoLinkHeader size="h4" headingLevel="h3" className="ws-example-heading">
+      <AutoLinkHeader metaText={isBeta ? <Badge className="ws-beta-badge pf-u-ml-xs">Beta</Badge> : null} size="h4" headingLevel="h3" className="ws-example-heading">
         {exampleName}
       </AutoLinkHeader>
       <LiveProvider
@@ -136,7 +137,7 @@ export const Example = props => {
           isFullscreen={isFullscreen}
           fullscreenLink={fullscreenLink}
           code={editorCode}
-          codeBoxParams={codeBoxParams} 
+          codeBoxParams={codeBoxParams}
           componentName={props.componentName}/>
         <LiveError />
       </LiveProvider>

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Badge } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
 const renderType = prop => {
@@ -41,8 +42,8 @@ export const PropsTable = props => {
           cells: [
             <div className='pf-m-fit-content'>
               {row.deprecated && 'Deprecated: '}
-              {row.beta && 'Beta: '}
               {row.name}
+              {row.beta && <Badge className="ws-beta-badge pf-u-ml-sm">Beta</Badge>}
             </div>,
             renderType(row),
             <div>

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/templates/mdx.js
@@ -105,12 +105,12 @@ const MDXTemplate = ({ data, location, pageContext }) => {
           {beta && (
             <Alert
               variant={'info'}
-              title="Beta"
+              title="Beta feature"
               className="pf-u-my-md"
               style={{ marginBottom: '1rem' }}
               isInline
             >
-              This is a beta feature, it is not yet intended for production use. Beta features may require minor adjustments as we receive feedback on them.
+              This Beta component is currently under review, so please join in and give us your feedback at https://forum.patternfly.org/
             </Alert>
           )}
           {data.designDoc && (


### PR DESCRIPTION
This PR adds support for badges to represent beta properties and examples. Should help facilitate this design https://github.com/patternfly/patternfly-org/issues/1646#issuecomment-582939063