### PR TITLE
fix(release): fixes for Org bump

### DIFF
--- a/packages/gatsby-theme-patternfly-org/templates/mdx.css
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.css
@@ -48,6 +48,7 @@ p ~ .ws-toc {
 
 .ws-release-notes-toc .pf-c-card__header .pf-c-badge {
   vertical-align: middle;
+  line-height: var(--pf-global--LineHeight--md);
 }
 
 .ws-release-notes-toc .pf-c-card__body {

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.css
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.css
@@ -34,11 +34,6 @@ p ~ .ws-toc {
 }
 
 .ws-release-notes-toc .pf-c-card__header {
-  color: #0066CC;
-  font-family: RedHatDisplay;
-  font-size: 24px;
-  font-weight: 500;
-  line-height: 32px;
   padding-bottom: 4px;
 }
 
@@ -49,6 +44,8 @@ p ~ .ws-toc {
 .ws-release-notes-toc .pf-c-card__header .pf-c-badge {
   vertical-align: middle;
   line-height: var(--pf-global--LineHeight--md);
+  font-family: var(--pf-global--FontFamily--sans-serif);
+  flex-shrink: 0;
 }
 
 .ws-release-notes-toc .pf-c-card__body {

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.css
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.css
@@ -33,19 +33,20 @@ p ~ .ws-toc {
   height: 100%;
 }
 
-.ws-release-notes-toc .pf-c-card__header {
+.ws-release-notes-toc .pf-c-card__title {
   padding-bottom: 4px;
 }
 
-.ws-release-notes-toc .pf-c-card__header a {
+.ws-release-notes-toc .pf-c-card__title .pf-c-title {
+  display: inline;
+}
+
+.ws-release-notes-toc .pf-c-card__title a {
   margin-right: 8px;
 }
 
-.ws-release-notes-toc .pf-c-card__header .pf-c-badge {
-  vertical-align: middle;
-  line-height: var(--pf-global--LineHeight--md);
-  font-family: var(--pf-global--FontFamily--sans-serif);
-  flex-shrink: 0;
+.ws-release-notes-toc .pf-c-card__title .pf-c-badge {
+  vertical-align: text-top;
 }
 
 .ws-release-notes-toc .pf-c-card__body {

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -6,7 +6,7 @@ import {
   Alert,
   Badge,
   Card,
-  CardHeader,
+  CardTitle,
   CardBody,
   Grid,
   GridItem,
@@ -150,18 +150,18 @@ const MDXTemplate = ({ data, location, pageContext }) => {
                   return releaseTitle && (
                     <GridItem sm={6} md={4} key={version.name}>
                       <Card>
-                        <CardHeader>
+                        <CardTitle>
                           {releaseTitle && (
-                            <a key={version.name} href={`#${slugger(releaseTitle)}`}>
-                              <Title size="2xl" headingLevel="h2" >
+                            <Title size="2xl" headingLevel="h2" >
+                              <a key={version.name} href={`#${slugger(releaseTitle)}`}>
                                 Release {version.name}
-                              </Title>
-                            </a>
+                              </a>
+                            </Title>
                           )}
                           {version.latest && (
                             <Badge>Latest</Badge>
                           )}
-                        </CardHeader>
+                        </CardTitle>
                         <CardBody>
                           Released on {releaseDate}.
                         </CardBody>

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -153,7 +153,9 @@ const MDXTemplate = ({ data, location, pageContext }) => {
                         <CardHeader>
                           {releaseTitle && (
                             <a key={version.name} href={`#${slugger(releaseTitle)}`}>
-                              Release {version.name}
+                              <Title size="2xl" headingLevel="h2" >
+                                Release {version.name}
+                              </Title>
                             </a>
                           )}
                           {version.latest && (

--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.js
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.js
@@ -45,8 +45,8 @@ export const styleProps = {
     fontFamily: "RedHatDisplay"
   },
   fourth: {
-    fontWeight: "700",
-    fontWeightText: "700 (bold)",
+    fontWeight: "400",
+    fontWeightText: "400 (medium)",
     fontSize: "16px",
     variableName: "--pf-global--FontSize--md",
     lineHeight: "1.5",

--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.md
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.md
@@ -31,7 +31,7 @@ Use our typographic styles to communicate visual hierarchy. A consistent and log
 <TitleLevel
   asGrid
   title="Body*"
-  note="*Some components use RedHatText at 700 font weight, which is RedHatText Medium (i.e. alerts, navigation)"
+  note="*Some components use RedHatText at 700 font weight, which is RedHatText Medium (e.g. alerts, navigation)"
   styleProps = {styleProps.body} />
 <TitleLevel asGrid title="Small text" styleProps = {styleProps.small} />
 <TitleLevel 


### PR DESCRIPTION
Org release feedback:
- fix styling of "latest" badge on release notes
- fix font weight for heading level 4 on Typography page
- switch "i.e." to "e.g." on Typography page