### PR TITLE
updated classes and CSS rules for close button alignment

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.css
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.css
@@ -11,12 +11,4 @@
   flex-wrap: nowrap;
   background: #FFF;
   border: 1px solid #151515;
-  align-items: center;
-}
-
-@media (max-width: 767px) {
-  #ws-gdpr-banner .pf-u-mr-xl {
-    margin-right: 0 !important;
-    top: 10px;
-  }
 }

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
@@ -14,15 +14,15 @@ export const GdprBanner = () => {
 
   return (
     <div className="ws-gdpr-banner-container pf-l-flex">
-      <div id="ws-gdpr-banner" className="pf-l-flex">
+      <div id="ws-gdpr-banner" className="pf-l-flex pf-u-py-md pf-m-align-items-flex-start">
         {isBannerOpen && (
           <React.Fragment>
-            <div className="pf-u-my-md">
+            <div>
               <p id="ws-gdpr-banner-text" className="pf-u-ml-xl">
                 We use cookies on our websites to deliver our online services. Details about how we use cookies and how you may disable them are set out in our <a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a>. By using this website you agree to our use of cookies.
               </p>
             </div>
-            <div className="pf-u-mr-xl">
+            <div>
               <Button variant="plain" aria-label="Close banner" onClick={closeBanner}>
                 <TimesIcon />
               </Button>

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
@@ -14,7 +14,7 @@ export const GdprBanner = () => {
 
   return (
     <div className="ws-gdpr-banner-container pf-l-flex">
-      <div id="ws-gdpr-banner" className="pf-l-flex pf-u-py-md pf-m-align-items-flex-start">
+      <div id="ws-gdpr-banner" className="pf-l-flex pf-u-py-md pf-m-align-items-center">
         {isBannerOpen && (
           <React.Fragment>
             <div>
@@ -22,7 +22,7 @@ export const GdprBanner = () => {
                 We use cookies on our websites to deliver our online services. Details about how we use cookies and how you may disable them are set out in our <a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a>. By using this website you agree to our use of cookies.
               </p>
             </div>
-            <div>
+            <div className="pf-m-align-self-flex-start">
               <Button variant="plain" aria-label="Close banner" onClick={closeBanner}>
                 <TimesIcon />
               </Button>


### PR DESCRIPTION
Closes #1715 - this PR updates the classes and CSS styles applied to the GDPR banner in order to position the "X" close button in the top-right rather than centered vertically.