### PR TITLE
remove duplicate routes

### DIFF
--- a/packages/theme-patternfly-org/app.js
+++ b/packages/theme-patternfly-org/app.js
@@ -29,14 +29,25 @@ const SideNavRouter = () => {
       <Router id="ws-page-content-router">
         {Object.entries(routes)
           .map(([path, { Component, title, sources, katacodaLayout }]) => Component
-            ? <AppRoute key={path} path={path} default={path === '/404'} child={<Component />} katacodaLayout={katacodaLayout} />
-            : <AppRoute key={path} path={path + '/*'} child={
-                <MDXTemplate
-                  path={path}
-                  title={title}
-                  sources={sources}
-                />
-              } katacodaLayout={katacodaLayout} />
+            ? <AppRoute
+                key={path}
+                path={path}
+                default={path === '/404'}
+                child={<Component />}
+                katacodaLayout={katacodaLayout}
+              />
+            : <AppRoute
+                key={path}
+                path={path + '/*'}
+                child={
+                  <MDXTemplate
+                    path={path}
+                    title={title}
+                    sources={sources}
+                  />
+                }
+                katacodaLayout={katacodaLayout}
+              />
           )
         }
       </Router>

--- a/packages/theme-patternfly-org/scripts/webpack/getHtmlWebpackPlugins.js
+++ b/packages/theme-patternfly-org/scripts/webpack/getHtmlWebpackPlugins.js
@@ -60,7 +60,7 @@ async function getHtmlWebpackPlugins(options) {
     .map(([url, { sources = [], title, isFullscreen }]) => [
       [url, { title, isFullscreen }],
       // Add pages for sources
-      ...sources.map(source => [source.slug, source])
+      ...sources.slice(1).map(source => [source.slug, source])
     ])
     .flat()
     .sort();

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -138,7 +138,7 @@ export const MDXTemplate = ({
         {!isSinglePage && (
           <div className="pf-c-tabs ws-source-tabs">
             <ul className="pf-c-tabs__list">
-              {sourceKeys.map(source => (
+              {sourceKeys.map((source, index) => (
                 <li
                   key={source}
                   className={css(
@@ -146,7 +146,7 @@ export const MDXTemplate = ({
                     activeSource === source && 'pf-m-current'
                   )}
                 >
-                  <Link className="pf-c-tabs__link" to={`${path}/${source}`}>
+                  <Link className="pf-c-tabs__link" to={`${path}${index === 0 ? '' : '/' + source}`}>
                     {capitalize(source.replace('html', 'HTML').replace(/-/g, ' '))}
                   </Link>
                 </li>
@@ -166,7 +166,8 @@ export const MDXTemplate = ({
                 source.index = index;
                 return source;
               })
-              .map(MDXChildTemplate)}
+              .map(MDXChildTemplate)
+            }
           </Router>
         </PageSection>
       )}


### PR DESCRIPTION
Only create page for `/components/about-modal` and NOT `/components/about-modal/react` (or whatever the first tab is in the source order).

Reduce number of pages by ~33%.

