### PR TITLE
chore(docs): updated font family text to add back RedHatDisplay

### DIFF
--- a/packages/gatsby-theme-patternfly-org/templates/mdx.css
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.css
@@ -35,6 +35,7 @@ p ~ .ws-toc {
 
 .ws-release-notes-toc .pf-c-card__header {
   color: #0066CC;
+  font-family: RedHatDisplay;
   font-size: 24px;
   font-weight: 500;
   line-height: 32px;

--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.js
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.js
@@ -25,49 +25,56 @@ export const styleProps = {
     fontWeightText: "400 (medium)",
     variableName: "--pf-global--FontSize--2xl",
     fontSize: "24px",
-    lineHeight: "1.3"
+    lineHeight: "1.3",
+    fontFamily: "RedHatDisplay"
   },
   second: {
     fontWeight: "400",
     fontWeightText: "400 (medium)",
     fontSize: "20px",
     variableName: "--pf-global--FontSize--xl",
-    lineHeight: "1.3"
+    lineHeight: "1.3",
+    fontFamily: "RedHatDisplay"
   },
   third: {
     fontWeight: "400",
     fontWeightText: "400 (medium)",
     fontSize: "18px",
     variableName: "--pf-global--FontSize--lg",
-    lineHeight: "1.5"
+    lineHeight: "1.5",
+    fontFamily: "RedHatDisplay"
   },
   fourth: {
     fontWeight: "700",
     fontWeightText: "700 (bold)",
     fontSize: "16px",
     variableName: "--pf-global--FontSize--md",
-    lineHeight: "1.5"
+    lineHeight: "1.5",
+    fontFamily: "RedHatDisplay"
   },
   body: {
     fontWeight: "400",
     fontWeightText: "400 (regular)*",
     fontSize: "16px",
     variableName: "--pf-global--FontSize--md",
-    lineHeight: "1.5"
+    lineHeight: "1.5",
+    fontFamily: "RedHatText"
   },
   small: {
     fontWeight: "400",
     fontWeightText: "400 (regular)",
     fontSize: "14px",
     variableName: "--pf-global--FontSize--sm",
-    lineHeight: "1.5"
+    lineHeight: "1.5",
+    fontFamily: "RedHatText"
   },
   tiny: {
     fontWeight: "400",
     fontWeightText: "400 (regular)",
     fontSize: "12px",
     variableName: "--pf-global--FontSize--xs",
-    lineHeight: "1.5"
+    lineHeight: "1.5",
+    fontFamily: "RedHatText"
   }
 }
 
@@ -81,6 +88,10 @@ export const TypographyGrid = ({title, note, symbol, fontWeight, fontWeightText,
       <GridItem span={12}>
         <table className="pf-c-table pf-m-compact ws-typography-tableTypography" aria-label="typography usage guidelines breakout">
           <tbody>
+            <tr>	
+              <td className="pf-u-pr-sm">Font family:</td>	
+              <td>{fontFamily}</td>	
+            </tr>
             <tr>
               <td>Font weight:</td>
               <td>{fontWeightText}</td>

--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.md
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.md
@@ -13,7 +13,7 @@ import incorrect from './typography_incorrect_spacing.png';
 import './typography.css';
 
 ## Our font family
-We use Red Hat Text.
+We use Red Hat Display and Red Hat Text.
 
 <Button style={{borderRadius: '0px', fontWeight: '600', paddingTop: '12px', paddingBottom: '12px', paddingLeft: '24px', paddingRight: '24px'}} variant="primary" component="a" href="https://github.com/RedHatOfficial/RedHatFont" target="_blank">DOWNLOAD</Button>
 

--- a/packages/v4/src/pages/get-in-touch.css
+++ b/packages/v4/src/pages/get-in-touch.css
@@ -10,4 +10,5 @@
 
 .ws-get-in-touch h1.ws-title {
   font-size: 36px;
+  font-family: RedHatDisplay;
 }

--- a/packages/v4/src/pages/get-in-touch.js
+++ b/packages/v4/src/pages/get-in-touch.js
@@ -20,7 +20,7 @@ const GetInTouch = ({ location }) => {
       <Grid sm={12} md={6} gutter="sm" className="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter" style={{ maxWidth: '450px' }}>
         <GridItem>
           <Split>
-            <SplitItem style={{ marginRight: '12px' }}><h3><ChatIcon /></h3></SplitItem>
+            <SplitItem style={{ marginRight: '12px' }}><ChatIcon /></SplitItem>
             <SplitItem isFilled>
               <Title size="lg" className="ws-title" headingLevel="h2">Chat with us</Title>
               <a href="https://slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>
@@ -29,7 +29,7 @@ const GetInTouch = ({ location }) => {
         </GridItem>
         <GridItem>
           <Split>
-            <SplitItem style={{ marginRight: '12px' }}><h3><MailBulkIcon /></h3></SplitItem>
+            <SplitItem style={{ marginRight: '12px' }}><MailBulkIcon /></SplitItem>
             <SplitItem isFilled>
               <Title size="lg" className="ws-title" headingLevel="h2">Stay in the loop</Title>
               <a href="https://www.redhat.com/mailman/listinfo/patternfly" target="_blank" rel="noopener noreferrer">PatternFly mailing list</a>
@@ -38,7 +38,7 @@ const GetInTouch = ({ location }) => {
         </GridItem>
         <GridItem>
           <Split>
-            <SplitItem style={{ marginRight: '12px' }}><h3><QuestionIcon /></h3></SplitItem>
+            <SplitItem style={{ marginRight: '12px' }}><QuestionIcon /></SplitItem>
             <SplitItem isFilled>
               <Title size="lg" className="ws-title" headingLevel="h2">Ask a question</Title>
               <a href="https://forum.patternfly.org/" target="_blank" rel="noopener noreferrer">PatternFly forum</a>
@@ -47,7 +47,7 @@ const GetInTouch = ({ location }) => {
         </GridItem>
         <GridItem>
           <Split>
-            <SplitItem style={{ marginRight: '12px' }}><h3><CatalogIcon /></h3></SplitItem>
+            <SplitItem style={{ marginRight: '12px' }}><CatalogIcon /></SplitItem>
             <SplitItem isFilled>
               <Title size="lg" className="ws-title" headingLevel="h2">Read the latest</Title>
               <a href="https://medium.com/patternfly" target="_blank" rel="noopener noreferrer">PatternFly Medium</a>


### PR DESCRIPTION
Closes #1892 

See original issue https://github.com/patternfly/patternfly/issues/3185
This PR adds back 'Red Hat Display' on Typography, Get in touch, and Release notes pages.