### PR TITLE
updated width to max-width

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -360,5 +360,5 @@
 }
 
 .ws-mdx-content-content {
-  width: 832px;
+  max-width: 832px;
 }


### PR DESCRIPTION
Closes #2078 

Changes `width` property to `max-width` so content doesn't overflow off smaller screens