### PR TITLE
update sitemap to reflect new urls

### DIFF
--- a/packages/theme-patternfly-org/scripts/webpack/getHtmlWebpackPlugins.js
+++ b/packages/theme-patternfly-org/scripts/webpack/getHtmlWebpackPlugins.js
@@ -41,7 +41,7 @@ async function getHtmlWebpackPlugins(options) {
       filename: 'sitemap.xml',
       templateParameters: {
         urls: Object.entries(routes)
-          .map(([path, { sources }]) => sources ? sources.map(source => source.slug) : path)
+          .map(([path, { sources }]) => [path, ...(sources || []).slice(1).map(source => source.slug)])
           .flat()
       },
       inject: false,


### PR DESCRIPTION
This makes it difficult for Algoila to know whether urls like `https://www.patternfly.org/v4/get-started/design` or `https://www.patternfly.org/v4/charts/area-chart` are sourced from but this fix at least tells it they exist and that they exist only once.