### PR TITLE
chore(docs): Remove PF3 banner, update version switcher

### DIFF
--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -174,3 +174,11 @@
   flex: 1 1;
   height: auto;
 }
+
+.ws-switcher-divider {
+  padding: 0 16px;
+}
+
+.ws-patternfly-3 > svg {
+  margin-left: 8px;
+}

--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -8,8 +8,8 @@ import React, { useEffect, useState, useContext } from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
 import { Helmet } from 'react-helmet';
 
-import { Page, PageHeader, PageSidebar, Toolbar, ToolbarItem, Form, TextInput, Brand, Dropdown, DropdownToggle, DropdownItem, DropdownGroup } from '@patternfly/react-core';
-import { SearchIcon, CaretDownIcon } from '@patternfly/react-icons';
+import { Page, PageHeader, PageSidebar, Toolbar, ToolbarItem, Form, TextInput, Brand, Dropdown, DropdownToggle, DropdownItem, DropdownGroup, Divider } from '@patternfly/react-core';
+import { SearchIcon, CaretDownIcon, ArrowIcon } from '@patternfly/react-icons';
 import { SideNav, TopNav,  Banner, Footer, GdprBanner } from '../../components';
 import staticVersions from 'gatsby-theme-patternfly-org/versions.json';
 import logo from '../logo.svg';
@@ -161,8 +161,20 @@ export const SideNavLayout = ({
     <DropdownGroup key="Previous" label="Previous releases">
       {Object.values(versions.Releases)
         .filter(version => !version.hidden && !version.latest)
+        .slice(0,3)
         .map(getDropdownItem)}
-    </DropdownGroup>
+    </DropdownGroup>,
+    <Divider className="ws-switcher-divider"/>,
+    <DropdownItem
+      key="PatternFly 3"
+      className="ws-patternfly-3"
+      component="a"
+      target="_blank"
+      href="https://www.patternfly.org/v3"
+    >
+      PatternFly 3
+      <ArrowIcon/>
+    </DropdownItem>
   ];
 
   const PageToolbar = pageSource === 'org'
@@ -244,7 +256,6 @@ export const SideNavLayout = ({
         <title>{title}{pageTitle && ` - ${pageTitle}`}</title>
       </Helmet>
       <div id="ws-page-banners">
-        {showBanner && <Banner />}
         {showGdprBanner && <GdprBanner />}
       </div>
       <Page isManagedSidebar header={Header} sidebar={SideBar} className="ws-page">

--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -9,7 +9,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { Helmet } from 'react-helmet';
 
 import { Page, PageHeader, PageSidebar, Toolbar, ToolbarItem, Form, TextInput, Brand, Dropdown, DropdownToggle, DropdownItem, DropdownGroup, Divider } from '@patternfly/react-core';
-import { SearchIcon, CaretDownIcon, ArrowIcon } from '@patternfly/react-icons';
+import { SearchIcon, CaretDownIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { SideNav, TopNav,  Banner, Footer, GdprBanner } from '../../components';
 import staticVersions from 'gatsby-theme-patternfly-org/versions.json';
 import logo from '../logo.svg';
@@ -172,7 +172,7 @@ export const SideNavLayout = ({
       href="https://www.patternfly.org/v3"
     >
       PatternFly 3
-      <ArrowIcon/>
+      <ExternalLinkAltIcon />
     </DropdownItem>
   ];
 

--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -255,6 +255,7 @@ export const SideNavLayout = ({
         <title>{title}{pageTitle && ` - ${pageTitle}`}</title>
       </Helmet>
       <div id="ws-page-banners">
+        {showBanner && <Banner />}
         {showGdprBanner && <GdprBanner />}
       </div>
       <Page isManagedSidebar header={Header} sidebar={SideBar} className="ws-page">

--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -168,7 +168,6 @@ export const SideNavLayout = ({
     <DropdownItem
       key="PatternFly 3"
       className="ws-patternfly-3"
-      component="a"
       target="_blank"
       href="https://www.patternfly.org/v3"
     >


### PR DESCRIPTION
Closes #1678 

- removed PF3 banner
- added PF3 to version switcher
- fixed version switcher links
- limited version switcher to 4 versions