### PR TITLE
Align columns in UX writing section

### DIFF
--- a/packages/v4/src/content/design-guidelines/content/brand-voice-and-tone.md
+++ b/packages/v4/src/content/design-guidelines/content/brand-voice-and-tone.md
@@ -24,6 +24,8 @@ Let’s consider how we use the Red Hat brand voice in our UX copy. If Red Hat w
 ## Voice traits
 To reflect the Red Hat voice in UX copy for Red Hat products, we have UX voice traits. Each voice trait is an extension of the Red Hat voice.
 
+<div class="ws-content-table">
+
 | **Red Hat voice traits**               | **UX voice traits** |
 |----------------------------------------|---------------------|
 | Helpful but humble (not arrogant)      | Friendly            |
@@ -31,11 +33,15 @@ To reflect the Red Hat voice in UX copy for Red Hat products, we have UX voice t
 | Open but ordered (not chaotic)         | Collaborative       |
 | Brave but balanced (not reckless)      | Inventive           |
 
+</div>
+
 You can’t *tell* your users what your voice is. You need to *show* them who you are in your writing. One way to do this is with “Voice Do and Don’t” charts. This is what Red Hat's UX copy voice charts look like:
 
 **Voice trait**: Friendly
 
 **Description**: Our #1 focus is the user. We make them feel welcome and create a sense of belonging and understanding.
+
+<div class="ws-content-table">
 
 | **Do** | **Don't** |
 |--------|-----------|
@@ -43,31 +49,46 @@ You can’t *tell* your users what your voice is. You need to *show* them who yo
 | Write how you speak, but add extra polish.                  ||
 | Focus on comprehension and use plain language.              ||
 
+</div>
+
 **Voice trait**: Approachable
 
 **Description**: People are comfortable engaging with us. We’re open to listening and changing our ways when better ideas come along.
+
+<div class="ws-content-table">
 
 | **Do** | **Don't** |
 |--------|-----------|
 | Say what you mean.                                             | Don’t use jargon, idioms, bizspeak, or formal language. |
 | Be direct and transparent with descriptive, specific language. ||
+
+</div>
+
 **Voice trait**: Collaborative
 
 **Description**: We embody Red Hat’s open source mission with our collaborative working style and our sense of community.
+
+<div class="ws-content-table">
 
 | **Do** | **Don't** |
 |--------|-----------|
 | Deliver content in a way that includes everyone.                                     | Don’t rely on inside jokes, colloquial expressions, culture-specific examples, or other alienating language to get your point across. |
 | Use “you” and the active voice to put emphasis on the user and power in their hands. | Don’t use “I” too much. Make the user the star of every story you tell. |
 
+</div>
+
 **Voice trait**: Inventive
 
 **Description**: We have a fearless edge, challenging the assumption that UX is for a niche group of techies. We’re also not afraid to share our ideas and welcome new ones.
+
+<div class="ws-content-table">
 
 | **Do** | **Don't** |
 |--------|-----------|
 | Deliver concepts and ideas with an air of confident simplicity. | Don’t belittle others or make jokes at their expense. We can laugh at ourselves but not at our users. |
 | Add real-world, global-friendly examples.                       | Don’t use others as examples of what not to do.                                                       |
+
+</div>
 
 When crafting your brand voice, consider your company or team values (if you have them) and align your voice traits accordingly.
 

