### PR TITLE
fix(docs): add sidenav shadow on mobile, close sidenav on NavItem click on mobile

### DIFF
--- a/packages/theme-patternfly-org/components/sideNav/sideNav.js
+++ b/packages/theme-patternfly-org/components/sideNav/sideNav.js
@@ -1,28 +1,32 @@
 import React from 'react';
 import { Link } from '../link/link';
-import { Nav, NavList, NavExpandable, capitalize } from '@patternfly/react-core';
+import { Nav, NavList, NavExpandable, PageContextConsumer, capitalize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { Location } from '@reach/router';
 import { slugger } from '../../helpers';
 import './sideNav.css';
 
 const NavItem = ({ text, href }) => (
-  <li key={href + text} className="pf-c-nav__item">
-    <Link
-      to={href}
-      getProps={({ isCurrent, href, location }) => {
-        const { pathname } = location;
-        return {
-          className: css(
-            'pf-c-nav__link',
-            (isCurrent || pathname.startsWith(href + '/')) && 'pf-m-current'
-          )
-        }}
-      }
-    >
-      {text}
-    </Link>
-  </li>
+  <PageContextConsumer key={href + text}>
+    {({ onNavToggle }) => (
+        <li key={href + text} className="pf-c-nav__item" onClick={window.innerWidth < 1200 ? onNavToggle : null}>
+          <Link
+            to={href}
+            getProps={({ isCurrent, href, location }) => {
+              const { pathname } = location;
+              return {
+                className: css(
+                  'pf-c-nav__link',
+                  (isCurrent || pathname.startsWith(href + '/')) && 'pf-m-current'
+                )
+              }}
+            }
+          >
+            {text}
+          </Link>
+        </li>
+    )}
+  </PageContextConsumer>
 );
 
 export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {

--- a/packages/theme-patternfly-org/components/sideNav/sideNav.js
+++ b/packages/theme-patternfly-org/components/sideNav/sideNav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from '../link/link';
-import { Nav, NavList, NavExpandable, PageContextConsumer, PageContextProvider, capitalize } from '@patternfly/react-core';
+import { Nav, NavList, NavExpandable, PageContextConsumer, capitalize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { Location } from '@reach/router';
 import { slugger } from '../../helpers';
@@ -33,7 +33,7 @@ const NavItem = ({ text, href }) => {
   )
 };
 
-export const SideNav = ({ groupedRoutes = {}, navItems = [], onNavToggle }) => {
+export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
   React.useEffect(() => {
     if (typeof window === 'undefined') {
       return;
@@ -50,39 +50,37 @@ export const SideNav = ({ groupedRoutes = {}, navItems = [], onNavToggle }) => {
   }, []);
   
   return (
-    <PageContextProvider value={{onNavToggle}}>
-      <Nav aria-label="Side Nav" theme="light">
-        <NavList className="ws-side-nav-list">
-          {navItems.map(({ section, text, href }) => section
-            ? (
-              <Location key={section}>
-                {({ location }) => {
-                  const isActive = location.pathname.startsWith(`${process.env.pathPrefix}/${slugger(section)}`);
-                  return (
-                    <NavExpandable
-                      title={capitalize(section.replace(/-/g, ' '))}
-                      isActive={isActive}
-                      isExpanded={isActive}
-                      className="ws-side-nav-group"
-                    >
-                      {Object.entries(groupedRoutes[section] || {})
-                        .filter(([, { hideNavItem }]) => !Boolean(hideNavItem))
-                        .map(([id, { slug }]) => ({ text: id, href: slug }))
-                        .sort(({ text: text1 }, { text: text2 }) => text1.localeCompare(text2))
-                        .map(NavItem)
-                      }
-                    </NavExpandable>
-                  );
-                }}
-              </Location>
-            )
-            : NavItem({
-                text: text || capitalize(href.replace(/\//g, '').replace(/-/g, ' ')),
-                href: href
-              })
-          )}
-        </NavList>
-      </Nav>
-    </PageContextProvider>
+    <Nav aria-label="Side Nav" theme="light">
+      <NavList className="ws-side-nav-list">
+        {navItems.map(({ section, text, href }) => section
+          ? (
+            <Location key={section}>
+              {({ location }) => {
+                const isActive = location.pathname.startsWith(`${process.env.pathPrefix}/${slugger(section)}`);
+                return (
+                  <NavExpandable
+                    title={capitalize(section.replace(/-/g, ' '))}
+                    isActive={isActive}
+                    isExpanded={isActive}
+                    className="ws-side-nav-group"
+                  >
+                    {Object.entries(groupedRoutes[section] || {})
+                      .filter(([, { hideNavItem }]) => !Boolean(hideNavItem))
+                      .map(([id, { slug }]) => ({ text: id, href: slug }))
+                      .sort(({ text: text1 }, { text: text2 }) => text1.localeCompare(text2))
+                      .map(NavItem)
+                    }
+                  </NavExpandable>
+                );
+              }}
+            </Location>
+          )
+          : NavItem({
+              text: text || capitalize(href.replace(/\//g, '').replace(/-/g, ' ')),
+              href: href
+            })
+        )}
+      </NavList>
+    </Nav>
   );
 }

--- a/packages/theme-patternfly-org/components/sideNav/sideNav.js
+++ b/packages/theme-patternfly-org/components/sideNav/sideNav.js
@@ -1,35 +1,39 @@
 import React from 'react';
 import { Link } from '../link/link';
-import { Nav, NavList, NavExpandable, PageContextConsumer, capitalize } from '@patternfly/react-core';
+import { Nav, NavList, NavExpandable, PageContextConsumer, PageContextProvider, capitalize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { Location } from '@reach/router';
 import { slugger } from '../../helpers';
 import './sideNav.css';
+import globalBreakpointXl from "@patternfly/react-tokens/dist/esm/global_breakpoint_xl";
 
-const NavItem = ({ text, href }) => (
-  <PageContextConsumer key={href + text}>
-    {({ onNavToggle }) => (
-        <li key={href + text} className="pf-c-nav__item" onClick={window.innerWidth < 1200 ? onNavToggle : null}>
-          <Link
-            to={href}
-            getProps={({ isCurrent, href, location }) => {
-              const { pathname } = location;
-              return {
-                className: css(
-                  'pf-c-nav__link',
-                  (isCurrent || pathname.startsWith(href + '/')) && 'pf-m-current'
-                )
-              }}
-            }
-          >
-            {text}
-          </Link>
-        </li>
-    )}
-  </PageContextConsumer>
-);
+const NavItem = ({ text, href }) => {
+  const isMobileView = window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
+  return (
+    <PageContextConsumer key={href + text}>
+      {({onNavToggle}) => (
+          <li key={href + text} className="pf-c-nav__item" onClick={() => isMobileView && onNavToggle()}>
+            <Link
+              to={href}
+              getProps={({ isCurrent, href, location }) => {
+                const { pathname } = location;
+                return {
+                  className: css(
+                    'pf-c-nav__link',
+                    (isCurrent || pathname.startsWith(href + '/')) && 'pf-m-current'
+                  )
+                }}
+              }
+            >
+              {text}
+            </Link>
+          </li>
+      )}
+    </PageContextConsumer>
+  )
+};
 
-export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
+export const SideNav = ({ groupedRoutes = {}, navItems = [], onNavToggle }) => {
   React.useEffect(() => {
     if (typeof window === 'undefined') {
       return;
@@ -46,37 +50,39 @@ export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
   }, []);
   
   return (
-    <Nav aria-label="Side Nav" theme="light">
-      <NavList className="ws-side-nav-list">
-        {navItems.map(({ section, text, href }) => section
-          ? (
-            <Location key={section}>
-              {({ location }) => {
-                const isActive = location.pathname.startsWith(`${process.env.pathPrefix}/${slugger(section)}`);
-                return (
-                  <NavExpandable
-                    title={capitalize(section.replace(/-/g, ' '))}
-                    isActive={isActive}
-                    isExpanded={isActive}
-                    className="ws-side-nav-group"
-                  >
-                    {Object.entries(groupedRoutes[section] || {})
-                      .filter(([, { hideNavItem }]) => !Boolean(hideNavItem))
-                      .map(([id, { slug }]) => ({ text: id, href: slug }))
-                      .sort(({ text: text1 }, { text: text2 }) => text1.localeCompare(text2))
-                      .map(NavItem)
-                    }
-                  </NavExpandable>
-                );
-              }}
-            </Location>
-          )
-          : NavItem({
-              text: text || capitalize(href.replace(/\//g, '').replace(/-/g, ' ')),
-              href: href
-            })
-        )}
-      </NavList>
-    </Nav>
+    <PageContextProvider value={{onNavToggle}}>
+      <Nav aria-label="Side Nav" theme="light">
+        <NavList className="ws-side-nav-list">
+          {navItems.map(({ section, text, href }) => section
+            ? (
+              <Location key={section}>
+                {({ location }) => {
+                  const isActive = location.pathname.startsWith(`${process.env.pathPrefix}/${slugger(section)}`);
+                  return (
+                    <NavExpandable
+                      title={capitalize(section.replace(/-/g, ' '))}
+                      isActive={isActive}
+                      isExpanded={isActive}
+                      className="ws-side-nav-group"
+                    >
+                      {Object.entries(groupedRoutes[section] || {})
+                        .filter(([, { hideNavItem }]) => !Boolean(hideNavItem))
+                        .map(([id, { slug }]) => ({ text: id, href: slug }))
+                        .sort(({ text: text1 }, { text: text2 }) => text1.localeCompare(text2))
+                        .map(NavItem)
+                      }
+                    </NavExpandable>
+                  );
+                }}
+              </Location>
+            )
+            : NavItem({
+                text: text || capitalize(href.replace(/\//g, '').replace(/-/g, ' ')),
+                href: href
+              })
+          )}
+        </NavList>
+      </Nav>
+    </PageContextProvider>
   );
 }

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.css
@@ -16,8 +16,10 @@
   margin-left: 8px;
 }
 
-.ws-page-sidebar {
-  box-shadow: none !important;
+@media (min-width: 1200px) {
+  .ws-page-sidebar {
+    box-shadow: none !important;
+  }
 }
 
 .ws-page-sidebar > .pf-c-page__sidebar-body {

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -196,8 +196,7 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
     <PageSidebar
       className="ws-page-sidebar"
       theme="light"
-      nav={<SideNav navItems={sideNavItems} groupedRoutes={groupedRoutes} onNavToggle={() => setNavOpen(!isNavOpen)} />}
-      isNavOpen={isNavOpen}
+      nav={<SideNav navItems={sideNavItems} groupedRoutes={groupedRoutes} />}
     />
   );
 

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -196,7 +196,8 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
     <PageSidebar
       className="ws-page-sidebar"
       theme="light"
-      nav={<SideNav navItems={sideNavItems} groupedRoutes={groupedRoutes} />}
+      nav={<SideNav navItems={sideNavItems} groupedRoutes={groupedRoutes} onNavToggle={() => setNavOpen(!isNavOpen)} />}
+      isNavOpen={isNavOpen}
     />
   );
 


### PR DESCRIPTION
Closes #2205 

This PR:
- Adds dropshadow to sidenav on mobile
- Closes sidenav on mobile when user clicks a page link in the sidenav by passing `onNavToggle` to `Sidenav` component & triggering in `onClick` in `navItem`