### PR TITLE
Add S and / as hotkeys to open the search bar, and ESC to close it

### DIFF
--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -48,6 +48,24 @@ const HeaderTools = ({
   );
   const searchRef = React.useRef();
 
+  useEffect(() => {
+    const handleSearchHotkeys = (event) => {
+      const tagName = event.target.tagName.toLowerCase();
+      if (
+        (event.code === 'Slash' || event.code === 'KeyS') &&
+        tagName !== 'input' &&
+        tagName !== 'textarea'
+      ) {
+        setSearchExpanded(true);
+        setTimeout(() => searchRef.current && searchRef.current.focus(), 0);
+      } else if (event.code === 'Escape' && event.target === searchRef.current) {
+        setSearchExpanded(false);
+      }
+    };
+    window.addEventListener('keyup', handleSearchHotkeys);
+    return () => window.removeEventListener('keyup', handleSearchHotkeys);
+  }, []);
+
   return (
     <PageHeaderTools>
       {hasSearch && (


### PR DESCRIPTION
Based on a conversation with @redallen . Just a nice little shortcut easter egg for those of us vim nerds who like to quickly start a search by pressing the `/` key. Also includes `S` as an alternate key in case `/` is already bound (in Firefox, it triggers the "find in page" bar). The search box won't be focused if the key press is coming from within an `<input>` or `<textarea>` in one of the examples. Also, if the user presses the `Escape` key while they are focused in the search box, it will close.

Before this approach, I tried to use the `keyboardShortcuts` option for Algolia detailed at https://github.com/algolia/autocomplete.js#global-options, but because our search input is not in the DOM until we call `setSearchExpanded`, the built in keyboard shortcut wasn't working. I couldn't see any callback I could give Algolia to have it set that state when the key is pressed, and after adding my listener to call `setSearchExpanded` I found that it still wasn't focusing the bar (because the built in handler ran before React mounted the search input). So I decided to just handle it all in my own event handler.

This is such a tiny unimportant thing, but I find it really nice to be able to quickly jump to the search this way, especially since I search the docs so often.