### PR TITLE
upgrade react-docgen

### DIFF
--- a/packages/theme-patternfly-org/package.json
+++ b/packages/theme-patternfly-org/package.json
@@ -46,7 +46,7 @@
     "prismjs": "^1.17.1",
     "puppeteer": "^5.3.1",
     "puppeteer-cluster": "^0.22.0",
-    "react-docgen": "^5.3.0",
+    "react-docgen": "^5.3.1",
     "react-live": "^2.2.0",
     "react-ssr-prepass": "^1.2.1",
     "remark-footnotes": "^1.0.0",

--- a/packages/theme-patternfly-org/scripts/tsDocgen.js
+++ b/packages/theme-patternfly-org/scripts/tsDocgen.js
@@ -45,7 +45,7 @@ function getComponentMetadata(filename, sourceText) {
     );
   } catch (err) {
     // eslint-disable-next-line no-console
-    // console.warn('No component found in', filename);
+    // console.warn(`No component found in ${filename}:`, err);
   }
 
   return (parsedComponents || []).filter(parsed => parsed && parsed.displayName);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,10 +3358,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@^0.13.2:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
-  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
+ast-types@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
   dependencies:
     tslib "^2.0.1"
 
@@ -11953,14 +11953,14 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-docgen@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.3.0.tgz#9aabde5e69f1993c8ba839fd9a86696504654589"
-  integrity sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==
+react-docgen@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.3.1.tgz#940b519646a6c285c2950b96512aed59e8f90934"
+  integrity sha512-YG7YujVTwlLslr2Ny8nQiUfbBuEwKsLHJdQTSdEga1eY/nRFh/7LjCWUn6ogYhu2WDKg4z+6W/BJtUi+DPUIlA==
   dependencies:
     "@babel/core" "^7.7.5"
     "@babel/runtime" "^7.7.6"
-    ast-types "^0.13.2"
+    ast-types "^0.14.2"
     commander "^2.19.0"
     doctrine "^3.0.0"
     neo-async "^2.6.1"


### PR DESCRIPTION
5.3.1 fixes:
> /home/circleci/project/node_modules/@patternfly/react-table/src/components/Table/examples/Table.md
  1:1  warning  Prop component TableComposable missing from tsDocgen
  1:1  warning  Prop component Td missing from tsDocgen
  1:1  warning  Prop component Th missing from tsDocgen

Which is caused by no AST support for the optional chaining operator:
>  No component found in /Users/zallen/src/patternfly-org/node_modules/@patternfly/react-table/src/components/TableComposable/TableComposable.tsx: Error: did not recognize object of type "ChainExpression"
    at Object.getFieldNames (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/types.js:660:19)
    at visitChildren (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:184:36)
    at Visitor.PVp.visitWithoutReset (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:166:20)
    at NodePath.each (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path.js:87:26)
    at visitChildren (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:178:18)
    at Visitor.PVp.visitWithoutReset (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:166:20)
    at visitChildren (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:203:25)
    at Visitor.PVp.visitWithoutReset (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:166:20)
    at visitChildren (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:203:25)
    at Visitor.PVp.visitWithoutReset (/Users/zallen/src/patternfly-org/node_modules/ast-types/lib/path-visitor.js:166:20)