### PR TITLE
fix(docs): Fixed missing breadcrumb in training modules

### DIFF
--- a/packages/gatsby-theme-patternfly-org/layouts/trainingLayout/trainingLayout.js
+++ b/packages/gatsby-theme-patternfly-org/layouts/trainingLayout/trainingLayout.js
@@ -59,7 +59,7 @@ export const TrainingLayout = ({ trainingType, katacodaId, location }) => {
         href: url || '/'
       }}
       showNavToggle
-      toolbar={Breadcrumbs}
+      headerTools={Breadcrumbs}
     />
   );
 


### PR DESCRIPTION
Closes #1891 

renamed `toolbar` prop to `headerTools` in PageHeader