### PR TITLE
Add ResourcesEmptyIcon to icons page

### DIFF
--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.js
@@ -1112,10 +1112,17 @@ export const iconsData = [
   },
   {
     "Style": "pf-icon",
+    "Name": "pf-icon-resources-empty",
+    "React_name": "ResourcesEmptyIcon",
+    "Type": "Status",
+    "Contextual_usage": "Represents status: is empty"
+  },
+  {
+    "Style": "pf-icon",
     "Name": "pf-icon-resources-almost-empty",
     "React_name": "ResourcesAlmostEmptyIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: almost empty"
+    "Contextual_usage": "Represents status: is almost empty"
   },
   {
     "Style": "pf-icon",


### PR DESCRIPTION
Following up on https://github.com/patternfly/patternfly-design/issues/930#issuecomment-735936630.

cc @redallen @bdellasc @mcoker @evwilkin 