### PR TITLE
fixed mailing list link

### DIFF
--- a/packages/v4/src/pages/community.js
+++ b/packages/v4/src/pages/community.js
@@ -39,9 +39,7 @@ const CommunityPage = () => (
             Flyers may be spread all over the globe, but we make sure to come together once a month to share updates and collect feedback. All meetings are recorded and published on <a href="https://www.youtube.com/channel/UCqLT0IEvYmb8z__9IFLSVyQ">PatternFly’s YouTube channel</a>, and you can join PatternFly’s mailing list for the invites.
           </p>
           <Title size="xl" className="ws-title" headingLevel="h4">
-          <Link to="#get-in-touch">
-            <strong>Join our mailing list</strong>
-          </Link>
+            <a href="https://www.redhat.com/mailman/listinfo/patternfly"><strong>Join our mailing list</strong></a>
           </Title>
         </GridItem>
         <GridItem>


### PR DESCRIPTION
Closes #2368 

This PR fixes the "Join our mailing list" link in the body copy of the Community page.