### PR TITLE
fix(site nav): removed custom styles from PageHeader

### DIFF
--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -19,14 +19,6 @@
 }
 /* Hide version switcher on mobile */
 @media screen and (max-width: 1200px) {
-  .ws-page-header {
-    grid-template-columns: 3fr 1fr;
-  }
-      
-  .ws-page-header .pf-c-page__header-brand-link {
-    justify-content: center;
-  }
-  
   .ws-org-version-switcher {
     display: none;
   }


### PR DESCRIPTION
Closes #1868 
Closes #1900 

Removed custom styles from PageHeader that were causing:
- PF brand logo to float towards the center rather than align left beside hamburger menu
- search box to have black box below it at certain widths as seen in #1900 
- nav items to be squished at exactly 1200px width as seen in #1868