### PR TITLE
fix(docs): fix double dashes where they've been replaced by em dashes

### DIFF
--- a/packages/v4/src/content/design-guidelines/components/banner/banner.md
+++ b/packages/v4/src/content/design-guidelines/components/banner/banner.md
@@ -18,7 +18,7 @@ PatternFly offers five different banner types detailed below.
 |Info     |Blue <br />(--pf-global--info-color--100)|Black| Use for general information messages |
 |Danger  |Red <br />(--pf-global--danger-color--100) |White| Use for high severity messages
 |Success|Green <br />(--pf-global--success-color--100) | White | Use for positive, success messages|
-|Warning |Orange <br />(--pf-global—warning-color--100) | Black | Use for warning or medium severity messages |
+|Warning |Orange <br />(--pf-global--warning-color--100) | Black | Use for warning or medium severity messages |
 <br />
 PatternFly suggests that users adopt one of these five colors, as they’ve been tested against their text colors for accessibility. However, if colors outside of these suggestions are used, we encourage using discretion when selecting the inner text color.
  

--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.md
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.md
@@ -29,7 +29,7 @@ If you're a developer, check out our [getting started](/get-started/develop#usin
       </FlexItem>
       <FlexItem>
         <p>Small (10px)</p>
-        <code>--pf-global--icon--FontSize—sm</code>
+        <code>--pf-global--icon--FontSize--sm</code>
       </FlexItem>
     </Flex>
     <Flex className="ws-icon-sizes ws-icon-sizes-md" alignItems={{ default: 'alignItemsFlexStart' }}>
@@ -38,7 +38,7 @@ If you're a developer, check out our [getting started](/get-started/develop#usin
       </FlexItem>
       <FlexItem>
         <p>Medium (18px)</p>
-        <code>--pf-global--icon--FontSize—md</code>
+        <code>--pf-global--icon--FontSize--md</code>
       </FlexItem>
     </Flex>
     <Flex className="ws-icon-sizes ws-icon-sizes-lg" alignItems={{ default: 'alignItemsFlexStart' }}>
@@ -47,7 +47,7 @@ If you're a developer, check out our [getting started](/get-started/develop#usin
       </FlexItem>
       <FlexItem>
         <p>Large (24px)</p>
-        <code>--pf-global--icon--FontSize—lg</code>
+        <code>--pf-global--icon--FontSize--lg</code>
       </FlexItem>
     </Flex>
     <Flex className="ws-icon-sizes ws-icon-sizes-xl" alignItems={{ default: 'alignItemsFlexStart' }}>
@@ -56,7 +56,7 @@ If you're a developer, check out our [getting started](/get-started/develop#usin
       </FlexItem>
       <FlexItem>
         <p>X-large (54px)</p>
-        <code>--pf-global--icon--FontSize—xl</code>
+        <code>--pf-global--icon--FontSize--xl</code>
       </FlexItem>
     </Flex>
   </GridItem>


### PR DESCRIPTION
Closes #2236 

This PR changes incorrect em dashes (—) to double dashes (--) on Icons page and Banner design guidelines in code examples.