### PR TITLE
applied className & font-family styling to code text example

### DIFF
--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.css
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.css
@@ -10,6 +10,10 @@
   margin-top: 24px;
 }
 
+.ws-typography-code-font + div {
+  font-family: var(--pf-global--FontFamily--monospace) !important;
+}
+
 .table-typography {
   background-color: transparent;
 }

--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.js
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.js
@@ -7,11 +7,12 @@ export const PfStyledText = ({ children, variableName, fontWeight, lineHeight, f
   </div>
 );
 
-export const TitleLevel = ({ asGrid, styleProps, children, title = '', note = '' }) => {
+export const TitleLevel = ({ asGrid, styleProps, children, title = '', note = '', className = '' }) => {
   return asGrid ? (
     <TypographyGrid 
       title={title} 
       note={note}
+      className={className}
       {...styleProps}
     />
   ) : (
@@ -86,9 +87,9 @@ export const styleProps = {
   }
 }
 
-export const TypographyGrid = ({title, note, symbol, fontWeight, fontWeightText, fontSize, variableName, lineHeight, fontFamily}) => (
+export const TypographyGrid = ({title, note, symbol, fontWeight, fontWeightText, fontSize, variableName, lineHeight, fontFamily, className}) => (
   <React.Fragment>
-    <h3 className="ws-title">{title} {symbol && <span className="ws-typography-gridTitleSymbol">{symbol}</span>}</h3>
+    <h3 className={className ? `ws-title ${className}` : 'ws-title'}>{title} {symbol && <span className="ws-typography-gridTitleSymbol">{symbol}</span>}</h3>
     <PfStyledText fontFamily={fontFamily} fontWeight={fontWeight} variableName={variableName} lineHeight={lineHeight}>
       Design is where science and art break even.
     </PfStyledText>

--- a/packages/v4/src/content/design-guidelines/styles/typography/typography.md
+++ b/packages/v4/src/content/design-guidelines/styles/typography/typography.md
@@ -39,7 +39,8 @@ Use typography to create visual hierarchy. A consistent and logical hierarchy ma
   title="Tiny text*"
   note="*Not to be used in content blocks (only used with data visualizations when 14px is not small enough)"
   styleProps = {styleProps.tiny} />
-  <TitleLevel 
+<TitleLevel
+  className="ws-typography-code-font"
   asGrid 
   title="Code*"
   note="*Used for code blocks "


### PR DESCRIPTION
Closes #1974 

Follow-up to #1915 - this PR adds the correct font-family styling to the code text sample