### PR TITLE
fixed positioning of search results on mobile

### DIFF
--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -182,3 +182,12 @@
 .ws-patternfly-3 > svg {
   margin-left: 8px;
 }
+
+@media screen and (max-width: 768px) {
+  .ws-page-header .algolia-autocomplete #global-search-input ~ .ds-dropdown-menu {
+    right: 0 !important;
+    width: 500px;
+    max-width: calc(100vw - 32px);
+    min-width: 288px;
+  }
+}


### PR DESCRIPTION
Towards #1769 

This PR fixes the positioning of the search results on mobile so they don't stretch off the right side of screen.