### PR TITLE
fix(docs): fix broken datatoolbar links in bulk selection docs

### DIFF
--- a/packages/v4/src/content/design-guidelines/usage-and-behavior/bulk-selection/bulk-selection.md
+++ b/packages/v4/src/content/design-guidelines/usage-and-behavior/bulk-selection/bulk-selection.md
@@ -55,9 +55,9 @@ Note: To hide integrated bulk selection and enable selection control from the to
 
 ### Core HTML/CSS
 * [Split button](/documentation/core/components/dropdown#split-button)
-* [Data toolbar (beta)](/documentation/core/beta/datatoolbar)
+* [Data toolbar (beta)](/documentation/core/components/datatoolbar)
 
 ### React
 * [Split button](/documentation/react/components/dropdown#split-button)
-* [Data toolbar (beta)](/documentation/core/beta/datatoolbar)
+* [Data toolbar (beta)](/documentation/react/components/datatoolbar)
 * [Bulk select table demo](/documentation/react/demos/bulkselecttable)


### PR DESCRIPTION
Closes #1708 

This PR fixes the broken links from the Bulk Selection page to the Data Toolbar (Core & React) pages