### PR TITLE
Update to icon guidelines to emphasize ability to use any FA free icon

### DIFF
--- a/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
@@ -173,7 +173,8 @@ export class IconsTable extends React.Component {
               No results found for "{ searchValue }"
             </Title>
             <EmptyStateBody>
-            We couldn't find any icons that matched your search. If none of the icons listed fit your use case, you may use any additional 'fa' icons within <a href="https://fontawesome.com/icons?d=gallery&amp;m=free">Font Awesome's free set</a>.
+            We couldn't find any icons that matched your search. If none of the icons listed fit 
+            your use case, you may use any additional 'fa' icons within <a href="https://fontawesome.com/icons?d=gallery&amp;m=free">Font Awesome's free set</a>.
             </EmptyStateBody>
           </EmptyState>
         )}

--- a/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
@@ -170,10 +170,10 @@ export class IconsTable extends React.Component {
           <EmptyState variant={EmptyStateVariant.full}>
             <EmptyStateIcon icon={icons.SearchIcon}/>
             <Title headingLevel="h5" size="2xl">
-              No results found for "{ searchValue }".
+              No results found for "{ searchValue }"
             </Title>
             <EmptyStateBody>
-              We couldn't find any icons that matched your search. Try entering a new search term to find what you're looking for.
+            We couldn't find any icons that matched your search. If none of the icons listed fit your use case, you may use any additional 'fa' icons within <a href="https://fontawesome.com/icons?d=gallery&amp;m=free">Font Awesome's free set</a>.
             </EmptyStateBody>
           </EmptyState>
         )}

--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.md
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.md
@@ -97,11 +97,11 @@ Visit our <Link to="/design-guidelines/styles/colors" className="pf-m-link">colo
 <Divider className="ws-icons-divider" />
 
 ## All icons
-PatternFly uses custom icons and selections from <a href="https://fontawesome.com/icons?d=gallery&m=free">Font Awesome Free</a>. PatternFly icons are mostly two dimensional and flat. Navigate to Font Awesome’s website to download SVGs of any additional ‘fa’ icons within their free set. Proper attribution should be given as outlined on the Font Awesome site.
+PatternFly uses custom icons and selections from <a href="https://fontawesome.com/icons?d=gallery&m=free">Font Awesome Free</a> which are listed below. PatternFly icons are mostly two dimensional and flat. If none of the PatternFly offered icons fit your use case, you may use any additional ‘fa’ icons within Font Awesome's free set. Simply download your chosen icon's SVG and give the icon proper attribution as outlined on the <a href="https://fontawesome.com/license/freeFont"> Font Awesome site</a>.
 
 Click on any single icon in the table to download it as an SVG. Download all icon SVGs <a href="https://patternfly-org.s3.us-east-2.amazonaws.com/patternfly-icons.zip">here</a>.
 
-If you’re a designer, these icons are the same set as the ones in the <a href="https://www.patternfly.org/v4/get-started/designers">PatternFly Sketch Design Kit</a>. It is possible to use any FontAwesome icon as long it follows the guidelines above.
+If you’re a designer, these icons are the same set as the ones in the <a href="https://www.patternfly.org/v4/get-started/designers">PatternFly Sketch Design Kit</a>. **As mentioned above, if none of these icons fit your use case, you may use any <a href="https://fontawesome.com/icons?d=gallery&m=free">Font Awesome Free</a> icon as long it follows the guidelines above.**
 
 If you’re looking to copy HTML for an icon:<br/>
 Use this for 'pficon' icons: `<i className="pf-icon [insert-icon-name]"></i>`<br />


### PR DESCRIPTION
Made a few updates to the icon guidelines text to further emphasize the fact that designers can use any FA free icon offered.

Fixes #1888 