### PR TITLE
Update GitHub capitalization

### DIFF
--- a/packages/v3/source/get-started/index.html
+++ b/packages/v3/source/get-started/index.html
@@ -50,7 +50,7 @@ layout: page
             PatternFly is built on top of <a href="https://getbootstrap.com">Bootstrap 3</a> and is licensed <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>. Additionally, there are a number of <a href="{{ site.baseurl }}/get-started/repositories/">PatternFly JS framework implementations</a> available. We perform cross-browser testing with <a href="https://www.browserstack.com/">BrowserStack</a>.          </p>
           <ul class="list-unstyled">
             <li>
-              <a href="https://github.com/patternfly/">View PatternFly on Github</a>
+              <a href="https://github.com/patternfly/">View PatternFly on GitHub</a>
             </li>
           </ul>
         </div>

--- a/packages/v4/src/content/contribute/design-guidelines/design-guidelines.md
+++ b/packages/v4/src/content/contribute/design-guidelines/design-guidelines.md
@@ -190,7 +190,7 @@ On GitHub, create a pull request to submit your changes:
 5. Tag [mmenestr](https://github.com/mmenestr) to initiate a final review. 
 6. Submit the PR.  
 
-If your PR has merge conflicts in Github:
+If your PR has merge conflicts in GitHub:
 
 1. Return to your terminal and `type git fetch upstream` and press **Enter**. 
 2. Type `git rebase upstream/master` and ress **Enter**. 

--- a/packages/v4/src/content/contribute/design/design.md
+++ b/packages/v4/src/content/contribute/design/design.md
@@ -35,7 +35,7 @@ Before you begin the contribution process, follow [these guidelines](/get-starte
 Follow these steps and this [template format](https://documentcloud.adobe.com/link/track?uri=urn%3Aaaid%3Ascds%3AUS%3A28fd970d-8b77-4008-b598-b2f629bda589) to submit your designs:
 
 __1. Create an issue__
-  - Navigate to the [PatternFly page](https://github.com/patternfly) on Github and go to the [feature board](https://github.com/orgs/patternfly/projects/3)
+  - Navigate to the [PatternFly page](https://github.com/patternfly) on GitHub and go to the [feature board](https://github.com/orgs/patternfly/projects/3)
   - Open an issue for a new feature or comment on an existing issue for an enhancement
 
 __2. Propose a design__

--- a/packages/v4/src/content/design-guidelines/components/login-page/login-page.md
+++ b/packages/v4/src/content/design-guidelines/components/login-page/login-page.md
@@ -83,7 +83,7 @@ Please refer to branding guidelines when using logos for social login page. Exam
 
 * [Facebook brand guidelines](https://en.facebookbrand.com/guidelines/brand)
 * [Twitter brand guidelines](https://about.twitter.com/en_us/company/brand-resources.html)
-* [Github brand guidelines](https://github.com/logos)
+* [GitHub brand guidelines](https://github.com/logos)
 * [Stack Exchange brand guidelines](https://stackexchange.com/legal/trademark-guidance)
 * [Google brand guidelines](https://developers.google.com/identity/branding-guidelines)
 * [LinkedIn brand guidelines](https://brand.linkedin.com/)

--- a/packages/v4/src/pages/home.js
+++ b/packages/v4/src/pages/home.js
@@ -48,7 +48,7 @@ const HomePage = () => (
                 Get started
               </Link>
               <a className="pf-c-button pf4-c-button__cta-outline fadeIn animated fadeInFour" href="//github.com/patternfly" target="_blank">
-                <GithubIcon className="pf-u-mr-sm" />Github
+                <GithubIcon className="pf-u-mr-sm" />GitHub
               </a>
             </div>
           </TextContent>


### PR DESCRIPTION
Updates `Github` to `GitHub` in a few places, including the homepage button.