### PR TITLE
chore(docs): add meta description tag

### DIFF
--- a/packages/theme-patternfly-org/templates/html.ejs
+++ b/packages/theme-patternfly-org/templates/html.ejs
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+    <meta name="description" content="PatternFly is Red Hat's open source design system. It consists of components, documentation, and code for building enterprise applications at scale.">
     <title><%= title %></title>
     <%= htmlWebpackPlugin.tags.headTags %>
   </head>


### PR DESCRIPTION
Closes #2249 

This PR adds a `<meta name="description"` tag to the site with a content attribute describing the site. 