### PR TITLE
change "PR name" to "branch name"

### DIFF
--- a/packages/v4/src/content/contribute/design-guidelines/design-guidelines.md
+++ b/packages/v4/src/content/contribute/design-guidelines/design-guidelines.md
@@ -56,14 +56,14 @@ If you’re creating a new PR:
 
     a. Type `git fetch upstream` and press **Enter**. 
     
-    b. Create a new branch by typing `git checkout -b [name of your PR] upstream/master` and press **Enter**. For example, if your PR name is iss2020, you would type `git checkout -b iss2020 upstream/master`.  
+    b. Create a new branch by typing `git checkout -b [name of your branch] upstream/master` and press **Enter**. For example, if your branch name is iss2020, you would type `git checkout -b iss2020 upstream/master`.  
 
 3. Edit files by typing `code .` and then pressing **Enter**. This will open Visual Studio Code (if this doesn’t work, you can manually open the Visual Studio Code app).
 
 If you’re editing an existing PR:
 
 1. Type git fetch upstream and press **Enter**.
-2. Type `git checkout [name of your existing PR]` and press **Enter**. For example, if your existing PR name is iss2020, you would type `git checkout iss2020`. 
+2. Type `git checkout [name of your existing branch]` and press **Enter**. For example, if your existing branch name is iss2020, you would type `git checkout iss2020`. 
 3. If GitHub shows merge conflicts, type `git pull upstream master` and press **Enter**.
 4. Edit files by typing  `code .` and pressing **Enter**. This will open your Visual Studio Code (if this doesn’t work, you can manually open the VIsual Studio Code app). 
 
@@ -171,7 +171,7 @@ Once you’re finished making changes, stage them in Visual Studio Code:
     
     b. Type  `git commit -m ‘title of your PR’` and press **Enter**. You can edit this title later in GitHub if necessary, but it must be placed between single quote marks ( ‘ ) for now. Be sure to type these single quote marks—copy/pasting them from this page won’t register correctly. 
     
-    c. Type `git push origin --set-upstream [name of your PR]` and press **Enter**. 
+    c. Type `git push origin --set-upstream [name of your branch]` and press **Enter**. 
 
 ## Step 10: Create a pull request 
 
@@ -185,7 +185,7 @@ On GitHub, create a pull request to submit your changes:
 
 <img src="./image-9-pr.png" alt="creating a pull request screen in GitHub" /> 
 
-3. Change your PR name and/or add a comment to your PR if you need to.
+3. Change your PR title and/or add a comment to your PR if you need to.
 4. Attach all of your image files to this PR so that they can be updated in the original document, merged back into the main branch, and uploaded back to Sketch Cloud for future access.
 5. Tag [mmenestr](https://github.com/mmenestr) to initiate a final review. 
 6. Submit the PR.  
@@ -197,7 +197,7 @@ If your PR has merge conflicts in Github:
 3. Solve the merge conflicts.
 4. Type `git add -A` and press **Enter**.
 5. Type `git rebase --continue` and press **Enter**.
-6. Type `git push --force origin <name of your PR>` and press **Enter**. 
+6. Type `git push --force origin <name of your branch>` and press **Enter**. 
 
 <img src="./image-10-conflicts.png" alt="code conflicts in Microsoft Visual Studio Code" /> 
 


### PR DESCRIPTION
Changing the words "PR name" to "branch name" to alleviate confusion. Right now, the mention of PR title vs PR name gets confused. In reality, what was being referred to as "PR name" is actually the "branch name", so I changed it to reflect that!