### PR TITLE
Releasenotes toc has gutter 1823

### DIFF
--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -122,7 +122,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
             </MDXRenderer>
           )}
           {releaseNoteTOC && (
-            <Grid gutter="sm" className="ws-release-notes-toc">
+            <Grid hasGutter className="ws-release-notes-toc">
               {versions.Releases
                 .filter(version => (
                   tableOfContents.some(header => header.includes(version.name))))


### PR DESCRIPTION
closes #1823 

The padding between the release note cards is not correct. The fix is to move to using the new "hasGutter" prop.

## How it is now:
![Screen Shot 2020-04-29 at 9 30 43 AM](https://user-images.githubusercontent.com/57504257/80603077-ee8a6580-89fd-11ea-9515-9d9d72c116f3.png)


## How it should be:
![Screen Shot 2020-04-29 at 9 32 25 AM](https://user-images.githubusercontent.com/57504257/80603089-f21dec80-89fd-11ea-9805-56a8692b96d4.png)
