### PR TITLE
fix(docs): fixed MD sourcing to display React docs & React demos tabs correctly

### DIFF
--- a/packages/v4/patternfly-docs.source.js
+++ b/packages/v4/patternfly-docs.source.js
@@ -31,10 +31,14 @@ module.exports = (sourceMD, sourceProps) => {
   const reactChartsPath = require
     .resolve('@patternfly/react-charts/package.json')
     .replace('package.json', 'src');
+  const reactDatetimePath = require
+  .resolve('@patternfly/react-datetime/package.json')
+  .replace('package.json', 'src');
   const reactPropsIgnore = '**/*.test.tsx';
   sourceProps(path.join(reactCorePath, '/**/*.tsx'), reactPropsIgnore);
   sourceProps(path.join(reactTablePath, '/**/*.tsx'), reactPropsIgnore);
   sourceProps(path.join(reactChartsPath, '/**/*.tsx'),reactPropsIgnore);
+  sourceProps(path.join(reactDatetimePath, '/**/*.tsx'),reactPropsIgnore);
 
   // React MD
   sourceMD(path.join(reactCorePath, '/**/examples/*.md'), 'react');
@@ -46,6 +50,9 @@ module.exports = (sourceMD, sourceProps) => {
 
   // Charts MD (no demos yet)
   sourceMD(path.join(reactChartsPath, '/**/examples/*.md'), 'react');
+
+  // Datetime MD (no demos yet)
+  sourceMD(path.join(reactDatetimePath, '/**/examples/*.md'), 'react');
 
   // Release notes
   sourceMD(require.resolve('@patternfly/patternfly/RELEASE-NOTES.md'), 'html');

--- a/packages/v4/patternfly-docs.source.js
+++ b/packages/v4/patternfly-docs.source.js
@@ -42,11 +42,11 @@ module.exports = (sourceMD, sourceProps) => {
 
   // React MD
   sourceMD(path.join(reactCorePath, '/**/examples/*.md'), 'react');
-  sourceMD(path.join(reactCorePath, '/**/demos/**/*.md'), 'react');
+  sourceMD(path.join(reactCorePath, '/**/demos/**/*.md'), 'react-demos');
 
   // React-table MD
   sourceMD(path.join(reactTablePath, '/**/examples/*.md'), 'react');
-  sourceMD(path.join(reactTablePath, '/**/demos/*.md'), 'react');
+  sourceMD(path.join(reactTablePath, '/**/demos/*.md'), 'react-demos');
 
   // Charts MD (no demos yet)
   sourceMD(path.join(reactChartsPath, '/**/examples/*.md'), 'react');


### PR DESCRIPTION
Closes #2182 

Adds Datetime package to MD docs sourcing to pull in React docs.
TODO: update versions/React release notes?