### PR TITLE
empty state header fix

### DIFF
--- a/packages/v4/src/content/design-guidelines/components/empty-state/empty-state.md
+++ b/packages/v4/src/content/design-guidelines/components/empty-state/empty-state.md
@@ -184,7 +184,7 @@ If the success state appears in a full-page, you can choose to use the extra lar
 
 <img src="./img/xl-success.png" alt="Example of success full page" width="990"/> 
 
-## Addition or creation 
+### Addition or creation 
 In some situations, users may need to add or create something to view associated information. Let them know what they need to add and guide them with calls-to-action to lead them the right way.
 
 <img src="./img/add-or-create.png" alt="Example of add empty state" width="990"/> 


### PR DESCRIPTION
just fixed a header in the empty state examples that was supposed to be H3 but was H2.