### PR TITLE
change cacheGroups, add lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "develop": "yarn develop:v4",
     "develop:v4": "yarn workspace patternfly-org-4 develop",
     "build": "yarn build:v4",
-    "build:analyze": "yarn workspace patternfly-org-4 build:analyze && yarn copy:v5",
+    "build:analyze": "yarn workspace patternfly-org-4 build:analyze && yarn copy:v4",
     "build:v3": "yarn workspace patternfly-org-3 build && yarn copy:v3",
     "build:v4": "yarn workspace patternfly-org-4 build && yarn copy:v4",
     "copy:v3": "rm -rf build/patternfly-org/v3 && mkdir -p build/patternfly-org && cp -r packages/v3/_site build/patternfly-org/v3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "develop": "yarn develop:v4",
     "develop:v4": "yarn workspace patternfly-org-4 develop",
     "build": "yarn build:v4",
+    "build:analyze": "yarn workspace patternfly-org-4 build:analyze && yarn copy:v5",
     "build:v3": "yarn workspace patternfly-org-3 build && yarn copy:v3",
     "build:v4": "yarn workspace patternfly-org-4 build && yarn copy:v4",
     "copy:v3": "rm -rf build/patternfly-org/v3 && mkdir -p build/patternfly-org && cp -r packages/v3/_site build/patternfly-org/v3",

--- a/packages/theme-patternfly-org/package.json
+++ b/packages/theme-patternfly-org/package.json
@@ -34,6 +34,7 @@
     "html-formatter": "^0.1.9",
     "html-webpack-plugin": "^4.4.1",
     "js-yaml": "^3.14.0",
+    "lodash-es": "^4.17.15",
     "mdast-util-to-hast": "^9.1.0",
     "mdurl": "^1.0.0",
     "mini-css-extract-plugin": "^0.11.1",

--- a/packages/theme-patternfly-org/scripts/webpack/webpack.base.config.js
+++ b/packages/theme-patternfly-org/scripts/webpack/webpack.base.config.js
@@ -112,6 +112,7 @@ module.exports = (_env, argv) => {
         './routes-client': path.resolve(process.cwd(), 'patternfly-docs.routes.js'),
         './routes-generated': path.resolve(process.cwd(), 'src/generated/index.js'),
         'buble': '@philpl/buble', // https://github.com/FormidableLabs/react-live#what-bundle-size-can-i-expect
+        'lodash': 'lodash-es' // Sanely bundle react-charts.
       },
       modules: [
         'node_modules',

--- a/packages/theme-patternfly-org/scripts/webpack/webpack.client.config.js
+++ b/packages/theme-patternfly-org/scripts/webpack/webpack.client.config.js
@@ -40,26 +40,32 @@ const clientConfig = async (env, argv) => {
         chunks: 'all',
         // https://webpack.js.org/plugins/mini-css-extract-plugin/#extracting-all-css-in-a-single-file
         cacheGroups: {
-          // We need patternfly.css to come before our styles because of selector specificity
           vendorStyles: {
             test: /[\\/]node_modules[\\/].*\.css$/,
-            priority: 2
+            priority: 10
           },
           mainStyles: {
             test: /\.css$/,
-            priority: 1
+            priority: 9
           },
+          // This speeds up reloads 2x in React and doesn't affect org's reload times
           ...(!isProd && {
-            // This speeds up reloads 2x in React, doesn't affect org's
             reactPackage: {
               test: reactJSRegex,
               name(module, _chunks, cacheGroupKey) {
                 const package = module.identifier().match(reactJSRegex)[1];
                 return `${cacheGroupKey}-${package}`;
               },
-              priority: 3
-            }
-          })
+              reuseExistingChunk: true,
+              priority: 5
+            },
+          }),
+          defaultVendors: {
+            test: /[\\/]node_modules[\\/]/,
+            enforce: true,
+            reuseExistingChunk: true,
+            priority: 3
+          },
         },
       },
       minimize: isProd ? true : false,

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -6,8 +6,8 @@
   "author": "Red Hat",
   "license": "MIT",
   "scripts": {
+    "analyze": "theme-patternfly-org build all --analyze",
     "build": "theme-patternfly-org build all",
-    "build:analyze": "theme-patternfly-org build all --analyze",
     "build:server": "theme-patternfly-org build server",
     "build:client": "theme-patternfly-org build client",
     "clean": "rm -rf .cache public size-plugin.json src/generated/**/*.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,6 +9348,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"


### PR DESCRIPTION
~3s faster reload times in React. The theme, `@patternfly/react-*` packages, and `node_modules` packages are now nicely split:
![image](https://user-images.githubusercontent.com/47335686/93635687-b7bee700-f9c0-11ea-88dd-2484b37dd381.png)
