### PR TITLE
move 2 pages to get started

### DIFF
--- a/packages/theme-patternfly-org/pages/global-css-variables.md
+++ b/packages/theme-patternfly-org/pages/global-css-variables.md
@@ -1,6 +1,6 @@
 ---
 id: Global CSS variables
-section: overview
+section: get-started
 ---
 
 import { CSSVariables } from '../components/cssVariables/cssVariables';

--- a/packages/theme-patternfly-org/pages/red-hat-font.md
+++ b/packages/theme-patternfly-org/pages/red-hat-font.md
@@ -1,6 +1,6 @@
 ---
 id: Red Hat font
-section: overview
+section: get-started
 ---
 
 PR - [https://github.com/patternfly/patternfly-next/pull/1813](https://github.com/patternfly/patternfly-next/pull/1813)


### PR DESCRIPTION
Removing release notes and upgrade guide will have to be done upstream. It will also affect the live site to do that, so we're probably better off waiting to do this after our last normal site release.