### PR TITLE
fix(css): side-nav-link colors

### DIFF
--- a/packages/gatsby-theme-patternfly-org/components/sideNav/sideNav.css
+++ b/packages/gatsby-theme-patternfly-org/components/sideNav/sideNav.css
@@ -27,11 +27,9 @@
 }
 
 .ws-page-sidebar .pf-c-nav { --pf-c-nav__link--before--BorderBottomWidth: 0; }
-.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--hover--BackgroundColor:
-        var(--pf-global--BackgroundColor--light-200); }
-.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--focus--BackgroundColor:
-        var(--pf-global--BackgroundColor--light-200); }
-.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--m-current--BackgroundColor:
-        var(--pf-global--BackgroundColor--light-200); }
-.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--active--BackgroundColor:
-        var(--pf-global--BackgroundColor--light-200); }
+.ws-page-sidebar .pf-c-nav {
+  --pf-c-nav--m-light__link--hover--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+  --pf-c-nav--m-light__link--focus--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+  --pf-c-nav--m-light__link--m-current--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+  --pf-c-nav--m-light__link--active--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+}

--- a/packages/gatsby-theme-patternfly-org/components/sideNav/sideNav.css
+++ b/packages/gatsby-theme-patternfly-org/components/sideNav/sideNav.css
@@ -27,3 +27,11 @@
 }
 
 .ws-page-sidebar .pf-c-nav { --pf-c-nav__link--before--BorderBottomWidth: 0; }
+.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--hover--BackgroundColor:
+        var(--pf-global--BackgroundColor--light-200); }
+.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--focus--BackgroundColor:
+        var(--pf-global--BackgroundColor--light-200); }
+.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--m-current--BackgroundColor:
+        var(--pf-global--BackgroundColor--light-200); }
+.ws-page-sidebar .pf-c-nav { --pf-c-nav--m-light__link--active--BackgroundColor:
+        var(--pf-global--BackgroundColor--light-200); }


### PR DESCRIPTION
Closes #1832

side-nav-link colors now match page background.

## Before:
![Screen Shot 2020-05-04 at 12 21 08 PM](https://user-images.githubusercontent.com/57504257/80989453-f0d82f80-8e02-11ea-865a-323e64be50a5.png)

## After:
![Screen Shot 2020-05-04 at 12 22 44 PM](https://user-images.githubusercontent.com/57504257/80989483-fcc3f180-8e02-11ea-83ef-d5fff9ed483d.png)