--- a/packages/v4/src/content/design-guidelines/content/content.css
+++ b/packages/v4/src/content/design-guidelines/content/content.css
@@ -1,4 +1,4 @@
-.ws-content-table {
+.ws-content-table > table {
   table-layout: fixed;
-  width: 80%;
+  width: 100%;
 }

--- a/packages/v4/src/content/design-guidelines/content/error-messages.md
+++ b/packages/v4/src/content/design-guidelines/content/error-messages.md
@@ -9,24 +9,28 @@ An error message is a message indicating something went wrong. A user typically 
 | **Before**                      | **After**                  |
 |---------------------------------|----------------------------|
 | You entered the wrong password. | The password is incorrect. |
+<br />
 
 **Give users a next step**: A user should never feel stuck. If they’re hit with an error, give them the information they need to continue with their task.
 
 |**Before**  | **After** |
 |------------|-----------|
 | Your list already has the maximum number of items. You are not able to continue customizing. | Your list has the maximum number of items. To continue customizing, remove one item. |
+<br />
 
 **Avoid jargon**: Error messages are frustrating enough without technical terms that users might not understand. Avoid jargon and use terms that are familiar to your users.
 
 |**Before**  | **After** |
 |------------|-----------|
 | Error code 5959: Outdated version information. Task termination pending. | Your task is outdated. To keep it active, update its version. |
+<br />
 
 **Include the right amount of description**: Tell your user what is wrong. An error without an explanation can add to their frustration and prevent them from finding a solution.
 
 |**Before**  | **After** |
 |------------|-----------|
 | An error occurred. The email cannot be sent. | To send this email, turn on your email permissions in user settings. |
+<br />
 
 However, don’t include too much information. The user doesn’t need to know exactly what is going on behind the scenes. Only give them information about what went wrong and what they can do next.
 

--- a/packages/v4/src/content/design-guidelines/content/error-messages.md
+++ b/packages/v4/src/content/design-guidelines/content/error-messages.md
@@ -6,34 +6,54 @@ An error message is a message indicating something went wrong. A user typically 
 
 **Don’t blame users**. A user should never feel like the error is their fault. Avoid language like “You did something wrong.”
 
+<div class="ws-content-table">
+
 | **Before**                      | **After**                  |
 |---------------------------------|----------------------------|
 | You entered the wrong password. | The password is incorrect. |
+
+</div>
 <br />
 
 **Give users a next step**: A user should never feel stuck. If they’re hit with an error, give them the information they need to continue with their task.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | Your list already has the maximum number of items. You are not able to continue customizing. | Your list has the maximum number of items. To continue customizing, remove one item. |
+
+</div>
 <br />
 
 **Avoid jargon**: Error messages are frustrating enough without technical terms that users might not understand. Avoid jargon and use terms that are familiar to your users.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | Error code 5959: Outdated version information. Task termination pending. | Your task is outdated. To keep it active, update its version. |
+
+</div>
 <br />
 
 **Include the right amount of description**: Tell your user what is wrong. An error without an explanation can add to their frustration and prevent them from finding a solution.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | An error occurred. The email cannot be sent. | To send this email, turn on your email permissions in user settings. |
+
+</div>
 <br />
 
 However, don’t include too much information. The user doesn’t need to know exactly what is going on behind the scenes. Only give them information about what went wrong and what they can do next.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | Your information cannot be saved. Our system is currently designed to accommodate 1 record per user. The system memory is unable to store more at this time. | Only 1 record can be saved. To continue, remove one of your records. |
+
+</div>

--- a/packages/v4/src/content/design-guidelines/content/numerics.md
+++ b/packages/v4/src/content/design-guidelines/content/numerics.md
@@ -50,6 +50,8 @@ Using **absolute** or **relative** timestamps will depend on the context. If you
 
 If users are interested in how long ago an event occurred, use a relative timestamp. When reporting relative time, follow these examples:
 
+<div class="ws-content-table">
+
 | **Time frame**      | **Usage**              |
 |---------------------|------------------------|
 | 0–60 seconds        | Just now               |
@@ -61,12 +63,18 @@ If users are interested in how long ago an event occurred, use a relative timest
 | 1 year+             | 21 Jan 2020            |
 | Exact date and time | 21 Jan 2020, 23:33 UTC |
 
+</div>
+
 ## Numbers and currency
 In a UI, use numerals instead of written numbers. 
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | Your transaction will be complete in three business days. | Your transaction will be complete in 3 business days. |
+
+</div>
 
 For larger numbers, add a comma after every 3 digits from the right. 
 

--- a/packages/v4/src/content/design-guidelines/content/product-tours.md
+++ b/packages/v4/src/content/design-guidelines/content/product-tours.md
@@ -8,18 +8,30 @@ In product tours, your UX copy is never strictly to tell a user *how* something 
 
 **Focus on the user’s goals**: Emphasize what the user can do with the product.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | We introduced a new feature for designing called Flyer Fact. Discover how it works by taking a tour to learn more.<br />**OK \| Cancel** | Create consistency and design faster with Flyer Fact.<br />**Start tour \| Not now** |
 
+</div>
+
 **Be conversational**: Imagine that you’re sitting beside the user and walking them through the product. Avoid jargon and be casual.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | There are three major areas of Flyer Fact: components, layouts, and documentation. These are for designers to utilize in order to build user experiences that serve the needs of their users. | Create accessible and intuitive interfaces with Flyer Fact’s components, layouts, and documentation. |
 
+</div>
+
 **Empathize with the user**: Learning new things can be scary, so don’t stuff your onboarding flow with exclamation marks, and avoid telling the user how hard you worked on the new tool or how excited you are. Instead, understand that the user might be a little intimidated. Focus on giving them information and guidance in a straightforward way.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | We are so excited to announce the Flyer Fact redesign! We can’t wait to show you around. | Flyer Fact has a new look. Let’s explore what you can do. |
+
+</div>

--- a/packages/v4/src/content/design-guidelines/content/punctuation.md
+++ b/packages/v4/src/content/design-guidelines/content/punctuation.md
@@ -9,9 +9,13 @@ Avoid using ampersands, and use "and" instead.
 ## Referring to text in the UI
 Use bold text (not quotation marks) when referring to an element or text in the UI.
 
+<div class="ws-content-table">
+
 | Before                             | After                                |
 |------------------------------------|--------------------------------------|
 | Add user to the “Group title” team | Add user to the **Group title** team |
+
+</div>
 
 ## Commas
 When a conjunction connects two independent clauses, a comma should precede it. Also put a comma before “and” if it’s the Oxford comma.
@@ -24,9 +28,13 @@ Examples:
 ## Ellipses (...)
 Ellipses (...) are commonly used when information is omitted. You might use ellipses when you cannot fit all words onto a line or when you remove less relevant information (like in a quote).
 
+<div class="ws-content-table">
+
 |**Before ellipses**  | **After ellipses** |
 |---------------------|--------------------|
 | They said, “For many reasons, I think the PatternFly community is great.” | They said, “...I think the PatternFly community is great.” |
+
+</div>
 
 Ellipses can also be used in more creative contexts to signify someone’s thoughts or speech, like a pause for thinking.
 
@@ -59,16 +67,24 @@ Use exclamation marks sparingly. Don’t use one to generate excitement; only us
 
 To more accurately capture human expression, use an exclamation mark after just a few words, not after a long sentence.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | Congratulations on creating an account! | Congratulations! You created an account. |
 
+</div>
+
 ## Parallel structure
 All items in a list or series should be of the same part of speech.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | Remember these important tips: Write clearly; conduct research; spelling and grammar. | Remember these important tips: Write clearly; conduct research; use correct spelling and grammar. |
+
+</div>
 
 ## Parentheses 
 Do not use parentheses to indicate a possible plural of something, like "Account(s)." If a user can select one thing or multiple things, use the plural form.

--- a/packages/v4/src/content/design-guidelines/content/sentence-structure.md
+++ b/packages/v4/src/content/design-guidelines/content/sentence-structure.md
@@ -9,20 +9,32 @@ Use the first person "I" when the user is agreeing to something. For example, a 
 
 Try to avoid using third person "he/she/they/it." Third person sounds formal and disconnected from the user.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | Users can simplify their designs with PatternFly. | Simplify your designs with PatternFly. |
+
+</div>
 
 Use the active voice whenever possible. The active voice makes a sentence shorter and gets the point across faster.
 
 The active voice is when the subject of the sentence performs the action. The passive voice is when the subject of the sentence receives the action.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | The book is being read by Matt. | Matt is reading the book. |
 
+</div>
+
 There are some occasions when the [passive voice is appropriate](https://writing.wisc.edu/handbook/style/ccs_activevoice/), like when you don’t wish to point out a subject or when you want to emphasize an action. Also, use the passive voice to avoid assigning blame to a user, especially in error messages.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | You entered the wrong password. | The password is incorrect. |
+
+</div>

--- a/packages/v4/src/content/design-guidelines/content/ux-writing-best-practices.md
+++ b/packages/v4/src/content/design-guidelines/content/ux-writing-best-practices.md
@@ -43,37 +43,57 @@ Users carry around a lot of baggage, so it’s important to know where they’re
 ## Use positive, action-oriented language
 Focus on what the user needs to do in order to complete the task or reach their goal.
 
+<div class="ws-content-table">
+
 |**Before**  | **After** |
 |------------|-----------|
 | Your user settings do not allow you to access this file. | To access this file, adjust your user settings. |
 
+</div>
+
 ## Lead with the benefit
 Users want to know why they should do something. What’s in it for them? They typically focus on the beginning of a sentence, so make your instruction worth it by starting with the outcome—in other words, the benefit.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | Install this extension to learn more about email. | To learn more about email, install this extension. |
 
+</div>
+
 ## Sound like a person
 Jargon, bizpeak, and formal language make you sound more like a brochure than a human. Users need to relate to your brand and like you before they can trust you. Talk with them as people using familiar, conversational words.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | Utilizing the open source phenomenon allows you to leverage collaborative communications. | Open source is great for collaboration. |
 
+</div>
+
 ## Be clear and concise
 Dr. Seuss says it best: “So the writer who breeds more words than he needs, is making a chore for the reader who reads.” Use plain language, and don’t use more words than you need. Chunk content into short, related sections, and avoid long paragraphs or strings of text.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | Make the decision to send a notification to your administrator. | Notify your administrator. |
 
+</div>
+
 ## Be consistent
 Stick with the same terminology to describe actions and objects across the entire user experience. Using two terms interchangeably—even when they mean the same thing—can confuse users.
+
+<div class="ws-content-table">
 
 |**Before**  | **After** |
 |------------|-----------|
 | Log in to your account only. Never sign in to your friend’s account. | Log in to your account only. Never log in to your friend’s account. |
+
+</div>
 
 ## Align with your brand
 As mentioned in the brand section, make sure your UX copy reflects your brand voice. UX copy is not just for adding clarity and guiding users through the interface. You’re also creating a user experience with your words, making a product interaction sound, feel, and look like a human conversation.


### PR DESCRIPTION
Closes #2063 

This PR wraps markdown tables within the `UX writing` section with `<div class="ws-content-table">` to apply fixed `table-layout` styling.

Note: Table at bottom of `Terminology` section remains unchanged, as do tables outside of the `UX writing` section, ex: http://localhost:8003/guidelines/filters