### PR TITLE
Add alert to Training because Katacoda is down

### DIFF
--- a/packages/gatsby-theme-patternfly-org/components/trainingCard/trainingCard.css
+++ b/packages/gatsby-theme-patternfly-org/components/trainingCard/trainingCard.css
@@ -1,75 +1,81 @@
-.pf-c-card:not(.small-card-icon).ws-org-training-card {
+.pf-c-card:not(.pf-org__card-small).pf-org__card {
   border: 2px solid #d2d2d2;
   box-shadow: unset;
   height: 277px;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__head {
+.pf-org__card .pf-c-card__header {
   position: relative;
 }
-.pf-c-card.ws-org-training-card .pf-c-card__head:first-child {
+
+.pf-org__card .pf-c-card__header:first-child {
   padding-top: 24px !important;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__head:not(:last-child) {
+.pf-org__card .pf-c-card__header:not(:last-child) {
   padding-bottom: 24px !important;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__head .pf-c-card.small-card-icon {
+.pf-org__card .pf-org__card-small {
   position: absolute;
   left: 0px;
   padding: 8px 18px;
   background-color: #fff;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__head div.level {
+.pf-org__card .pf-c-card__header .pf-org__level {
   margin-left: auto;
   font-size: 12px;
   color: #737679;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__head div.level > svg {
+.pf-org__card .pf-c-card__header .pf-org__level > svg {
   margin-right: 8px;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__body {
+.pf-org__card .pf-c-card__body {
   font-size: 14px;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__body .pf-org-card-body__time {
+.pf-org__card .pf-c-card__body .pf-org__time {
   color: #737679;
   font-size: 12px;
   padding-bottom: 12px;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__body .pf-org-card-body__time > svg {
+.pf-org__card .pf-c-card__body .pf-org__time > svg {
   margin-right: 8px;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__footer .pf-c-button.pf-m-link {
+.pf-org__card .pf-c-card__footer .pf-c-button.pf-m-link {
   padding-left: 0;
   font-weight: bold;
 }
 
-.pf-c-card.ws-org-training-card .pf-c-card__footer .pf-c-button.pf-m-link > svg {
+.pf-org__card .pf-c-card__footer .pf-c-button.pf-m-link > svg {
   margin-left: 8px;
 }
 
-.level-beginner {
+.pf-org__level-beginner {
   color: #5ba352;
 }
-.level-intermediate {
+
+.pf-org__level-intermediate {
   color: #f0ab00;
 }
-.level-advanced {
+
+.pf-org__level-advanced {
   color: #a30000;
 }
-.training-basics {
+
+.pf-org__training-basics {
   color: #ec7a08;
 }
-.training-components {
+
+.pf-org__training-components {
   color: #a18fff;
 }
-.training-charts {
+
+.pf-org__training-charts {
   color: #6ec664
 }

--- a/packages/gatsby-theme-patternfly-org/components/trainingCard/trainingCard.js
+++ b/packages/gatsby-theme-patternfly-org/components/trainingCard/trainingCard.js
@@ -8,13 +8,13 @@ import './trainingCard.css';
 
 const getTrainingIcon = trainingType => {
   if (['html-css', 'react'].includes(trainingType)) {
-    return <CubesIcon className="training-basics" />;
+    return <CubesIcon className="pf-org__training-basics" />;
   }
   else if (trainingType === 'react-components') {
-    return <PuzzlePieceIcon className="training-components" />;
+    return <PuzzlePieceIcon className="pf-org__training-components" />;
   }
 
-  return <ChartBarIcon className="training-charts" />;
+  return <ChartBarIcon className="pf-org__training-charts" />;
 }
 
 export const TrainingCard = ({
@@ -25,13 +25,13 @@ export const TrainingCard = ({
   description,
   katacodaId
 }) => (
-  <Card className="ws-org-training-card" isCompact>
+  <Card className="pf-org__card" isCompact>
     <CardHeader>
-      <Card className="small-card-icon">
+      <Card className="pf-org__card-small">
         {getTrainingIcon(trainingType)}
       </Card>
-      <div className="level">
-        <RunningIcon className={`level-${level}`} />
+      <div className="pf-org__level">
+        <RunningIcon className={`pf-org__level-${level}`} />
         {capitalize(level)}
       </div>
     </CardHeader>
@@ -39,7 +39,7 @@ export const TrainingCard = ({
       {title}
     </CardTitle>
     <CardBody>
-      <div className="pf-org-card-body__time">
+      <div className="pf-org__time">
         <ClockIcon />
         {time}
       </div>

--- a/packages/gatsby-theme-patternfly-org/index.js
+++ b/packages/gatsby-theme-patternfly-org/index.js
@@ -10,6 +10,7 @@ exports.mdxTypeDefs = `
     hideTOC: Boolean
     optIn: String
     beta: Boolean
+    katacodaBroken: Boolean
     propComponents: [String]
     hideDarkMode: Boolean
     reactComponentName: String
@@ -42,6 +43,7 @@ exports.mdxTypeDefs = `
   }
   type PropsType @dontInfer {
     beta: Boolean
+    katacodaBroken: Boolean
     name: String!
     description: String
     required: Boolean

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -40,7 +40,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
         katacodaId={location.state.katacodaId} />
     );
   }
-  const { cssPrefix, hideTOC, beta, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = data.doc.frontmatter;
+  const { cssPrefix, hideTOC, beta, katacodaBroken, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = data.doc.frontmatter;
   const { componentName, navSection } = data.doc.fields;
   const { title, source, tableOfContents, htmlExamples, propComponents = [''], showBanner, showGdprBanner, showFooter, sourceLink } = pageContext;
   const props = data.props && data.props.nodes && propComponents
@@ -113,6 +113,17 @@ const MDXTemplate = ({ data, location, pageContext }) => {
               isInline
             >
               This Beta component is currently under review, so please join in and give us your feedback on the <a href="https://forum.patternfly.org/">PatternFly forum</a>
+            </Alert>
+          )}
+          {katacodaBroken && (
+            <Alert
+              variant={'danger'}
+              title="Katacoda is going through maintenance"
+              className="pf-u-my-md"
+              style={{ marginBottom: '1rem' }}
+              isInline
+            >
+              We're sorry to inform you that our training modules are going through maintenance. Hopefully this won't take long, so check back soon.
             </Alert>
           )}
           {/* Design docs should not apply to demos and overview */}
@@ -275,6 +286,7 @@ export const pageQuery = graphql`
         hideTOC
         optIn
         beta
+        katacodaBroken
         hideDarkMode
         showTitle
         releaseNoteTOC
@@ -305,6 +317,7 @@ export const pageQuery = graphql`
         name
         props {
           beta
+          katacodaBroken
           name
           required
           description

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -118,12 +118,12 @@ const MDXTemplate = ({ data, location, pageContext }) => {
           {katacodaBroken && (
             <Alert
               variant={'danger'}
-              title="Katacoda is going through maintenance"
+              title="Down for maintenance"
               className="pf-u-my-md"
               style={{ marginBottom: '1rem' }}
               isInline
             >
-              We're sorry to inform you that our training modules are going through maintenance. Hopefully this won't take long, so check back soon.
+              We'll be up and running in a bit, so check back soon. Thanks!
             </Alert>
           )}
           {/* Design docs should not apply to demos and overview */}

--- a/packages/gatsby-transformer-react-docgen-typescript/gatsby-node.js
+++ b/packages/gatsby-transformer-react-docgen-typescript/gatsby-node.js
@@ -150,6 +150,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
     type PropsType @noInfer {
       beta: Boolean
+      katacodaBroken: Boolean
       name: String!
       description: String
       required: Boolean

--- a/packages/v4/gatsby-config.js
+++ b/packages/v4/gatsby-config.js
@@ -126,7 +126,7 @@ module.exports = {
       resolve: 'gatsby-source-filesystem',
       options: {
         name: 'core', // This goes in URLs
-        path: '/training/core-training'
+        path: path.join(__dirname, '/src/content/training/core-training.md')
       }
     },
     // React docs (MD + TSX)
@@ -190,7 +190,7 @@ module.exports = {
       resolve: 'gatsby-source-filesystem',
       options: {
         name: 'react', // This goes in URLs
-        path: '/training/react-training'
+        path: path.join(__dirname, '/src/content/training/react-training.md')
       }
     },
     // Org docs

--- a/packages/v4/gatsby-config.js
+++ b/packages/v4/gatsby-config.js
@@ -126,7 +126,7 @@ module.exports = {
       resolve: 'gatsby-source-filesystem',
       options: {
         name: 'core', // This goes in URLs
-        path: require.resolve('@patternfly/patternfly/site/training.md')
+        path: '/training/core-training'
       }
     },
     // React docs (MD + TSX)
@@ -190,7 +190,7 @@ module.exports = {
       resolve: 'gatsby-source-filesystem',
       options: {
         name: 'react', // This goes in URLs
-        path: require.resolve('@patternfly/react-docs/src/training.md')
+        path: '/training/react-training'
       }
     },
     // Org docs

--- a/packages/v4/src/content/training/core-training.md
+++ b/packages/v4/src/content/training/core-training.md
@@ -1,0 +1,62 @@
+---
+title: Training
+section: overview
+---
+
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { TrainingCard } from 'gatsby-theme-patternfly-org/components';
+
+## Fundamentals
+
+<Gallery gutter="md">
+  <GalleryItem>
+    <TrainingCard
+      trainingType="html-css"
+      title="The building blocks of PatternFly"
+      level="beginner"
+      time="20 minutes"
+      description="Learn about components, layouts, and demos."
+      katacodaId="building-blocks"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="html-css"
+      title="Variable naming principles"
+      level="intermediate"
+      time="20 minutes"
+      description="Create and override component and global variables by following BEM naming principles."
+      katacodaId="variable-naming-principles"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="html-css"
+      title="Modifiers and utilities"
+      level="beginner"
+      time="15 minutes"
+      description="Apply modifier and utility classes to create new variations."
+      katacodaId="modifier-utilities"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="html-css"
+      title="Layouts"
+      level="beginner"
+      time="25 minutes"
+      description="Learn how to use all seven of PatternFly's layouts."
+      katacodaId="layouts"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="html-css"
+      title="Override and extend variables"
+      level="advanced"
+      time="25 minutes"
+      description="Practice overriding and extending variables to create new designs."
+      katacodaId="override-extend-variables"
+    />
+  </GalleryItem>
+</Gallery>

--- a/packages/v4/src/content/training/core-training.md
+++ b/packages/v4/src/content/training/core-training.md
@@ -1,6 +1,7 @@
 ---
 title: Training
 section: overview
+katacodaBroken: true
 ---
 
 import { Gallery, GalleryItem } from '@patternfly/react-core';

--- a/packages/v4/src/content/training/react-training.md
+++ b/packages/v4/src/content/training/react-training.md
@@ -1,0 +1,161 @@
+---
+title: Training
+section: overview
+---
+
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { TrainingCard } from 'gatsby-theme-patternfly-org/components';
+
+## Fundamentals
+
+<Gallery hasGutter>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react"
+      title="PatternFly React basics"
+      level="beginner"
+      time="10 minutes"
+      description="Build your first PatternFly component."
+      katacodaId="react-basics"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react"
+      title="Customize PatternFly"
+      level="beginner"
+      time="5 minutes"
+      description="Learn how to customize components in PatternFly."
+      katacodaId="react-customize"
+    />
+  </GalleryItem>
+</Gallery>
+
+## Components
+<Gallery hasGutter>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-components"
+      title="Table component: beginner"
+      level="intermediate"
+      time="45 minutes"
+      description="Build a React table with pagination."
+      katacodaId="table-intro"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-components"
+      title="Toolbar component with filter"
+      level="intermediate"
+      time="30 minutes"
+      description="Build a React toolbar that is filterable."
+      katacodaId="toolbar-filter"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-components"
+      title="Select component: beginner"
+      level="intermediate"
+      time="30 minutes"
+      description="Build and customize a React select component."
+      katacodaId="select"
+    />
+  </GalleryItem>
+</Gallery>
+
+## Charts
+
+<Gallery hasGutter>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Area chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React area chart."
+      katacodaId="area-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Bar chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React bar chart."
+      katacodaId="bar-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Bullet chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React bullet chart."
+      katacodaId="bullet-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Donut chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React donut chart."
+      katacodaId="donut-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Donut utilization chart"
+      level="beginner"
+      time="12 minutes"
+      description="Learn how to implement a React donut utilization chart."
+      katacodaId="donut-utilization-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Line chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React line chart."
+      katacodaId="line-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Pie chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React pie chart."
+      katacodaId="pie-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Stack chart"
+      level="beginner"
+      time="10 minutes"
+      description="Learn how to implement a React pie chart."
+      katacodaId="stack-chart"
+    />
+  </GalleryItem>
+  <GalleryItem>
+    <TrainingCard
+      trainingType="react-charts"
+      title="Sparkline chart"
+      level="beginner"
+      time="12 minutes"
+      description="Learn how to implement a React sparkline chart."
+      katacodaId="sparkline-chart"
+    />
+  </GalleryItem>
+</Gallery>

--- a/packages/v4/src/content/training/react-training.md
+++ b/packages/v4/src/content/training/react-training.md
@@ -1,6 +1,7 @@
 ---
 title: Training
 section: overview
+katacodaBroken: true
 ---
 
 import { Gallery, GalleryItem } from '@patternfly/react-core';


### PR DESCRIPTION
closes #1874 

<img width="1086" alt="Screen Shot 2020-06-11 at 10 10 01 AM" src="https://user-images.githubusercontent.com/20118816/84395074-c16bce00-abcb-11ea-8a10-e94d0778cd13.png">

@redallen there used to be navigation in the top right corner of the tutorial page, I think the code is still there but im not sure why its not displaying any more 

<img width="1096" alt="Screen Shot 2020-06-11 at 10 13 03 AM" src="https://user-images.githubusercontent.com/20118816/84396090-3b9c5280-abcc-11ea-9f85-efda220ca7e3.png">

