### PR TITLE
fix(css-variables): remove font type temporarily

### DIFF
--- a/packages/gatsby-theme-patternfly-org/pages/global-css-variables.md
+++ b/packages/gatsby-theme-patternfly-org/pages/global-css-variables.md
@@ -56,5 +56,5 @@ PatternFly 4 styles provide a default starting point. You can use the variable s
 
 ## Font type CSS variables
 
-<CSSVariables prefix="patternfly_variables" selector=".pf-m-redhat-font" />
+<CSSVariables prefix="patternfly_variables" selector=".pf-m-overpass-font" />
 


### PR DESCRIPTION
Breaking build in React currently since pf-m-redhat-font was removed.