### PR TITLE
fix whitespace in JSXText

### DIFF
--- a/packages/theme-patternfly-org/helpers/buble.js
+++ b/packages/theme-patternfly-org/helpers/buble.js
@@ -53,10 +53,9 @@ const generator = Object.assign({}, baseGenerator, {
     this[node.expression.type](node.expression, state);
   },
   JSXText(node, state) {
-    node.value = node.value.trim();
     if (node.value) {
       state.write(',"');
-      state.write(node.value.replace(/"/g, '\\"').replace(/\n/g, ''));
+      state.write(node.value.replace(/"/g, '\\"').replace(/\n/g, ' '));
       state.write('"');
     }
   },

--- a/packages/theme-patternfly-org/helpers/buble.js
+++ b/packages/theme-patternfly-org/helpers/buble.js
@@ -53,9 +53,12 @@ const generator = Object.assign({}, baseGenerator, {
     this[node.expression.type](node.expression, state);
   },
   JSXText(node, state) {
+    if (node.value.trim() === '') {
+      node.value = null;
+    }
     if (node.value) {
       state.write(',"');
-      state.write(node.value.replace(/"/g, '\\"').replace(/\n/g, ' '));
+      state.write(node.value.replace(/"/g, '\\"'));
       state.write('"');
     }
   },
@@ -102,6 +105,7 @@ function transform(code) {
     allowReturnOutsideFunction: true
   });
   code = generate(ast, { generator });
+  console.log('code', code);
   return { code };
 }
 


### PR DESCRIPTION
Fixes problem @jschuler reported in https://github.com/patternfly/patternfly-react/pull/5172 where there was no space between "hi" and "there" for examples like this:
```jsx
<div>
  hi <a href="#">there</a>
</div>
```
and this:
```jsx
<div>
  hi
  <a href="#">there</a>
</div>
```