### PR TITLE
chore(title): set headingLevel explicitly in Title usage

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/pages/404.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/pages/404.js
@@ -7,8 +7,7 @@ const Page404 = ({ location }) => {
   return (
     <SideNavLayout location={location} hideSideNav showGdprBanner={true}>
       <PageSection className="ws-section" style={{ height: '70vh' }}>
-        <Title size="2xl">404</Title>
-        <Title size="lg">Page not found</Title>
+        <Title size="2xl" headingLevel="h1">404 - Page not found</Title>
         <p><Link to="/">Go home.</Link></p>
       </PageSection>
     </SideNavLayout>

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/templates/mdx.js
@@ -73,7 +73,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
     <React.Fragment>
       {showTitle && (
         <React.Fragment>
-          <Title size="4xl" className="ws-page-title">{title}</Title>
+          <Title size="4xl" headingLevel="h1" className="ws-page-title">{title}</Title>
           {optIn && (
             <Alert
               variant="info"
@@ -91,7 +91,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
           <label id="source-label" className="ws-framework-title pf-c-title" aria-hidden>
             {getSourceTitle(source)}
           </label>
-          <Title id="component-title" size="4xl" className="ws-page-title" aria-labelledby="source-label component-title">{title}</Title>
+          <Title headingLevel="h1" id="component-title" size="4xl" className="ws-page-title" aria-labelledby="source-label component-title">{title}</Title>
           {optIn && (
             <Alert
               variant="info"
@@ -179,7 +179,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
 
   const PropsSection = () => (
     <React.Fragment>
-      <AutoLinkHeader id="props" size="h2" className="ws-h2">
+      <AutoLinkHeader headingLevel="h2" id="props" size="h2" className="ws-h2">
         Props
       </AutoLinkHeader>
       {props.map(component => (
@@ -193,7 +193,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
 
   const CSSVariablesSection = () => (
     <React.Fragment>
-      <AutoLinkHeader id="css-variables" size="h2" className="ws-h2">
+      <AutoLinkHeader headingLevel="h2" id="css-variables" size="h2" className="ws-h2">
         CSS Variables
       </AutoLinkHeader>
       <CSSVariables prefix={cssPrefix} />
@@ -225,7 +225,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
 
     return (
       <React.Fragment>
-        <AutoLinkHeader id="feedback" size="h2" className="ws-h2">
+        <AutoLinkHeader headingLevel="h2" id="feedback" size="h2" className="ws-h2">
           Feedback
         </AutoLinkHeader>
         <a href={sourceLink} target="_blank">View page source on Github</a> / <a href={issueLink} target="_blank">Report an issue on Github</a>

--- a/packages/patternfly-4/src/pages/get-in-touch.js
+++ b/packages/patternfly-4/src/pages/get-in-touch.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SideNavLayout } from 'gatsby-theme-patternfly-org/layouts';
 import { ChatIcon, QuestionIcon, CatalogIcon, MailBulkIcon } from '@patternfly/react-icons';
-import { Grid, GridItem, PageSection, PageSectionVariants, Split, SplitItem } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, PageSectionVariants, Split, SplitItem, Title } from '@patternfly/react-core';
 import "./get-in-touch.css";
 
 const GetInTouch = ({ location }) => {
@@ -20,12 +20,12 @@ const GetInTouch = ({ location }) => {
 
       <p className="ws-mdx-p">We are here to help.</p>
 
-      <Grid sm={12} md={6} gutter="sm" class="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter" style={{ maxWidth: '450px' }}>
+      <Grid sm={12} md={6} gutter="sm" className="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter" style={{ maxWidth: '450px' }}>
         <GridItem>
           <Split>
             <SplitItem style={{ marginRight: '12px' }}><h3><ChatIcon /></h3></SplitItem>
             <SplitItem isFilled>
-              <h3 className="ws-title">Chat with us</h3>
+              <Title size="lg" className="ws-title" headingLevel="h2">Chat with us</Title>
               <a href="https://patternfly.slack.com" target="_blank" rel="noopener noreferrer">Slack</a>
             </SplitItem>
           </Split>
@@ -34,7 +34,7 @@ const GetInTouch = ({ location }) => {
           <Split>
             <SplitItem style={{ marginRight: '12px' }}><h3><MailBulkIcon /></h3></SplitItem>
             <SplitItem isFilled>
-              <h3 className="ws-title">Stay in the loop</h3>
+              <Title size="lg" className="ws-title" headingLevel="h2">Stay in the loop</Title>
               <a href="https://www.redhat.com/mailman/listinfo/patternfly" target="_blank" rel="noopener noreferrer">PatternFly mailing list</a>
             </SplitItem>
           </Split>
@@ -43,7 +43,7 @@ const GetInTouch = ({ location }) => {
           <Split>
             <SplitItem style={{ marginRight: '12px' }}><h3><QuestionIcon /></h3></SplitItem>
             <SplitItem isFilled>
-              <h3 className="ws-title">Ask a question</h3>
+              <Title size="lg" className="ws-title" headingLevel="h2">Ask a question</Title>
               <a href="https://forum.patternfly.org/" target="_blank" rel="noopener noreferrer">PatternFly forum</a>
             </SplitItem>
           </Split>
@@ -52,7 +52,7 @@ const GetInTouch = ({ location }) => {
           <Split>
             <SplitItem style={{ marginRight: '12px' }}><h3><CatalogIcon /></h3></SplitItem>
             <SplitItem isFilled>
-              <h3 className="ws-title">Read the latest</h3>
+              <Title size="lg" className="ws-title" headingLevel="h2">Read the latest</Title>
               <a href="https://medium.com/patternfly" target="_blank" rel="noopener noreferrer">PatternFly Medium</a>
             </SplitItem>
           </Split>

--- a/packages/patternfly-4/src/pages/index.js
+++ b/packages/patternfly-4/src/pages/index.js
@@ -38,7 +38,7 @@ const IndexPage = ({ location }) => {
         <GridItem sm={12} md={8} mdOffset={2} lg={6} lgOffset={3} className="pf-u-py-2xl pf-u-text-align-center">
           <TextContent>
             <img src={orb} alt="PatternFly logo" className="fadeInDown animated fadeInOne" />
-            <Title size="4xl" className="pf-m-white pf4-site-c-hero fadeIn animated fadeInTwo">
+            <Title headingLevel="h1" size="4xl" className="pf-m-white pf4-site-c-hero fadeIn animated fadeInTwo">
               Build better experiences with repeatable, scalable design.
             </Title>
             <Title size="xl" headingLevel="h2" className="pf-m-white pf-u-mb-md pf-u-mb-3xl-on-md fadeInUp animated fadeInThree">
@@ -69,7 +69,7 @@ const IndexPage = ({ location }) => {
     <PageSection variant={PageSectionVariants.light} className="ws-homepage-main-section">
       <Grid>
         <GridItem sm={12} md={6} mdOffset={3} className="pf-u-py-2xl pf-u-text-align-center" id="about-patternfly-section">
-          <AutoLinkHeader size="h1" className="ws-title pf-u-mb-md">
+          <AutoLinkHeader size="h1" headingLevel="h2" className="ws-title pf-u-mb-md">
             {aboutPatternFly}
           </AutoLinkHeader>
           <Text component={TextVariants.p} className="ws-mdx-p">


### PR DESCRIPTION
This PR updates all usage of Title component to explicitly set the `headingLevel` prop. Pairs along with https://github.com/patternfly/patternfly-react/pull/3922

Nothing should actually have changed in terms of what heading levels are applied on the site, just that they are now set explicitly. Upcoming changes for Title will make this a required prop so just getting ahead of it.