### PR TITLE
Chore/1793 redesign combine docs

### DIFF
--- a/packages/gatsby-theme-patternfly-org/components/example/example.js
+++ b/packages/gatsby-theme-patternfly-org/components/example/example.js
@@ -24,8 +24,8 @@ const getSupportedLanguages = className => {
 
 // This component uses hooks in order to call useMDXScope()
 export const Example = props => {
-  const html = props.html
-    ? props.html
+  const html = (props.html && props.html.code)
+    ? props.html.code
     : 'This is a hbs code block, but no html trickled down from gatsby-node.js to mdx.js to example.js';
   const supportedLangs = getSupportedLanguages(props.className);
   const initialLang = supportedLangs[0];

--- a/packages/gatsby-theme-patternfly-org/components/sideNav/sideNav.js
+++ b/packages/gatsby-theme-patternfly-org/components/sideNav/sideNav.js
@@ -59,7 +59,6 @@ export const SideNav = ({
 
     return accum;
   }, {});
-  console.log('sideNavContexts: ', sideNavContexts);
 
   const sideNavItems = ['react', 'core'].includes(context)
     ? combineCoreReactNavs(sideNavContexts.react, sideNavContexts.core)
@@ -71,9 +70,7 @@ export const SideNav = ({
         {sideNavItems.map(navItem => {
           const { section } = navItem;
           const isActive = location.pathname.includes(`/${slugger(section)}/`);
-          console.log(sideNavItems, section, allNavItems, allNavItems[section]);
           if (section && allNavItems[section]) {
-            console.log('YES');
             return (
               <NavExpandable
                 key={section}
@@ -83,7 +80,7 @@ export const SideNav = ({
                 className="ws-side-nav-group"
               >
                 {allNavItems[section]
-                  .filter(node => node.source === context || node.source === 'shared')
+                  .filter(node => node.source === context || node.source === 'shared' || node.source === 'react' || node.source === 'core')
                   .map(renderNavItem)}
               </NavExpandable>
             );

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -304,13 +304,12 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
     result.data.components.group
       .filter(component => !hiddenTitles.includes(component.nodes[0].fields.title.toLowerCase()))
       .forEach(component => {
-        console.log('CLEARNING COMPONENT DATA');
         const componentData = {
           ids: [],
           designIds: [],
           propComponents: []
         };
-        console.log(componentData);
+        
         component.nodes.forEach(node => {
           const { componentName, slug, navSection = null, title, source, propComponents = [''] } = node.fields;
           const fileRelativePath = path.relative(__dirname, node.absolutePath || node.fileAbsolutePath);
@@ -349,14 +348,13 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
             showBanner,
             showGdprBanner,
             showFooter,
+            source,
             sourceLink
           };
           componentData.ids.push(node.id);
           componentData.designIds.push(designId);
           componentData.propComponents = componentData.propComponents.concat(...propComponents);
-          if (!componentData.slug) {
-            componentData.slug = slug.replace(/\/(core|react)\//, '/');
-          }
+          componentData.slug = componentData.slug || slug.replace(/\/(core|react)\//, '/');
           
           // Create per-example fullscreen pages for documentation pages
           if (['core', 'react'].includes(source)) {
@@ -385,8 +383,6 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
             );
           }
         });
-
-        console.log(componentData);
         
         // Create our dynamic templated pages
         actions.createPage({

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -197,9 +197,25 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
       component: path.resolve(__dirname, './pages/404.js')
     });
     // Create our per-MDX file pages
-    result.data.docs.nodes
-      .concat(result.data.pages.nodes)
-      .filter(node => !hiddenTitles.includes(node.fields.title.toLowerCase()))
+    Object.entries(
+      
+      result.data.docs.nodes
+        .concat(result.data.pages.nodes)
+        .filter(node => !hiddenTitles.includes(node.fields.title.toLowerCase()))
+
+        .reduce((acc, cur) => {
+          if (!acc[cur.fields.navSection]) {
+            acc[cur.fields.navSection] = {};
+          }
+          if (!acc[cur.fields.navSection][cur.fields.componentName]) {
+            acc[cur.fields.navSection][cur.fields.componentName] = [];
+          }
+          acc[cur.fields.navSection][cur.fields.componentName].push(cur);
+          console.log(acc);
+          return acc;
+        }, {})
+    )
+
       .forEach(node => {
         const { componentName, slug, navSection = null, title, source, propComponents = [''], wrapperTag } = node.fields;
         const fileRelativePath = path.relative(__dirname, node.absolutePath || node.fileAbsolutePath);

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -31,10 +31,7 @@ const makeSlug = (source, section, componentName) => {
   let url = '';
 
   // We know these belong in the "documentation" section of the site
-  if (['react', 'core',].includes(source)) {
-    url += `/documentation/${source}`;
-  }
-  else if (source === 'shared') {
+  if (['react', 'core', 'shared'].includes(source)) {
     url += '/documentation';
   }
   else if (!source.includes('pages-')) {
@@ -140,6 +137,23 @@ const fullscreenPages = {};
 
 exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
   {
+    components: allMdx(filter: {fields: {source: {in: ["core", "react"]}}}) {
+      group(field: frontmatter___title) {
+        nodes {
+          id
+          fileAbsolutePath
+          mdxAST
+          fields {
+            slug
+            source
+            navSection
+            title
+            propComponents
+            componentName
+          }
+        }
+      }
+    }
     docs: allMdx(filter: { fields: { source: { ne: "design-snippets" } } }) {
       nodes {
         id
@@ -197,25 +211,9 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
       component: path.resolve(__dirname, './pages/404.js')
     });
     // Create our per-MDX file pages
-    Object.entries(
-      
-      result.data.docs.nodes
-        .concat(result.data.pages.nodes)
-        .filter(node => !hiddenTitles.includes(node.fields.title.toLowerCase()))
-
-        .reduce((acc, cur) => {
-          if (!acc[cur.fields.navSection]) {
-            acc[cur.fields.navSection] = {};
-          }
-          if (!acc[cur.fields.navSection][cur.fields.componentName]) {
-            acc[cur.fields.navSection][cur.fields.componentName] = [];
-          }
-          acc[cur.fields.navSection][cur.fields.componentName].push(cur);
-          console.log(acc);
-          return acc;
-        }, {})
-    )
-
+    result.data.docs.nodes
+      .concat(result.data.pages.nodes)
+      .filter(node => !hiddenTitles.includes(node.fields.title.toLowerCase()))
       .forEach(node => {
         const { componentName, slug, navSection = null, title, source, propComponents = [''], wrapperTag } = node.fields;
         const fileRelativePath = path.relative(__dirname, node.absolutePath || node.fileAbsolutePath);
@@ -301,6 +299,12 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
           );
         }
       });
+
+    // results.data.components.groups
+    //   .filter(group => !hiddenTitles.includes(group.nodes[0].fields.title.toLowerCase()))
+    //   .forEach(group => {
+        
+    //   })
   });
 
 // https://www.gatsbyjs.org/docs/schema-customization/

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -150,6 +150,7 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
             title
             propComponents
             componentName
+            wrapperTag
           }
         }
       }
@@ -311,7 +312,7 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
         };
         
         component.nodes.forEach(node => {
-          const { componentName, slug, navSection = null, title, source, propComponents = [''] } = node.fields;
+          const { componentName, slug, navSection = null, title, source, propComponents = [''], wrapperTag } = node.fields;
           const fileRelativePath = path.relative(__dirname, node.absolutePath || node.fileAbsolutePath);
           let sourceLink = 'https://github.com/patternfly/';
           if (source === 'react') {

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -345,6 +345,7 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
             tableOfContents,
             title,
             htmlExamples: source === 'core' ? examples : undefined,
+            navSection: "components",
             showBanner,
             showGdprBanner,
             showFooter,
@@ -355,6 +356,8 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
           componentData.designIds.push(designId);
           componentData.propComponents = componentData.propComponents.concat(...propComponents);
           componentData.slug = componentData.slug || slug.replace(/\/(core|react)\//, '/');
+          componentData.source = componentData.source || source;
+          componentData.navSection = componentData.navSection || "components";
           
           // Create per-example fullscreen pages for documentation pages
           if (['core', 'react'].includes(source)) {

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -304,10 +304,13 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
     result.data.components.group
       .filter(component => !hiddenTitles.includes(component.nodes[0].fields.title.toLowerCase()))
       .forEach(component => {
+        console.log('CLEARNING COMPONENT DATA');
         const componentData = {
           ids: [],
+          designIds: [],
           propComponents: []
         };
+        console.log(componentData);
         component.nodes.forEach(node => {
           const { componentName, slug, navSection = null, title, source, propComponents = [''] } = node.fields;
           const fileRelativePath = path.relative(__dirname, node.absolutePath || node.fileAbsolutePath);
@@ -333,11 +336,12 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
           const designNode = result.data.designSnippets.nodes.find(
             node => node.frontmatter[`${source}ComponentName`] === componentName
           );
+          const designId = designNode ? designNode.id : 'undefined';
 
           // Update componentData object with this node's data
           componentData[source] = {
             id: node.id,
-            designId: designNode ? designNode.id : 'undefined',
+            designId,
             propComponents,
             tableOfContents,
             title,
@@ -348,6 +352,7 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
             sourceLink
           };
           componentData.ids.push(node.id);
+          componentData.designIds.push(designId);
           componentData.propComponents = componentData.propComponents.concat(...propComponents);
           if (!componentData.slug) {
             componentData.slug = slug.replace(/\/(core|react)\//, '/');
@@ -380,41 +385,15 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
             );
           }
         });
+
+        console.log(componentData);
         
         // Create our dynamic templated pages
         actions.createPage({
           path: componentData.slug,
           component: path.resolve(__dirname, `./templates/componentMdx.js`),
           context: componentData
-          /*
-          context: {
-            // Required by template to fetch more MDX/React docgen data from GraphQL
-            id: ids,
-            designId: designNode ? designNode.id : 'undefined',
-            propComponents,
-            // For dynamic TOC on templated page
-            tableOfContents,
-            // For sideNav GraphQL query and dynamic classNames in Example.js
-            navSection: "components",
-            // For top of TOC
-            title,
-            // For top of TOC, dynamic classNames in Example.js, and some feature flags
-            source,
-            // To render static example HTML from patternfly
-            htmlExamples: source === 'core' ? examples : undefined,
-            // To hide the banner for core/React sites
-            showBanner,
-            // To hide the GDPR banner
-            showGdprBanner,
-            // To hide the footer
-            showFooter,
-            // To link each MD file back to Github
-            sourceLink,
-          }
-          */
         });
-        
-        console.log(componentData);
 
       })
   });

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -358,6 +358,7 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
           componentData.slug = componentData.slug || slug.replace(/\/(core|react)\//, '/');
           componentData.source = componentData.source || source;
           componentData.navSection = componentData.navSection || "components";
+          componentData.title = title;
           
           // Create per-example fullscreen pages for documentation pages
           if (['core', 'react'].includes(source)) {

--- a/packages/gatsby-theme-patternfly-org/gatsby-node.js
+++ b/packages/gatsby-theme-patternfly-org/gatsby-node.js
@@ -376,7 +376,9 @@ exports.createPages = ({ actions, graphql }, pluginOptions) => graphql(`
                   // For page title
                   title: `${source === 'core' ? 'HTML' : 'React'} - ${title} ${key.replace(/-/g, ' ')}`,
                   // The HTML or JSX to render
-                  code: example
+                  code: example.code,
+                  // The tag to use as a wrapper
+                  wrapperTag: example.wrapperTag || wrapperTag
                 }
               });
             });

--- a/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/gatsby-theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -33,7 +33,7 @@ export const SideNavLayout = ({
   children,
   location,
   context,
-  parityComponent, // aboutmodal <=> aboutmodalbox
+  // parityComponent, // aboutmodal <=> aboutmodalbox
   hideSideNav = false,
   showGdprBanner = false,
   showFooter = false,
@@ -103,6 +103,7 @@ export const SideNavLayout = ({
     }
   }
   `);
+
   const { title } = data.site.siteMetadata;
   const { num, url } = data.prInfo;
   const { topNavItems, sideNav, context: pageSource } = data.sitePlugin.pluginOptions;
@@ -141,8 +142,9 @@ export const SideNavLayout = ({
           pageSource={pageSource}
           allPages={data.allSitePage.nodes}
           sideNavContexts={sideNav}
-          parityComponent={parityComponent} />}
-          />;
+          // parityComponent={parityComponent}
+        />}
+      />;
 
   const latestVersion = versions.Releases.find(version => version.latest);
   const dropdownToggle = (

--- a/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
@@ -281,8 +281,8 @@ const MDXTemplate = ({ data, location, pageContext }) => {
 export default MDXTemplate;
 
 export const pageQuery = graphql`
-  query ComponentMdxDocsPage($id: [String!], $designId: String!, $propComponents: [String]!) {
-    doc: allMdx(filter: {id: {in: $id}}) {
+  query ComponentMdxDocsPage($id: [String!], $designId: [String!], $propComponents: [String]!) {
+    doc: allMdx(filter: { id: { in: $id }}) {
       nodes {
         body
         frontmatter {
@@ -303,11 +303,13 @@ export const pageQuery = graphql`
         }
       }
     }
-    designDoc: mdx(id: { eq: $designId }) {
-      body
-      frontmatter {
-        reactComponentName
-        coreComponentName
+    designDoc: allMdx(filter: { id: { in: $designId }}) {
+      nodes {
+        body
+        frontmatter {
+          reactComponentName
+          coreComponentName
+        }
       }
     }
     partials: allFile(filter: { fields: { name: { ne: null } } }) {

--- a/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
@@ -40,12 +40,12 @@ const MDXTemplate = ({ data, location, pageContext }) => {
         katacodaId={location.state.katacodaId} />
     );
   }
-  console.log('DATAAAA:__  ', data, location, pageContext);
+
   const combinedComponent = data.doc.nodes.map((node, idx) => {
     const { cssPrefix, hideTOC, beta, katacodaBroken, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = node.frontmatter;
     const { componentName, navSection, source } = node.fields;
     const { title, tableOfContents, htmlExamples, propComponents = [''], showBanner, showGdprBanner, showFooter, sourceLink } = pageContext[source];
-    console.log('SOURCE: ', source);
+
     const props = data.props && data.props.nodes && propComponents
       ? propComponents
         .filter(name => name !== '') // Filter default entry we make for GraphQL schema
@@ -119,9 +119,11 @@ const MDXTemplate = ({ data, location, pageContext }) => {
               </Alert>
             )}
             {/* Design docs should not apply to demos and overview */}
-            {data.designDoc && !['overview', 'demos'].includes(navSection) && console.log(data.designDoc.nodes[idx]) && (
+            {data.designDoc && !['overview', 'demos'].includes(navSection) && (
               <MDXRenderer>
-                {data.designDoc.nodes[idx].body}
+                {data.designDoc.nodes.map(node => (
+                  node.body
+                ))}
               </MDXRenderer>
             )}
             {releaseNoteTOC && (
@@ -255,16 +257,17 @@ const MDXTemplate = ({ data, location, pageContext }) => {
       </React.Fragment>
     );
   });
+
   return (
     <React.Fragment>
       <SkipToContent href="#main-content">Skip to Content</SkipToContent>
       <SideNavLayout
         location={location}
-        // context={source}
+        context={pageContext.source}
         // showBanner={showBanner}
         // showGdprBanner={showGdprBanner}
         // showFooter={showFooter}
-        pageTitle={pageContext[source].title}
+        pageTitle={pageContext.title}
       >
         <PageSection id="main-content" className="ws-section">
           {combinedComponent}

--- a/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
@@ -212,7 +212,8 @@ const MDXTemplate = ({ data, location, pageContext }) => {
     const MDXContent = () => (
       <MDXProvider components={{
         ...commonComponents,
-        code: props =>
+        code: props => {
+          return (
           <Example
             location={location}
             source={source}
@@ -221,6 +222,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
             navSection={navSection}
             componentName={componentName}
             {...props} />
+          )}
       }}>
         <MDXRenderer>
           {node.body}

--- a/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
@@ -1,0 +1,347 @@
+import React from 'react';
+import { graphql, Link } from 'gatsby';
+import { MDXProvider } from '@mdx-js/react';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
+import {
+  Alert,
+  Badge,
+  Card,
+  CardTitle,
+  CardBody,
+  Grid,
+  GridItem,
+  PageSection,
+  SkipToContent,
+  Title
+} from '@patternfly/react-core';
+import { SideNavLayout, TrainingLayout } from '../layouts';
+import { AutoLinkHeader, Example, CSSVariables, PropsTable, commonComponents } from '../components';
+import { getId , slugger, capitalize} from '../helpers';
+import versions from '../versions.json';
+import './mdx.css';
+
+const getSourceTitle = source => {
+  switch(source) {
+    case 'core':
+      return 'HTML';
+    case 'shared':
+      return 'HTML/React';
+    default:
+      return capitalize(source);
+  }
+}
+
+const MDXTemplate = ({ data, location, pageContext }) => {
+  if (location.state && location.state.trainingType && location.state.katacodaId) {
+    return (
+      <TrainingLayout
+        location={location}
+        trainingType={location.state.trainingType}
+        katacodaId={location.state.katacodaId} />
+    );
+  }
+  const { cssPrefix, hideTOC, beta, katacodaBroken, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = data.doc.frontmatter;
+  const { componentName, navSection } = data.doc.fields;
+  console.log(componentName, navSection, data, location, pageContext);
+  const { title, source, tableOfContents, htmlExamples, propComponents = [''], showBanner, showGdprBanner, showFooter, sourceLink } = pageContext;
+  const props = data.props && data.props.nodes && propComponents
+    ? propComponents
+      .filter(name => name !== '') // Filter default entry we make for GraphQL schema
+      .map(name => {
+        const propTable = data.props.nodes.find(node => node.name === name);
+        if (!propTable) {
+          console.warn(`PropComponent "${name}" specified in frontmatter, but not found at runtime.`);
+        }
+
+        return propTable;
+      })
+      .filter(Boolean)
+    : [];
+
+  let parityComponent = undefined;
+  if (data.designDoc && ['components', 'beta', 'utilities'].includes(navSection)) {
+    const { reactComponentName, coreComponentName } = data.designDoc.frontmatter;
+    if (source === 'core' && reactComponentName) {
+      parityComponent = `${navSection}/${reactComponentName}`;
+    }
+    else if (source === 'react' && coreComponentName) {
+      parityComponent = `${navSection}/${coreComponentName}`;
+    }
+  }
+
+  // TODO: Stop hiding TOC in design pages
+  const TableOfContents = () => (
+    <React.Fragment>
+      {showTitle && (
+        <React.Fragment>
+          <Title size="4xl" headingLevel="h1" className="ws-page-title">{title}</Title>
+          {optIn && (
+            <Alert
+              variant="info"
+              title="Opt-in feature"
+              className="pf-u-my-md"
+              isInline
+            >
+              {optIn}
+            </Alert>
+          )}
+        </React.Fragment>
+      )}
+      {!hideTOC && (
+        <React.Fragment>
+          {!hideSource && (
+            <label id="source-label" className="ws-framework-title pf-c-title" aria-hidden>
+              {getSourceTitle(source)}
+            </label>
+          )}
+          <Title headingLevel="h1" id="component-title" size="4xl" className="ws-page-title" aria-labelledby="source-label component-title">{title}</Title>
+          {optIn && (
+            <Alert
+              variant="info"
+              title="Opt-in feature"
+              className="pf-u-my-md"
+              isInline
+            >
+              {optIn}
+            </Alert>
+          )}
+          {beta && (
+            <Alert
+              variant={'info'}
+              title="Beta feature"
+              className="pf-u-my-md"
+              style={{ marginBottom: '1rem' }}
+              isInline
+            >
+              This Beta component is currently under review, so please join in and give us your feedback on the <a href="https://forum.patternfly.org/">PatternFly forum</a>
+            </Alert>
+          )}
+          {katacodaBroken && (
+            <Alert
+              variant={'danger'}
+              title="Down for maintenance"
+              className="pf-u-my-md"
+              style={{ marginBottom: '1rem' }}
+              isInline
+            >
+              We'll be up and running in a bit, so check back soon. Thanks!
+            </Alert>
+          )}
+          {/* Design docs should not apply to demos and overview */}
+          {data.designDoc && !['overview', 'demos'].includes(navSection) && (
+            <MDXRenderer>
+              {data.designDoc.body}
+            </MDXRenderer>
+          )}
+          {releaseNoteTOC && (
+            <Grid hasGutter className="ws-release-notes-toc">
+              {versions.Releases
+                .filter(version => (
+                  tableOfContents.some(header => header.includes(version.name))))
+                .slice(0, 6)                         // limit to newest releases
+                .map(version => {
+                  const [year, month, day] = version.date.split('-');
+                  const releaseDate = new Date(+year, +month - 1, +day)
+                    .toLocaleDateString('us-EN', {
+                      month: 'long',
+                      day: 'numeric',
+                      year: 'numeric'
+                    });
+                  const releaseTitle = tableOfContents.find(heading => heading.includes(version.name));
+                  return releaseTitle && (
+                    <GridItem sm={6} md={4} key={version.name}>
+                      <Card>
+                        <CardTitle>
+                          {releaseTitle && (
+                            <Title size="2xl" headingLevel="h2" >
+                              <a key={version.name} href={`#${slugger(releaseTitle)}`}>
+                                Release {version.name}
+                              </a>
+                            </Title>
+                          )}
+                          {version.latest && (
+                            <Badge>Latest</Badge>
+                          )}
+                        </CardTitle>
+                        <CardBody>
+                          Released on {releaseDate}.
+                        </CardBody>
+                      </Card>
+                    </GridItem>
+                  );
+                })
+              }
+            </Grid>
+          )}
+          {!releaseNoteTOC && tableOfContents.map(heading => (
+            <a key={heading} href={`#${slugger(heading)}`} className="ws-toc">
+              {heading}
+            </a>
+          ))}
+          {!releaseNoteTOC && props.length > 0 && (
+            <a href="#props" className="ws-toc">
+              Props
+            </a>
+          )}
+          {!releaseNoteTOC && cssPrefix && (
+            <a href="#css-variables" className="ws-toc">
+              CSS Variables
+            </a>
+          )}
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  );
+
+  const PropsSection = () => (
+    <React.Fragment>
+      <AutoLinkHeader headingLevel="h2" id="props" size="h2" className="ws-h2">
+        Props
+      </AutoLinkHeader>
+      {props.map(component => (
+        <PropsTable
+          key={component.name}
+          caption={`${component.name} properties`}
+          rows={component.props} />
+      ))}
+    </React.Fragment>
+  );
+
+  const CSSVariablesSection = () => (
+    <React.Fragment>
+      <AutoLinkHeader headingLevel="h2" id="css-variables" size="h2" className="ws-h2">
+        CSS Variables
+      </AutoLinkHeader>
+      <CSSVariables prefix={cssPrefix} />
+    </React.Fragment>
+  );
+
+  const MDXContent = () => (
+    <MDXProvider components={{
+      ...commonComponents,
+      code: props =>
+        <Example
+          location={location}
+          source={source}
+          html={props.title && htmlExamples && htmlExamples[getId(props.title)]}
+          hideDarkMode={hideDarkMode}
+          navSection={navSection}
+          componentName={componentName}
+          {...props} />
+    }}>
+      <MDXRenderer>
+        {data.doc.body}
+      </MDXRenderer>
+    </MDXProvider>
+  );
+
+  const FeedbackSection = () => {
+    const issueBody = encodeURIComponent(`\n\n\nProblem is in [this file.](${sourceLink})`);
+    const issueLink = sourceLink.replace(/\/blob\/master\/.*/, `/issues/new?title=&body=${issueBody}`);
+
+    return (
+      <React.Fragment>
+        <AutoLinkHeader headingLevel="h2" id="feedback" size="h2" className="ws-h2">
+          Feedback
+        </AutoLinkHeader>
+        <a href={sourceLink} target="_blank">View page source on Github</a> / <a href={issueLink} target="_blank">Report an issue on Github</a>
+      </React.Fragment>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <SkipToContent href="#main-content">Skip to Content</SkipToContent>
+      <SideNavLayout
+        location={location}
+        context={source}
+        parityComponent={parityComponent}
+        showBanner={showBanner}
+        showGdprBanner={showGdprBanner}
+        showFooter={showFooter}
+        pageTitle={pageContext.title}
+      >
+        <PageSection id="main-content" className="ws-section">
+          <TableOfContents />
+
+          {/* Wrap in div for :last-child CSS selectors */}
+          <div>
+            <MDXContent />
+          </div>
+
+          {props.length > 0 && <PropsSection />}
+          {cssPrefix && <CSSVariablesSection />}
+          {/* {sourceLink && <FeedbackSection />} */}
+        </PageSection>
+      </SideNavLayout>
+    </React.Fragment>
+  );
+}
+
+export default MDXTemplate;
+
+export const pageQuery = graphql`
+  query ComponentMdxDocsPage($id: [String!], $designId: String!, $propComponents: [String]!) {
+    doc: allMdx(filter: {id: {in: $id}}) {
+      nodes {
+        body
+        frontmatter {
+          cssPrefix
+          hideTOC
+          optIn
+          beta
+          katacodaBroken
+          hideDarkMode
+          showTitle
+          releaseNoteTOC
+          hideSource
+        }
+        fields {
+          navSection
+          componentName
+          source
+        }
+      }
+    }
+    designDoc: mdx(id: { eq: $designId }) {
+      body
+      frontmatter {
+        reactComponentName
+        coreComponentName
+      }
+    }
+    partials: allFile(filter: { fields: { name: { ne: null } } }) {
+      nodes {
+        fields {
+          name
+          partial
+        }
+      }
+    }
+    props: allComponentMetadata(filter: { name: { in: $propComponents, ne: null } }) {
+      nodes {
+        name
+        props {
+          beta
+          katacodaBroken
+          name
+          required
+          description
+          type {
+            name
+          }
+          tsType {
+            name
+            raw
+          }
+          defaultValue {
+            value
+          }
+          deprecated
+          hide
+          annotatedType
+        }
+      }
+    }
+  }
+`;

--- a/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/componentMdx.js
@@ -40,9 +40,9 @@ const MDXTemplate = ({ data, location, pageContext }) => {
         katacodaId={location.state.katacodaId} />
     );
   }
+  console.log('DATAAAA:__  ', data, location, pageContext);
   const { cssPrefix, hideTOC, beta, katacodaBroken, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = data.doc.frontmatter;
   const { componentName, navSection } = data.doc.fields;
-  console.log(componentName, navSection, data, location, pageContext);
   const { title, source, tableOfContents, htmlExamples, propComponents = [''], showBanner, showGdprBanner, showFooter, sourceLink } = pageContext;
   const props = data.props && data.props.nodes && propComponents
     ? propComponents
@@ -57,17 +57,6 @@ const MDXTemplate = ({ data, location, pageContext }) => {
       })
       .filter(Boolean)
     : [];
-
-  let parityComponent = undefined;
-  if (data.designDoc && ['components', 'beta', 'utilities'].includes(navSection)) {
-    const { reactComponentName, coreComponentName } = data.designDoc.frontmatter;
-    if (source === 'core' && reactComponentName) {
-      parityComponent = `${navSection}/${reactComponentName}`;
-    }
-    else if (source === 'react' && coreComponentName) {
-      parityComponent = `${navSection}/${coreComponentName}`;
-    }
-  }
 
   // TODO: Stop hiding TOC in design pages
   const TableOfContents = () => (
@@ -281,8 +270,8 @@ const MDXTemplate = ({ data, location, pageContext }) => {
 export default MDXTemplate;
 
 export const pageQuery = graphql`
-  query ComponentMdxDocsPage($id: [String!], $designId: [String!], $propComponents: [String]!) {
-    doc: allMdx(filter: { id: { in: $id }}) {
+  query ComponentMdxDocsPage($ids: [String!], $designIds: [String!], $propComponents: [String]!) {
+    doc: allMdx(filter: { id: { in: $ids }}) {
       nodes {
         body
         frontmatter {
@@ -303,7 +292,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    designDoc: allMdx(filter: { id: { in: $designId }}) {
+    designDoc: allMdx(filter: { id: { in: $designIds }}) {
       nodes {
         body
         frontmatter {

--- a/packages/gatsby-theme-patternfly-org/templates/fullscreenHTML.js
+++ b/packages/gatsby-theme-patternfly-org/templates/fullscreenHTML.js
@@ -3,8 +3,8 @@ import { Helmet } from 'react-helmet';
 import './fullscreen.css';
 
 const FullscreenHTMLTemplate = ({ pageContext }) => {
-  const { title, code } = pageContext;
-  const WrapperTag = pageContext.wrapperTag || 'main';
+  const { wrapperTag: WrapperTag, title, code } = pageContext;
+  
   return (
     <WrapperTag className="ws-site-root">
       <Helmet>

--- a/packages/gatsby-theme-patternfly-org/templates/fullscreenHTML.js
+++ b/packages/gatsby-theme-patternfly-org/templates/fullscreenHTML.js
@@ -3,7 +3,8 @@ import { Helmet } from 'react-helmet';
 import './fullscreen.css';
 
 const FullscreenHTMLTemplate = ({ pageContext }) => {
-  const { wrapperTag: WrapperTag, title, code } = pageContext;
+  const { title, code } = pageContext;
+  const WrapperTag = pageContext.wrapperTag || 'main';
   return (
     <WrapperTag className="ws-site-root">
       <Helmet>

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -42,6 +42,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
   }
   const { cssPrefix, hideTOC, beta, katacodaBroken, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = data.doc.frontmatter;
   const { componentName, navSection } = data.doc.fields;
+  console.log(componentName, navSection, data, location, pageContext);
   const { title, source, tableOfContents, htmlExamples, propComponents = [''], showBanner, showGdprBanner, showFooter, sourceLink } = pageContext;
   const props = data.props && data.props.nodes && propComponents
     ? propComponents

--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -42,7 +42,6 @@ const MDXTemplate = ({ data, location, pageContext }) => {
   }
   const { cssPrefix, hideTOC, beta, katacodaBroken, optIn, hideDarkMode, showTitle, releaseNoteTOC, hideSource } = data.doc.frontmatter;
   const { componentName, navSection } = data.doc.fields;
-  console.log(componentName, navSection, data, location, pageContext);
   const { title, source, tableOfContents, htmlExamples, propComponents = [''], showBanner, showGdprBanner, showFooter, sourceLink } = pageContext;
   const props = data.props && data.props.nodes && propComponents
     ? propComponents


### PR DESCRIPTION
Closes #1793 

POC showing that Core & React docs can be sourced together and displayed on a single page. Also updates Org sidenav to remove context switcher and instead show all components under the "Components" section regardless of Core vs React component.

Note that this does not incorporate work towards building out the actual design for the redesign, simply dumps both React & Core docs together onto one page.