### PR TITLE
fix(example): h3s for react

### DIFF
--- a/packages/gatsby-theme-patternfly-org/helpers/extractExamples.js
+++ b/packages/gatsby-theme-patternfly-org/helpers/extractExamples.js
@@ -33,32 +33,34 @@ module.exports = {
 
         let match = node.meta.match(/title=(\S*)/);
         if (match) {
+          console.log('match', match);
           id = getId(match[1]);
-        }
-        else {
-          // Starting from node, look up for h3s
-          let startLooking = false;
-          for (let i = parent.children.length - 1; i > 0; i--) {
-            const child = parent.children[i];
-            if (child === node) {
-              startLooking = true;
-            }
-            else if (startLooking) {
-              if (
-                child.type === 'heading' &&
-                child.depth === 3 &&
-                child.children && 
-                child.children[0].value
-              ) {
-                id = getId(child.children[0].value);
-                break;
-              }
-            }
-          }
         }
         match = node.meta.match(/wrapperTag=(\S*)/);
         if (match) {
           wrapperTag = match[1].toLowerCase();
+        }
+      }
+
+      if (id === 'no-id') {
+        // Starting from node, look up for h3s
+        let startLooking = false;
+        for (let i = parent.children.length - 1; i >= 0; i--) {
+          const child = parent.children[i];
+          if (child === node) {
+            startLooking = true;
+          }
+          else if (startLooking) {
+            if (
+              child.type === 'heading' &&
+              child.depth === 3 &&
+              child.children && 
+              child.children[0].value
+            ) {
+              id = getId(child.children[0].value);
+              break;
+            }
+          }
         }
       }
 

--- a/packages/gatsby-theme-patternfly-org/index.js
+++ b/packages/gatsby-theme-patternfly-org/index.js
@@ -4,7 +4,8 @@
 // We can't include these in gatsby-node since we aren't gatsby-mdx
 exports.mdxTypeDefs = `
   type MdxFrontmatter @dontInfer {
-    title: String!
+    id: String!
+    title: String
     section: String
     cssPrefix: String
     hideTOC: Boolean

--- a/packages/gatsby-theme-patternfly-org/templates/fullscreenMDX.js
+++ b/packages/gatsby-theme-patternfly-org/templates/fullscreenMDX.js
@@ -2,14 +2,19 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { LiveProvider, LivePreview } from 'react-live';
 import { useMDXScope } from 'gatsby-plugin-mdx/context';
+import * as PatternflyReactCore from '@patternfly/react-core';
 import { transformCode } from '../helpers/transformCode';
 import './fullscreen.css';
 
 const FullscreenMDXTemplate = ({ pageContext }) => {
   const { wrapperTag: WrapperTag, title, code } = pageContext;
+  const scope = {
+    ...PatternflyReactCore,
+    ...useMDXScope()
+  };
   return (
     <LiveProvider
-      scope={useMDXScope()}
+      scope={scope}
       code={code}
       transformCode={c => transformCode(c, 'jsx')}
     >


### PR DESCRIPTION
Fix fullscreen pages and extracting ids for examples without meta strings.