### PR TITLE
emptystateheadingfix

### DIFF
--- a/packages/v4/src/content/design-guidelines/components/empty-state/empty-state.md
+++ b/packages/v4/src/content/design-guidelines/components/empty-state/empty-state.md
@@ -180,7 +180,7 @@ If the success state appears in a full-page, you can choose to use the extra lar
 
 <img src="./img/xl-success.png" alt="Example of success full page" width="990"/> 
 
-## Addition or creation 
+### Addition or creation 
 In some situations, users may need to add or create something to view associated information. Let them know what they need to add and guide them with calls-to-action to lead them the right way.
 
 <img src="./img/add-or-create.png" alt="Example of add empty state" width="990"/> 


### PR DESCRIPTION
Just noticed that one of the headers in the empty state examples was H2 instead of H3