### PR TITLE
Chore/2056 animate search

### DIFF
--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -39,8 +39,11 @@
   /* For icon */
   padding-left: 32px;
 }
-#global-search-input + .global-search-icon,
-.algolia-autocomplete + .global-search-icon {
+.ws-hide-search .algolia-autocomplete {
+  width: 0;
+}
+#global-search-input + .ws-global-search-button,
+.algolia-autocomplete + .ws-global-search-button {
   position: absolute;
   top: 10px;
   left: 4px;

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -39,13 +39,20 @@
   /* For icon */
   padding-left: 32px;
 }
-.ws-hide-search .algolia-autocomplete {
+.ws-hide-search-input .algolia-autocomplete {
+  display: none !important;
   width: 0;
 }
-#global-search-input + .ws-global-search-button,
-.algolia-autocomplete + .ws-global-search-button {
+.algolia-autocomplete {
+  width: auto;
+}
+.ws-collapse-search {
+  position: relative;
+  top: 4px;
+}
+.ws-global-search > .global-search-icon {
   position: absolute;
-  top: 10px;
+  top: 14px;
   left: 4px;
 }
 #global-search-input,

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -39,7 +39,8 @@
   /* For icon */
   padding-left: 32px;
 }
-.global-search-icon {
+#global-search-input + .global-search-icon,
+.algolia-autocomplete + .global-search-icon {
   position: absolute;
   top: 10px;
   left: 4px;

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -42,10 +42,6 @@
 .ws-hide-search-input .algolia-autocomplete,
 .ws-hide-search-input #global-search-input {
   display: none !important;
-  width: 0;
-}
-.algolia-autocomplete {
-  width: auto;
 }
 .ws-collapse-search {
   position: relative;

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -39,7 +39,8 @@
   /* For icon */
   padding-left: 32px;
 }
-.ws-hide-search-input .algolia-autocomplete {
+.ws-hide-search-input .algolia-autocomplete,
+.ws-hide-search-input #global-search-input {
   display: none !important;
   width: 0;
 }

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -110,8 +110,7 @@ const HeaderTools = ({
 }
 
 function attachDocSearch(algolia, timeout) {
-  const hasGlobalSearchInput = document.getElementById('global-search-input');
-  if (window.docsearch && hasGlobalSearchInput) {
+  if (window.docsearch) {
     return window.docsearch({
       inputSelector: '#global-search-input',
       debug: false,

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -55,12 +55,12 @@ const HeaderTools = ({
             ? (
               <React.Fragment>
                 <SearchIcon className="global-search-icon" />
-                <Button variant="plain" className="ws-collapse-search" onClick={() => setSearchExpanded(false)}>
+                <Button aria-label="Expand search input" variant="plain" className="ws-collapse-search" onClick={() => setSearchExpanded(false)}>
                   <TimesIcon />
                 </Button>
               </React.Fragment>
             ) : (
-              <Button variant="plain" onClick={expandAndFocusSearch}>
+              <Button aria-label="Collapse search input" variant="plain" onClick={expandAndFocusSearch}>
                 <SearchIcon className="global-search-icon" />
               </Button>
             )

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -14,7 +14,7 @@ import {
   DropdownGroup,
   Divider
 } from '@patternfly/react-core';
-import { SearchIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { SearchIcon, ExternalLinkAltIcon, TimesIcon } from '@patternfly/react-icons';
 import { SideNav, TopNav, GdprBanner } from '../../components';
 import ConfigContext from '../../helpers/configContext';
 import staticVersions from '../../versions.json';
@@ -30,7 +30,6 @@ const HeaderTools = ({
   const initialVersion = staticVersions.Releases.find(release => release.latest);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [isSearchExpanded, setSearchExpanded] = useState(false);
-  const expandSearch = () => !isSearchExpanded && setSearchExpanded(true);
   const latestVersion = versions.Releases.find(version => version.latest);
   const getDropdownItem = version => (
     <DropdownItem
@@ -46,11 +45,22 @@ const HeaderTools = ({
   return (
     <PageHeaderTools>
       {hasSearch && (
-        <PageHeaderToolsItem className="ws-global-search">
-          <Button className="ws-global-search-button" variant="plain" aria-label="Expand search" onClick={expandSearch}>
-            <SearchIcon className="global-search-icon" />
-          </Button>
-          {isSearchExpanded && <TextInput id="global-search-input" placeholder="Search" />}
+        <PageHeaderToolsItem className={`ws-global-search ${isSearchExpanded ? '' : 'ws-hide-search-input'}`}>
+          <TextInput id="global-search-input"  placeholder="Search" autoFocus />
+          {isSearchExpanded
+            ? (
+              <React.Fragment>
+                <SearchIcon className="global-search-icon" />
+                <Button variant="plain" className="ws-collapse-search" onClick={() => setSearchExpanded(false)}>
+                  <TimesIcon />
+                </Button>
+              </React.Fragment>
+            ) : (
+              <Button variant="plain" onClick={() => setSearchExpanded(true)}>
+                <SearchIcon className="global-search-icon" />
+              </Button>
+            )
+          }
         </PageHeaderToolsItem>
       )}
       {hasVersionSwitcher && (
@@ -96,8 +106,7 @@ const HeaderTools = ({
 }
 
 function attachDocSearch(algolia, timeout) {
-  const hasSearchInput = document.getElementById('global-search-input');
-  if (window.docsearch && hasSearchInput) {
+  if (window.docsearch) {
     return window.docsearch({
       inputSelector: '#global-search-input',
       debug: false,

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -30,6 +30,12 @@ const HeaderTools = ({
   const initialVersion = staticVersions.Releases.find(release => release.latest);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [isSearchExpanded, setSearchExpanded] = useState(false);
+  const expandAndFocusSearch = () => {
+    if (!isSearchExpanded) {
+      setSearchExpanded(true);
+      setTimeout(() => document.getElementById('global-search-input').focus(), 0);
+    }
+  }
   const latestVersion = versions.Releases.find(version => version.latest);
   const getDropdownItem = version => (
     <DropdownItem
@@ -46,7 +52,7 @@ const HeaderTools = ({
     <PageHeaderTools>
       {hasSearch && (
         <PageHeaderToolsItem className={`ws-global-search ${isSearchExpanded ? '' : 'ws-hide-search-input'}`}>
-          <TextInput id="global-search-input"  placeholder="Search" autoFocus />
+          <TextInput id="global-search-input"  placeholder="Search" />
           {isSearchExpanded
             ? (
               <React.Fragment>
@@ -56,7 +62,7 @@ const HeaderTools = ({
                 </Button>
               </React.Fragment>
             ) : (
-              <Button variant="plain" onClick={() => setSearchExpanded(true)}>
+              <Button variant="plain" onClick={expandAndFocusSearch}>
                 <SearchIcon className="global-search-icon" />
               </Button>
             )
@@ -106,7 +112,8 @@ const HeaderTools = ({
 }
 
 function attachDocSearch(algolia, timeout) {
-  if (window.docsearch) {
+  const hasGlobalSearchInput = document.getElementById('global-search-input');
+  if (window.docsearch && hasGlobalSearchInput) {
     return window.docsearch({
       inputSelector: '#global-search-input',
       debug: false,

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext } from 'react';
 import {
+  Button,
   Page,
   PageHeader,
   PageSidebar,
@@ -29,7 +30,7 @@ const HeaderTools = ({
   const initialVersion = staticVersions.Releases.find(release => release.latest);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [isSearchExpanded, setSearchExpanded] = useState(false);
-  const toggleSearch = () => setSearchExpanded(!isSearchExpanded);
+  const expandSearch = () => !isSearchExpanded && setSearchExpanded(true);
   const latestVersion = versions.Releases.find(version => version.latest);
   const getDropdownItem = version => (
     <DropdownItem
@@ -46,8 +47,10 @@ const HeaderTools = ({
     <PageHeaderTools>
       {hasSearch && (
         <PageHeaderToolsItem className="ws-global-search">
+          <Button className="ws-global-search-button" variant="plain" aria-label="Expand search" onClick={expandSearch}>
+            <SearchIcon className="global-search-icon" />
+          </Button>
           {isSearchExpanded && <TextInput id="global-search-input" placeholder="Search" />}
-          <SearchIcon className="global-search-icon" onClick={toggleSearch} />
         </PageHeaderToolsItem>
       )}
       {hasVersionSwitcher && (

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -31,10 +31,8 @@ const HeaderTools = ({
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const [isSearchExpanded, setSearchExpanded] = useState(false);
   const expandAndFocusSearch = () => {
-    if (!isSearchExpanded) {
-      setSearchExpanded(true);
-      setTimeout(() => document.getElementById('global-search-input').focus(), 0);
-    }
+    setSearchExpanded(true);
+    setTimeout(() => document.getElementById('global-search-input').focus(), 0);
   }
   const latestVersion = versions.Releases.find(version => version.latest);
   const getDropdownItem = version => (

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -28,6 +28,8 @@ const HeaderTools = ({
 }) => {
   const initialVersion = staticVersions.Releases.find(release => release.latest);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const [isSearchExpanded, setSearchExpanded] = useState(false);
+  const toggleSearch = () => setSearchExpanded(!isSearchExpanded);
   const latestVersion = versions.Releases.find(version => version.latest);
   const getDropdownItem = version => (
     <DropdownItem
@@ -44,8 +46,8 @@ const HeaderTools = ({
     <PageHeaderTools>
       {hasSearch && (
         <PageHeaderToolsItem className="ws-global-search">
-          <TextInput id="global-search-input" placeholder="Search" />
-          <SearchIcon className="global-search-icon" />
+          {isSearchExpanded && <TextInput id="global-search-input" placeholder="Search" />}
+          <SearchIcon className="global-search-icon" onClick={toggleSearch} />
         </PageHeaderToolsItem>
       )}
       {hasVersionSwitcher && (
@@ -91,7 +93,8 @@ const HeaderTools = ({
 }
 
 function attachDocSearch(algolia, timeout) {
-  if (window.docsearch) {
+  const hasSearchInput = document.getElementById('global-search-input');
+  if (window.docsearch && hasSearchInput) {
     return window.docsearch({
       inputSelector: '#global-search-input',
       debug: false,


### PR DESCRIPTION
Closes #2056 

This PR hides the global search input by default, adds functionality to expand it when clicking on the search icon, and when open adds a close icon that hides the search input.