### PR TITLE
completely remove GDPR banner when closed

### DIFF
--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
@@ -27,5 +27,5 @@ export const GdprBanner = () => {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
+++ b/packages/patternfly-4/gatsby-theme-patternfly-org/components/gdprBanner/gdprBanner.js
@@ -12,24 +12,20 @@ export const GdprBanner = () => {
     setBannerOpen(false);
   }
 
-  return (
+  return isBannerOpen && (
     <div className="ws-gdpr-banner-container pf-l-flex">
       <div id="ws-gdpr-banner" className="pf-l-flex pf-u-py-md pf-m-align-items-center">
-        {isBannerOpen && (
-          <React.Fragment>
-            <div>
-              <p id="ws-gdpr-banner-text" className="pf-u-ml-xl">
-                We use cookies on our websites to deliver our online services. Details about how we use cookies and how you may disable them are set out in our <a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a>. By using this website you agree to our use of cookies.
-              </p>
-            </div>
-            <div className="pf-m-align-self-flex-start">
-              <Button variant="plain" aria-label="Close banner" onClick={closeBanner}>
-                <TimesIcon />
-              </Button>
-            </div>
-          </React.Fragment>
-        )}
+        <div>
+          <p id="ws-gdpr-banner-text" className="pf-u-ml-xl">
+            We use cookies on our websites to deliver our online services. Details about how we use cookies and how you may disable them are set out in our <a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a>. By using this website you agree to our use of cookies.
+          </p>
+        </div>
+        <div className="pf-m-align-self-flex-start">
+          <Button variant="plain" aria-label="Close banner" onClick={closeBanner}>
+            <TimesIcon />
+          </Button>
+        </div>
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
Fixes #1724 - moved conditional render statement outside of banner wrapper to ensure border is not rendered when banner is closed.