### PR TITLE
update error message on training

### DIFF
--- a/packages/gatsby-theme-patternfly-org/templates/mdx.js
+++ b/packages/gatsby-theme-patternfly-org/templates/mdx.js
@@ -123,7 +123,7 @@ const MDXTemplate = ({ data, location, pageContext }) => {
               style={{ marginBottom: '1rem' }}
               isInline
             >
-              We'll be up and running in a bit, so check back soon. Thanks!
+              The embedded version of our tutorials are broken, but you can still access our tutorials on <a href="https://www.katacoda.com/patternfly">Katacoda.com</a>
             </Alert>
           )}
           {/* Design docs should not apply to demos and overview */}


### PR DESCRIPTION
The previous issue with Katacoda (the files in the file tree not appearing) and the v4 updates to the tutorials have been resolved. But now there is an issue regarding how the tutorials are embedded and we are waiting on Katacoda to respond, so I have updated the message on our training page accordingly to redirect users to Katacoda.com where the tutorials are working.

The issue is documented here: https://github.com/patternfly/training-scenarios/issues/305

cc: @janwright73 @dgutride 