### PR TITLE
fix(keys): use unique keys for beta badge in props table

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/propsTable/propsTable.js
@@ -38,12 +38,12 @@ export const PropsTable = props => {
       caption={props.caption}
       rows={props.rows
         .filter(row => !row.hide)
-        .map(row => ({
+        .map((row, idx) => ({
           cells: [
             <div className='pf-m-fit-content'>
               {row.deprecated && 'Deprecated: '}
               {row.name}
-              {row.beta && <Badge className="ws-beta-badge pf-u-ml-sm">Beta</Badge>}
+              {row.beta && <Badge key={`${row.name}-${idx}`} className="ws-beta-badge pf-u-ml-sm">Beta</Badge>}
             </div>,
             renderType(row),
             <div>


### PR DESCRIPTION
This PR fixes an issue where we get development time warnings about non-unique keys when the new beta prop flag is used.

<img width="900" alt="Screen Shot 2020-02-14 at 10 06 41 AM" src="https://user-images.githubusercontent.com/5942899/74542944-8ce45000-4f12-11ea-9fce-bc7b62cdfc6f.png">
