### PR TITLE
Add tooltip labels & hide Type column

### DIFF
--- a/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
@@ -38,7 +38,8 @@ export class IconsTable extends React.Component {
       'Icon',
       { title: 'Name', transforms: [sortable], props: { className: css(styles.modifiers.fitContent)} },
       'Style',
-      { title: 'Type', transforms: [sortable] },
+      'Type',
+      'Tooltip label', 
       { title: 'React', props: { className: css(styles.modifiers.fitContent)} },
       { title: 'Contextual usage', transforms: [sortable] }
     ],
@@ -96,7 +97,7 @@ export class IconsTable extends React.Component {
     );
   }
 
-  buildRows = ({Style = ' ', Name = ' ', React_name: ReactName = ' ', Type = ' ', Contextual_usage = ' ', color}, removeBorder = false) => {
+  buildRows = ({Style = ' ', Name = ' ', React_name: ReactName = ' ', Type = ' ', Contextual_usage = ' ', color, Label = ' '}, removeBorder = false) => {
     const hasIcon = ReactName !== ' ';
     const Icon = hasIcon
       ? icons[ReactName]
@@ -118,6 +119,10 @@ export class IconsTable extends React.Component {
         {
           title: Type,
           props: { column: 'Type' }
+        },
+        {
+          title: Label,
+          props: { column: 'Tooltip label' },
         },
         ReactName,
         {

--- a/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
@@ -39,7 +39,7 @@ export class IconsTable extends React.Component {
       { title: 'Name', transforms: [sortable], props: { className: css(styles.modifiers.fitContent)} },
       'Style',
       'Type',
-      'Tooltip label', 
+      { title: 'Tooltip label', props: { style: { overflow: 'visible' } }}, 
       { title: 'React', props: { className: css(styles.modifiers.fitContent)} },
       { title: 'Contextual usage', transforms: [sortable] }
     ],

--- a/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/IconsTable.js
@@ -39,9 +39,9 @@ export class IconsTable extends React.Component {
       { title: 'Name', transforms: [sortable], props: { className: css(styles.modifiers.fitContent)} },
       'Style',
       'Type',
-      { title: 'Tooltip label', props: { style: { overflow: 'visible' } }}, 
       { title: 'React', props: { className: css(styles.modifiers.fitContent)} },
-      { title: 'Contextual usage', transforms: [sortable] }
+      { title: 'Contextual usage', transforms: [sortable] },
+      { title: 'Tooltip label', props: { style: { overflow: 'visible' } }},
     ],
     sortBy: {}
   };
@@ -120,14 +120,14 @@ export class IconsTable extends React.Component {
           title: Type,
           props: { column: 'Type' }
         },
-        {
-          title: Label,
-          props: { column: 'Tooltip label' },
-        },
         ReactName,
         {
           title: Contextual_usage,
           props: { column: 'Contextual usage' }
+        },
+        {
+          title: Label,
+          props: { column: 'Tooltip label' },
         }
       ]
     }

--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.css
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.css
@@ -47,6 +47,10 @@
   cursor: pointer;
 }
 
+#ws-icons-table [data-label="Type"] {
+  display: none;
+}
+
 #all-icons ~ .ws-p > .ws-code {
   margin-left: 8px;
 }

--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.js
@@ -66,7 +66,7 @@ export const iconsData = [
     "React_name": "ArrowCircleUpIcon",
     "Type": "Status",
     "Contextual_usage": "Represents status: an item (such as a VM) is up",
-    "Tooltip": "Upgrade"
+    "Label": "Upgrade"
   },
   {
     "Style": "fas",
@@ -110,7 +110,7 @@ export const iconsData = [
       "React_name": "BellIcon",
       "Type": "Framework",
       "Contextual_usage": "Indicates the ability to open a notification drawer.",
-      "Tooltip": "Notifications"
+      "Label": "Notifications"
     },
     {
       "Style": "",
@@ -204,7 +204,7 @@ export const iconsData = [
     "React_name": "CogIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates availability of configurable settings",
-    "Tooltip": "Settings"
+    "Label": "Settings"
   },
   {
     "Style": "fas",
@@ -240,7 +240,7 @@ export const iconsData = [
     "React_name": "CopyIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the availability of a copy to clipboard function",
-    "Tooltip": "Copy"
+    "Label": "Copy"
   },
   {
     "Style": "fas",
@@ -276,7 +276,7 @@ export const iconsData = [
     "React_name": "DownloadIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates a download function is available",
-    "Tooltip": "Download"
+    "Label": "Download"
   },
   {
     "Style": "fas",
@@ -284,7 +284,7 @@ export const iconsData = [
     "React_name": "EllipsisVIcon",
     "Type": "Framework",
     "Contextual_usage": "Indicates a contextual menu of actions or additional actions is available",
-    "Tooltip": "More options"
+    "Label": "More options"
   },
   {
     "Style": "fas",
@@ -514,7 +514,7 @@ export const iconsData = [
     "React_name": "PencilAltIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the ability to edit an item",
-    "Tooltip": "Edit"
+    "Label": "Edit"
   },
   {
     "Style": "fas",
@@ -606,7 +606,7 @@ export const iconsData = [
     "React_name": "SearchIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates that that user may perform a search",
-    "Tooltip": "Search"
+    "Label": "Search"
   },
   {
     "Style": "fas",
@@ -614,7 +614,7 @@ export const iconsData = [
     "React_name": "SearchMinusIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the ability to zoom out",
-    "Tooltip": "Search minus"
+    "Label": "Search minus"
   },
   {
     "Style": "fas",
@@ -622,7 +622,7 @@ export const iconsData = [
     "React_name": "SearchPlusIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the ability to zoom in",
-    "Tooltip": "Search plus"
+    "Label": "Search plus"
   },
   {
     "Style": "fas",
@@ -651,7 +651,7 @@ export const iconsData = [
     "React_name": "SyncAltIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the availability of a sync action",
-    "Tooltip": "Sync; Refresh; Running"
+    "Label": "Sync; Refresh; Running"
   },
   {
     "Style": "fas",
@@ -715,7 +715,7 @@ export const iconsData = [
     "React_name": "TrashIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the ability to delete",
-    "Tooltip": "Delete"
+    "Label": "Delete"
   },
   {
     "Style": "fas",
@@ -960,7 +960,7 @@ export const iconsData = [
     "React_name": "ExportIcon",
     "Type": "Action",
     "Contextual_usage": "Indicates the ability to export a file or other data",
-    "Tooltip": "Export"
+    "Label": "Export"
   },
   {
     "Style": "pf-icon",

--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.js
@@ -4,28 +4,28 @@ export const iconsData = [
     "Name": "fa-angle-double-left",
     "React_name": "AngleDoubleLeftIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to navigate to the first page of a multi-page data set"
+    "Contextual_usage": "Indicates the ability to navigate to the first page of a multi-page data set",
   },
   {
     "Style": "fas",
     "Name": "fa-angle-double-right",
     "React_name": "AngleDoubleRightIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to navigate to the last page of a multi-page data set"
+    "Contextual_usage": "Indicates the ability to navigate to the last page of a multi-page data set",
   },
   {
     "Style": "fas",
     "Name": "fa-angle-down",
     "React_name": "AngleDownIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates expandable components such as accordions, progressive disclosures, or expandable lists are currently expanded. Clicking this will collapse the component."
+    "Contextual_usage": "Indicates expandable components such as accordions, progressive disclosures, or expandable lists are currently expanded. Clicking this will collapse the component.",
   },
   {
     "Style": "fas",
     "Name": "fa-angle-left",
     "React_name": "AngleLeftIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to navigate to the previous page of a multi-page data set"
+    "Contextual_usage": "Indicates the ability to navigate to the previous page of a multi-page data set",
   },
   [
     {
@@ -33,10 +33,10 @@ export const iconsData = [
       "Name": "fa-angle-right",
       "React_name": "AngleRightIcon",
       "Type": "Framework",
-      "Contextual_usage": "Indicates expandable elements such as accordions, progressive disclosures, or expandable lists are currently collapsed. Clicking this will expand the element."
+      "Contextual_usage": "Indicates expandable elements such as accordions, progressive disclosures, or expandable lists are currently collapsed. Clicking this will expand the element.",
     },
     {
-      "Contextual_usage": "Also indicates the ability to navigate to the next page in a multipage data set."
+      "Contextual_usage": "Also indicates the ability to navigate to the next page in a multipage data set.",
     }
   ],
   {
@@ -44,63 +44,64 @@ export const iconsData = [
     "Name": "fa-angle-up",
     "React_name": "AngleUpIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates expandable table rows (on mobile) are currently expanded. Clicking this will collapse the component."
+    "Contextual_usage": "Indicates expandable table rows (on mobile) are currently expanded. Clicking this will collapse the component.",
   },
   {
     "Style": "",
     "Name": "ansible",
     "React_name": "AnsibleTowerIcon",
     "Type": "Brand",
-    "Contextual_usage": "Represents \"Ansible Tower\""
+    "Contextual_usage": "Represents \"Ansible Tower\"",
   },
   {
     "Style": "fas",
     "Name": "fa-arrow-circle-down",
     "React_name": "ArrowCircleDownIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: an item (such as a VM) is down"
+    "Contextual_usage": "Represents status: an item (such as a VM) is down",
   },
   {
     "Style": "fas",
     "Name": "fa-arrow-circle-up",
     "React_name": "ArrowCircleUpIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: an item (such as a VM) is up"
+    "Contextual_usage": "Represents status: an item (such as a VM) is up",
+    "Tooltip": "Upgrade"
   },
   {
     "Style": "fas",
     "Name": "fa-arrows-alt-v",
     "React_name": "ArrowsAltVIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the availability of a sorting function in a table header"
+    "Contextual_usage": "Indicates the availability of a sorting function in a table header",
   },
   {
     "Style": "fas",
     "Name": "fa-arrow-right",
     "React_name": "ArrowRightIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to take an action or navigate to another page. Is paired with text"
+    "Contextual_usage": "Indicates the ability to take an action or navigate to another page. Is paired with text",
   },
   {
     "Style": "fas",
     "Name": "fa-balance-scale",
     "React_name": "BalanceScaleIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: an item needs rebalancing"
+    "Contextual_usage": "Represents status: an item needs rebalancing",
   },
   {
     "Style": "fas",
     "Name": "fa-ban",
     "React_name": "BanIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: an item is disabled, canceled, terminated or is not ready"
+    "Contextual_usage": "Represents status: an item is disabled, canceled, terminated or is not ready",
   },
   {
     "Style": "fas",
     "Name": "fa-bars",
     "React_name": "BarsIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to collapse a navigation menu"
+    "Contextual_usage": "Indicates the ability to collapse a navigation menu",
   },
   [
     {
@@ -108,7 +109,8 @@ export const iconsData = [
       "Name": "fa-bell",
       "React_name": "BellIcon",
       "Type": "Framework",
-      "Contextual_usage": "Indicates the ability to open a notification drawer."
+      "Contextual_usage": "Indicates the ability to open a notification drawer.",
+      "Tooltip": "Notifications"
     },
     {
       "Style": "",
@@ -116,14 +118,14 @@ export const iconsData = [
       "React_name": "BellIcon",
       "Type": "Status",
       "Contextual_usage": "Represents status: default notification",
-      color: 'var(--pf-global--primary-color--100)'
+      color: 'var(--pf-global--primary-color--100)',
     },
     {
       "Style": "pf-icon",
       "Name": "pf-icon-attention-bell",
       "React_name": "AttentionBellIcon",
       "Type": "Status",
-      "Contextual_usage": "Represents status: attention"
+      "Contextual_usage": "Represents status: attention",
     }
   ],
   {
@@ -131,28 +133,28 @@ export const iconsData = [
     "Name": "fa-bug",
     "React_name": "BugIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: there is a bug present"
+    "Contextual_usage": "Represents status: there is a bug present",
   },
   {
     "Style": "far",
     "Name": "fa-calendar-alt",
     "React_name": "OutlinedCalendarAltIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates a date picker function is available"
+    "Contextual_usage": "Indicates a date picker function is available",
   },
   {
     "Style": "fas",
     "Name": "fa-caret-down",
     "React_name": "CaretDownIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to acces option panels for components like drop-downs, filters and page ranges"
+    "Contextual_usage": "Indicates the ability to acces option panels for components like drop-downs, filters and page ranges",
   },
   {
     "Style": "fas",
     "Name": "fa-check",
     "React_name": "CheckIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: Indicates a switch toggle is in the enabled position"
+    "Contextual_usage": "Represents status: Indicates a switch toggle is in the enabled position",
   },
   [
     {
@@ -161,11 +163,11 @@ export const iconsData = [
       "React_name": "CheckCircleIcon",
       "Type": "Action",
       "Contextual_usage": "Indicates the ability to commit edited changes.",
-      color: 'var(--pf-global--success-color--100)'
+      color: 'var(--pf-global--success-color--100)',
     },
     {
       "Type": "Status",
-      "Contextual_usage": "Represents status: OK in content views such as a tables"
+      "Contextual_usage": "Represents status: OK in content views such as a tables",
     }
   ],
   {
@@ -173,112 +175,116 @@ export const iconsData = [
     "Name": "fa-clipboard-check",
     "React_name": "ClipboardCheckIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents orders or tasks"
+    "Contextual_usage": "Represents orders or tasks",
   },
   {
     "Style": "far",
     "Name": "fa-clock",
     "React_name": "OutlinedClockIcon",
     "Type": "Framework",
-    "Contextual_usage": "Represents a time interval"
+    "Contextual_usage": "Represents a time interval",
   },
   {
     "Style": "fas",
     "Name": "fa-code",
     "React_name": "CodeIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents code"
+    "Contextual_usage": "Represents code",
   },
   {
     "Style": "fas",
     "Name": "fa-code-branch",
     "React_name": "CodeBranchIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents code branch"
+    "Contextual_usage": "Represents code branch",
   },
   {
     "Style": "fas",
     "Name": "fa-cog",
     "React_name": "CogIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates availability of configurable settings"
+    "Contextual_usage": "Indicates availability of configurable settings",
+    "Tooltip": "Settings"
   },
   {
     "Style": "fas",
     "Name": "fa-columns",
     "React_name": "ColumnsIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to manage columns for a table view"
+    "Contextual_usage": "Indicates the ability to manage columns for a table view",
   },
   {
     "Style": "far",
     "Name": "fa-comments",
     "React_name": "OutlinedCommentsIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates availability of commenting"
+    "Contextual_usage": "Indicates availability of commenting",
   },
   {
     "Style": "fas",
     "Name": "fa-compress",
     "React_name": "CompressIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to compress an item. Should toggle with fa-expand"
+    "Contextual_usage": "Indicates the ability to compress an item. Should toggle with fa-expand",
   },
   {
     "Style": "fas",
     "Name": "fa-compress-arrows-alt",
     "React_name": "CompressArrowsAltIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to compress an item (alt concept). Should toggle with fa-expand-arrows-alt"
+    "Contextual_usage": "Indicates the ability to compress an item (alt concept). Should toggle with fa-expand-arrows-alt",
   },
   {
     "Style": "fas",
     "Name": "fa-copy",
     "React_name": "CopyIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the availability of a copy to clipboard function"
+    "Contextual_usage": "Indicates the availability of a copy to clipboard function",
+    "Tooltip": "Copy"
   },
   {
     "Style": "fas",
     "Name": "fa-cube",
     "React_name": "CubeIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a container"
+    "Contextual_usage": "Represents a container",
   },
   {
     "Style": "fas",
     "Name": "fa-cubes",
     "React_name": "CubesIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a Kubernetes pod(s)"
+    "Contextual_usage": "Represents a Kubernetes pod(s)",
   },
   {
     "Style": "fas",
     "Name": "fa-database",
     "React_name": "DatabaseIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a database"
+    "Contextual_usage": "Represents a database",
   },
   {
     "Style": "fas",
     "Name": "fa-desktop",
     "React_name": "DesktopIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a desktop, workstation or terminal"
+    "Contextual_usage": "Represents a desktop, workstation or terminal",
   },
   {
     "Style": "fas",
     "Name": "fa-download",
     "React_name": "DownloadIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates a download function is available"
+    "Contextual_usage": "Indicates a download function is available",
+    "Tooltip": "Download"
   },
   {
     "Style": "fas",
     "Name": "fa-ellipsis-v",
     "React_name": "EllipsisVIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates a contextual menu of actions or additional actions is available"
+    "Contextual_usage": "Indicates a contextual menu of actions or additional actions is available",
+    "Tooltip": "More options"
   },
   {
     "Style": "fas",
@@ -286,7 +292,7 @@ export const iconsData = [
     "React_name": "ExclamationCircleIcon",
     "Type": "Status",
     "Contextual_usage": "Represents alert status: danger, major error or critical error",
-    color: 'var(--pf-global--danger-color--100)'
+    color: 'var(--pf-global--danger-color--100)',
   },
   {
     "Style": "fas",
@@ -294,35 +300,35 @@ export const iconsData = [
     "React_name": "ExclamationTriangleIcon",
     "Type": "Status",
     "Contextual_usage": "Represents alert status: warning",
-    color: 'var(--pf-global--warning-color--100)'
+    color: 'var(--pf-global--warning-color--100)',
   },
   {
     "Style": "fas",
     "Name": "fa-expand",
     "React_name": "ExpandIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to expand an item. Should toggle with fa-compress"
+    "Contextual_usage": "Indicates the ability to expand an item. Should toggle with fa-compress",
   },
   {
     "Style": "fas",
     "Name": "fa-expand-arrows-alt",
     "React_name": "ExpandArrowsAltIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to expand an item (alt concept). Should toggle with fa-compress-arrows-alt"
+    "Contextual_usage": "Indicates the ability to expand an item (alt concept). Should toggle with fa-compress-arrows-alt",
   },
   {
     "Style": "fas",
     "Name": "fa-external-link-alt",
     "React_name": "ExternalLinkAltIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the link navigates to an external site"
+    "Contextual_usage": "Indicates the link navigates to an external site",
   },
   {
     "Style": "fas",
     "Name": "fa-filter",
     "React_name": "FilterIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to filter search results or datasets"
+    "Contextual_usage": "Indicates the ability to filter search results or datasets",
   },
   [
     {
@@ -330,11 +336,11 @@ export const iconsData = [
       "Name": "fa-flag",
       "React_name": "FlagIcon",
       "Type": "Object",
-      "Contextual_usage": "Represents a message"
+      "Contextual_usage": "Represents a message",
     },
     {
       "Type": "Action",
-      "Contextual_usage": "Also indicates the ability to access a messages"
+      "Contextual_usage": "Also indicates the ability to access a messages",
     }
   ],
   [
@@ -343,7 +349,7 @@ export const iconsData = [
       "Name": "fa-folder",
       "React_name": "FolderIcon",
       "Type": "Framework",
-      "Contextual_usage": "Represents a collapsed hierarchical group."
+      "Contextual_usage": "Represents a collapsed hierarchical group.",
     },
     {
       "Contextual_usage": "Indicates the ability to expand the group.",
@@ -355,10 +361,10 @@ export const iconsData = [
       "Name": "fa-folder-open",
       "React_name": "FolderOpenIcon",
       "Type": "Framework",
-      "Contextual_usage": "Represents an expanded hierarchical group."
+      "Contextual_usage": "Represents an expanded hierarchical group.",
     },
     {
-      "Contextual_usage": "Indicates the ability to collapse the group."
+      "Contextual_usage": "Indicates the ability to collapse the group.",
     }
   ],
   {
@@ -366,42 +372,42 @@ export const iconsData = [
     "Name": "fa-grip-horizontal",
     "React_name": "GripHorizontalIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to move a vertically-oriented component via drag and drop"
+    "Contextual_usage": "Indicates the ability to move a vertically-oriented component via drag and drop",
   },
   {
     "Style": "fas",
     "Name": "fa-grip-vertical",
     "React_name": "GripVerticalIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to move a horizontally-oriented component via drag and drop"
+    "Contextual_usage": "Indicates the ability to move a horizontally-oriented component via drag and drop",
   },
   {
     "Style": "fas",
     "Name": "fa-history",
     "React_name": "HistoryIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: restarting"
+    "Contextual_usage": "Represents status: restarting",
   },
   {
     "Style": "fas",
     "Name": "fa-undo",
     "React_name": "UndoIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to undo an a step in a historical log"
+    "Contextual_usage": "Indicates the ability to undo an a step in a historical log",
   },
   {
     "Style": "fas",
     "Name": "fa-hdd",
     "React_name": "OutlinedHddIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a single node or host"
+    "Contextual_usage": "Represents a single node or host",
   },
   {
     "Style": "fas",
     "Name": "fa-home",
     "React_name": "HomeIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates a link to a default/home page"
+    "Contextual_usage": "Indicates a link to a default/home page",
   },
   {
     "Style": "fas",
@@ -409,308 +415,314 @@ export const iconsData = [
     "React_name": "InfoCircleIcon",
     "Type": "Status",
     "Contextual_usage": "Represents alert status: information",
-    color: 'var(--pf-global--info-color--100)'
+    color: 'var(--pf-global--info-color--100)',
   },
   {
     "Style": "fas",
     "Name": "fa-key",
     "React_name": "KeyIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents an SSH key or similar security concepts"
+    "Contextual_usage": "Represents an SSH key or similar security concepts",
   },
   {
     "Style": "fas",
     "Name": "fa-list",
     "React_name": "ListIcon",
     "Type": "View Type",
-    "Contextual_usage": "Represents data view content in a list format."
+    "Contextual_usage": "Represents data view content in a list format.",
   },
   {
     "Style": "fas",
     "Name": "fa-lock",
     "React_name": "LockIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: locked"
+    "Contextual_usage": "Represents status: locked",
   },
   {
     "Style": "fas",
     "Name": "fa-lock-open",
     "React_name": "LockOpenIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: unlocked"
+    "Contextual_usage": "Represents status: unlocked",
   },
   {
     "Style": "fas",
     "Name": "fa-long-arrow-alt-down",
     "React_name": "LongArrowAltDownIcon",
     "Type": "Framework",
-    "Contextual_usage": "Represents the largest-to-smallest, highest-to-lowest or last-to-first (descending) sort order for any data type in a data table column. Clicking this will toggle the sort to ascending."
+    "Contextual_usage": "Represents the largest-to-smallest, highest-to-lowest or last-to-first (descending) sort order for any data type in a data table column. Clicking this will toggle the sort to ascending.",
   },
   {
     "Style": "fas",
     "Name": "fa-long-arrow-alt-up",
     "React_name": "LongArrowAltUpIcon",
     "Type": "Framework",
-    "Contextual_usage": "Represents the smallest-to-largest, lowest-to-highest or first-to-last (ascending) sort order for any data type in a data table column. Clicking this will toggle the sort to descending."
+    "Contextual_usage": "Represents the smallest-to-largest, lowest-to-highest or first-to-last (ascending) sort order for any data type in a data table column. Clicking this will toggle the sort to descending.",
   },
   {
     "Style": "fas",
     "Name": "fa-map-marker",
     "React_name": "MapMarkerIcon",
     "Type": "Framework",
-    "Contextual_usage": "Represents a locale"
+    "Contextual_usage": "Represents a locale",
   },
   {
     "Style": "fas",
     "Name": "fa-memory",
     "React_name": "MemoryIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents the memory on a device"
+    "Contextual_usage": "Represents the memory on a device",
   },
   {
     "Style": "fas",
     "Name": "fa-microchip",
     "React_name": "MicrochipIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents the CPU of a device"
+    "Contextual_usage": "Represents the CPU of a device",
   },
   {
     "Style": "fas",
     "Name": "fa-minus",
     "React_name": "MinusIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to remove an item"
+    "Contextual_usage": "Indicates the ability to remove an item",
   },
   {
     "Style": "fas",
     "Name": "fa-minus-circle",
     "React_name": "MinusCircleIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to remove an item (alt concept)"
+    "Contextual_usage": "Indicates the ability to remove an item (alt concept)",
   },
   {
     "Style": "fas",
     "Name": "fa-pause",
     "React_name": "PauseIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to pause. Should toggle with fa-play"
+    "Contextual_usage": "Indicates the ability to pause. Should toggle with fa-play",
   },
   {
     "Style": "fas",
     "Name": "fa-pause-circle",
     "React_name": "PauseCircleIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: an interruption and/or stoppage of a process"
+    "Contextual_usage": "Represents status: an interruption and/or stoppage of a process",
   },
   {
     "Style": "fas",
     "Name": "fa-pencil-alt",
     "React_name": "PencilAltIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to edit an item"
+    "Contextual_usage": "Indicates the ability to edit an item",
+    "Tooltip": "Edit"
   },
   {
     "Style": "fas",
     "Name": "fa-plus",
     "React_name": "PlusIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to add an item; not for creating completely new objects (see pficon-circle-add)"
+    "Contextual_usage": "Indicates the ability to add an item; not for creating completely new objects (see pficon-circle-add)",
   },
   {
     "Style": "fas",
     "Name": "fa-plus-circle",
     "React_name": "PlusCircleIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to create an item"
+    "Contextual_usage": "Indicates the ability to create an item",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-add-circle-o",
     "React_name": "AddCircleOIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to create an item. Use this if there are many instances of this icon in a UI (data list, table, etc) to reduce visual noise."
+    "Contextual_usage": "Indicates the ability to create an item. Use this if there are many instances of this icon in a UI (data list, table, etc) to reduce visual noise.",
   },
   {
     "Style": "fas",
     "Name": "fa-power-off",
     "React_name": "PowerOffIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: powered on"
+    "Contextual_usage": "Represents status: powered on",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-off",
     "React_name": "OffIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: powered off"
+    "Contextual_usage": "Represents status: powered off",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-openshift",
     "React_name": "OpenshiftIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: OpenShift"
+    "Contextual_usage": "Represents brand: OpenShift",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-openstack",
     "React_name": "OpenstackIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: OpenStack"
+    "Contextual_usage": "Represents brand: OpenStack",
   },
   {
     "Style": "fas",
     "Name": "fa-play",
     "React_name": "PlayIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to start or resume. Should toggle with fa-pause"
+    "Contextual_usage": "Indicates the ability to start or resume. Should toggle with fa-pause",
   },
   {
     "Style": "fas",
     "Name": "fa-print",
     "React_name": "PrintIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the availability of a print function"
+    "Contextual_usage": "Indicates the availability of a print function",
   },
   {
     "Style": "far",
     "Name": "fa-question-circle",
     "React_name": "OutlinedQuestionCircleIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the availability of contextual help"
+    "Contextual_usage": "Indicates the availability of contextual help",
   },
   {
     "Style": "fas",
     "Name": "fa-question-circle",
     "React_name": "QuestionCircleIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the availability of a help system in the masthead"
+    "Contextual_usage": "Indicates the availability of a help system in the masthead",
   },
   {
     "Style": "fas",
     "Name": "fa-redo",
     "React_name": "RedoIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to refresh. Please use the animated spinner to indicate that something is “loading” or in the middle of processing"
+    "Contextual_usage": "Indicates the ability to refresh. Please use the animated spinner to indicate that something is “loading” or in the middle of processing",
   },
   {
     "Style": "fas",
     "Name": "fa-search",
     "React_name": "SearchIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates that that user may perform a search"
+    "Contextual_usage": "Indicates that that user may perform a search",
+    "Tooltip": "Search"
   },
   {
     "Style": "fas",
     "Name": "fa-search-minus",
     "React_name": "SearchMinusIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to zoom out"
+    "Contextual_usage": "Indicates the ability to zoom out",
+    "Tooltip": "Search minus"
   },
   {
     "Style": "fas",
     "Name": "fa-search-plus",
     "React_name": "SearchPlusIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to zoom in"
+    "Contextual_usage": "Indicates the ability to zoom in",
+    "Tooltip": "Search plus"
   },
   {
     "Style": "fas",
     "Name": "fa-share-square",
     "React_name": "ShareSquareIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to share via various methods with others"
+    "Contextual_usage": "Indicates the ability to share via various methods with others",
   },
   {
     "Style": "fas",
     "Name": "fa-sort-amount-down",
     "React_name": "SortAmountDownIcon",
     "Type": "Action",
-    "Contextual_usage": "Represents the largest-to-smallest, highest-to-lowest or last-to-first (descending) sort order for any data type."
+    "Contextual_usage": "Represents the largest-to-smallest, highest-to-lowest or last-to-first (descending) sort order for any data type.",
   },
   {
     "Style": "fas",
     "Name": "fa-sort-amount-down-alt",
     "React_name": "SortAmountDownAltIcon",
     "Type": "Action",
-    "Contextual_usage": "Represents the smallest-to-largest, lowest-to-highest or first-to-last (ascending) sort order for any data type."
+    "Contextual_usage": "Represents the smallest-to-largest, lowest-to-highest or first-to-last (ascending) sort order for any data type.",
   },
   {
     "Style": "fas",
     "Name": "fa-sync-alt",
     "React_name": "SyncAltIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the availability of a sync action"
+    "Contextual_usage": "Indicates the availability of a sync action",
+    "Tooltip": "Sync; Refresh; Running"
   },
   {
     "Style": "fas",
     "Name": "fa-tag",
     "React_name": "TagIcon",
     "Type": "Object",
-    "Contextual_usage": "Indicates the abiltiy to access or create a set of tags"
+    "Contextual_usage": "Indicates the abiltiy to access or create a set of tags",
   },
   {
     "Style": "fas",
     "Name": "fa-table",
     "React_name": "TableIcon",
     "Type": "View Type",
-    "Contextual_usage": "Represents data view content in a table format"
+    "Contextual_usage": "Represents data view content in a table format",
   },
   {
     "Style": "fas",
     "Name": "fa-tachometer-alt",
     "React_name": "TachometerAltIcon",
     "Type": "View Type",
-    "Contextual_usage": "Represents data view content in a dashboard"
+    "Contextual_usage": "Represents data view content in a dashboard",
   },
   {
     "Style": "fas",
     "Name": "fa-th",
     "React_name": "ThIcon",
     "Type": "View Type",
-    "Contextual_usage": "Represents data view content in a small card format"
+    "Contextual_usage": "Represents data view content in a small card format",
   },
   {
     "Style": "fas",
     "Name": "fa-th-large",
     "React_name": "ThLargeIcon",
     "Type": "View Type",
-    "Contextual_usage": "Represents data view content in a large card format"
+    "Contextual_usage": "Represents data view content in a large card format",
   },
   {
     "Style": "fas",
     "Name": "fa-thumbtack",
     "React_name": "ThumbtackIcon",
     "Type": "Framework",
-    "Contextual_usage": "Indicates the ability to pin an item"
+    "Contextual_usage": "Indicates the ability to pin an item",
   },
   {
     "Style": "fas",
     "Name": "fa-times",
     "React_name": "TimesIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to close a modal or other panel. Also indicates the ability to clear existing data, such as filter criteria or labels"
+    "Contextual_usage": "Indicates the ability to close a modal or other panel. Also indicates the ability to clear existing data, such as filter criteria or labels",
   },
   {
     "Style": "fas",
     "Name": "fa-times-circle",
     "React_name": "TimesCircleIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to close the about modal"
+    "Contextual_usage": "Indicates the ability to close the about modal",
   },
   {
     "Style": "fas",
     "Name": "fa-trash",
     "React_name": "TrashIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to delete"
+    "Contextual_usage": "Indicates the ability to delete",
+    "Tooltip": "Delete"
   },
   {
     "Style": "fas",
     "Name": "fa-upload",
     "React_name": "UploadIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates an upload function is available"
+    "Contextual_usage": "Indicates an upload function is available",
   },
   [
     {
@@ -718,11 +730,11 @@ export const iconsData = [
       "Name": "fa-user",
       "React_name": "UserIcon",
       "Type": "Object",
-      "Contextual_usage": "Represents a user (in a dataset, paired with a username)."
+      "Contextual_usage": "Represents a user (in a dataset, paired with a username).",
     },
     {
       "Type": "Framework",
-      "Contextual_usage": "Indicates the availability of a user profile (in the masthead, paired with a username)"
+      "Contextual_usage": "Indicates the availability of a user profile (in the masthead, paired with a username)",
     }
   ],
   {
@@ -730,552 +742,553 @@ export const iconsData = [
     "Name": "fa-users",
     "React_name": "UsersIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents multiple users, a user grouping or project"
+    "Contextual_usage": "Represents multiple users, a user grouping or project",
   },
   {
     "Style": "far",
     "Name": "fa-window-restore",
     "React_name": "OutlinedWindowRestoreIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to open link in a new window"
+    "Contextual_usage": "Indicates the ability to open link in a new window",
   },
   {
     "Style": "fas",
     "Name": "fa-wrench",
     "React_name": "WrenchIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: in preparation for maintenance"
+    "Contextual_usage": "Represents status: in preparation for maintenance",
   },
   {
     "Style": "fab",
     "Name": "fa-github",
     "React_name": "GithubIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: GitHub"
+    "Contextual_usage": "Represents brand: GitHub",
   },
   {
     "Style": "fab",
     "Name": "fa-gitlab",
     "React_name": "GitlabIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: GitLab"
+    "Contextual_usage": "Represents brand: GitLab",
   },
   {
     "Style": "fab",
     "Name": "fa-google",
     "React_name": "GoogleIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Google"
+    "Contextual_usage": "Represents brand: Google",
   },
   {
     "Style": "fab",
     "Name": "fa-stack-overflow",
     "React_name": "StackOverflowIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Stack Overflow"
+    "Contextual_usage": "Represents brand: Stack Overflow",
   },
   {
     "Style": "fab",
     "Name": "fa-facebook-square",
     "React_name": "FacebookSquareIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Facebook"
+    "Contextual_usage": "Represents brand: Facebook",
   },
   {
     "Style": "fab",
     "Name": "fa-twitter",
     "React_name": "TwitterIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Twitter"
+    "Contextual_usage": "Represents brand: Twitter",
   },
   {
     "Style": "fab",
     "Name": "fa-windows",
     "React_name": "WindowsIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Windows"
+    "Contextual_usage": "Represents brand: Windows",
   },
   {
     "Style": "fab",
     "Name": "fa-linkedin",
     "React_name": "LinkedinIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: LinkedIn"
+    "Contextual_usage": "Represents brand: LinkedIn",
   },
   {
     "Style": "fab",
     "Name": "fa-linux",
     "React_name": "LinuxIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Linux"
+    "Contextual_usage": "Represents brand: Linux",
   },
   {
     "Style": "fab",
     "Name": "fa-dropbox",
     "React_name": "DropboxIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Dropbox"
+    "Contextual_usage": "Represents brand: Dropbox",
   },
   {
     "Style": "fab",
     "Name": "fa-drupal",
     "React_name": "DrupalIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Drupal"
+    "Contextual_usage": "Represents brand: Drupal",
   },
   {
     "Style": "fab",
     "Name": "fa-js",
     "React_name": "JsIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: js"
+    "Contextual_usage": "Represents brand: js",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-asleep",
     "React_name": "AsleepIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents an item is asleep or in power suspended mode"
+    "Contextual_usage": "Represents an item is asleep or in power suspended mode",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-automation",
     "React_name": "AutomationIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a process-automation object"
+    "Contextual_usage": "Represents a process-automation object",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-blueprint",
     "React_name": "BlueprintIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a blueprint"
+    "Contextual_usage": "Represents a blueprint",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-build",
     "React_name": "BuildIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a build"
+    "Contextual_usage": "Represents a build",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-builder-image",
     "React_name": "BuilderImageIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a builder image"
+    "Contextual_usage": "Represents a builder image",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-bundle",
     "React_name": "BundleIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a package; used in Satellite, Cockpit, and Composer to indicate a generic package or rpm"
+    "Contextual_usage": "Represents a package; used in Satellite, Cockpit, and Composer to indicate a generic package or rpm",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-catalog",
     "React_name": "CatalogIcon",
     "Type": "Object",
-    "Contextual_usage": "Indicates the availability of a catalog or library"
+    "Contextual_usage": "Indicates the availability of a catalog or library",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-cloud-security",
     "React_name": "CloudSecurityIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents cloud security"
+    "Contextual_usage": "Represents cloud security",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-cloud-tenant",
     "React_name": "CloudTenantIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a cloud tenant"
+    "Contextual_usage": "Represents a cloud tenant",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-cluster",
     "React_name": "ClusterIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a cluster or server"
+    "Contextual_usage": "Represents a cluster or server",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-connected",
     "React_name": "ConnectedIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents an item's power is on and is “up”; this is a more active alternative to “pficon-on”"
+    "Contextual_usage": "Represents an item's power is on and is “up”; this is a more active alternative to “pficon-on”",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-degraded",
     "React_name": "DegradedIcon",
     "Type": "Status",
-    "Contextual_usage": "Volume replication is degraded"
+    "Contextual_usage": "Volume replication is degraded",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-disconnected",
     "React_name": "DisconnectedIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents an item's power is off and is “down”; this is a more active alternative to “pficon-off”"
+    "Contextual_usage": "Represents an item's power is off and is “down”; this is a more active alternative to “pficon-off”",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-domain",
     "React_name": "DomainIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a domain"
+    "Contextual_usage": "Represents a domain",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-enhancement",
     "React_name": "EnhancementIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: enhancement advisory is present"
+    "Contextual_usage": "Represents status: enhancement advisory is present",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-enterprise",
     "React_name": "EnterpriseIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents an enterprise"
+    "Contextual_usage": "Represents an enterprise",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-export",
     "React_name": "ExportIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to export a file or other data"
+    "Contextual_usage": "Indicates the ability to export a file or other data",
+    "Tooltip": "Export"
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-flavor",
     "React_name": "FlavorIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a flavor"
+    "Contextual_usage": "Represents a flavor",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-image",
     "React_name": "ImageIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents an image"
+    "Contextual_usage": "Represents an image",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-import",
     "React_name": "ImportIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to import a file or other data"
+    "Contextual_usage": "Indicates the ability to import a file or other data",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-in-progress",
     "React_name": "InProgressIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents running a determinite action"
+    "Contextual_usage": "Represents running a determinite action",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-infrastructure",
     "React_name": "InfrastructureIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents an infrastructure"
+    "Contextual_usage": "Represents an infrastructure",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-integration",
     "React_name": "IntegrationIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents an integration of two or more objects"
+    "Contextual_usage": "Represents an integration of two or more objects",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-migration",
     "React_name": "MigrationIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents an item such as a VM is currently migrating"
+    "Contextual_usage": "Represents an item such as a VM is currently migrating",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-middleware",
     "React_name": "MiddlewareIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents middleware"
+    "Contextual_usage": "Represents middleware",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-module",
     "React_name": "ModuleIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a module"
+    "Contextual_usage": "Represents a module",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-monitoring",
     "React_name": "MonitoringIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents monitoring"
+    "Contextual_usage": "Represents monitoring",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-network",
     "React_name": "NetworkIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents network"
+    "Contextual_usage": "Represents network",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-network-range",
     "React_name": "PficonNetworkRangeIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents network range"
+    "Contextual_usage": "Represents network range",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-running",
     "React_name": "RunningIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: running"
+    "Contextual_usage": "Represents status: running",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-optimize",
     "React_name": "OptimizeIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to optimize an item or a process"
+    "Contextual_usage": "Indicates the ability to optimize an item or a process",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-package",
     "React_name": "PackageIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a package"
+    "Contextual_usage": "Represents a package",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-pending",
     "React_name": "PendingIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: pending; currently waiting on contingencies"
+    "Contextual_usage": "Represents status: pending; currently waiting on contingencies",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-private",
     "React_name": "PrivateIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: private; cannot access with current credentials"
+    "Contextual_usage": "Represents status: private; cannot access with current credentials",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-port",
     "React_name": "PortIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a port or route"
+    "Contextual_usage": "Represents a port or route",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-process-automation",
     "React_name": "ProcessAutomationIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents process automation"
+    "Contextual_usage": "Represents process automation",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-regions",
     "React_name": "RegionsIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a region"
+    "Contextual_usage": "Represents a region",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-registry",
     "React_name": "RegistryIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a registry"
+    "Contextual_usage": "Represents a registry",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-replicator",
     "React_name": "ReplicatorIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a replicator"
+    "Contextual_usage": "Represents a replicator",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-repository",
     "React_name": "RepositoryIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a repository"
+    "Contextual_usage": "Represents a repository",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-resource-pool",
     "React_name": "ResourcePoolIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a resource pool"
+    "Contextual_usage": "Represents a resource pool",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-resources-empty",
     "React_name": "ResourcesEmptyIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: is empty"
+    "Contextual_usage": "Represents status: is empty",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-resources-almost-empty",
     "React_name": "ResourcesAlmostEmptyIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: is almost empty"
+    "Contextual_usage": "Represents status: is almost empty",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-resources-almost-full",
     "React_name": "ResourcesAlmostFullIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: is almost full"
+    "Contextual_usage": "Represents status: is almost full",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-resources-full",
     "React_name": "ResourcesFullIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: is full"
+    "Contextual_usage": "Represents status: is full",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-route",
     "React_name": "RouteIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a route"
+    "Contextual_usage": "Represents a route",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-satellite",
     "React_name": "PficonSatelliteIcon",
     "Type": "Brands",
-    "Contextual_usage": "Represents brand: Satellite"
+    "Contextual_usage": "Represents brand: Satellite",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-save",
     "React_name": "SaveIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to save a file or other object"
+    "Contextual_usage": "Indicates the ability to save a file or other object",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-security",
     "React_name": "SecurityIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: security advisory is present"
+    "Contextual_usage": "Represents status: security advisory is present",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-server-group",
     "React_name": "ServerGroupIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a server group"
+    "Contextual_usage": "Represents a server group",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-service",
     "React_name": "ServiceIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a Kubernetes service"
+    "Contextual_usage": "Represents a Kubernetes service",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-services",
     "React_name": "ServicesIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents services"
+    "Contextual_usage": "Represents services",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-service-catalog",
     "React_name": "ServiceCatalogIcon",
     "Type": "Object",
-    "Contextual_usage": "Indicates availability of a catalog/library to browse"
+    "Contextual_usage": "Indicates availability of a catalog/library to browse",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-storage-domain",
     "React_name": "StorageDomainIcon",
     "Type": "Object",
-    "Contextual_usage": "Indicates a storage domain"
+    "Contextual_usage": "Indicates a storage domain",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-template",
     "React_name": "PficonTemplateIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a template; includes contents or instructions used to generate one or more instances of a final output"
+    "Contextual_usage": "Represents a template; includes contents or instructions used to generate one or more instances of a final output",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-tenant",
     "React_name": "TenantIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a tenant"
+    "Contextual_usage": "Represents a tenant",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-topology",
     "React_name": "TopologyIcon",
     "Type": "View type",
-    "Contextual_usage": "Represents data view content in a topology format"
+    "Contextual_usage": "Represents data view content in a topology format",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-trend-down",
     "React_name": "TrendDownIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: downward trend"
+    "Contextual_usage": "Represents status: downward trend",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-trend-up",
     "React_name": "TrendUpIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: upward trend"
+    "Contextual_usage": "Represents status: upward trend",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-unknown",
     "React_name": "UnknownIcon",
     "Type": "Status",
-    "Contextual_usage": "Represents status: unknown"
+    "Contextual_usage": "Represents status: unknown",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-vcenter",
     "React_name": "PficonVcenterIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a vcenter"
+    "Contextual_usage": "Represents a vcenter",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-virtual-machine",
     "React_name": "VirtualMachineIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a virtual machine"
+    "Contextual_usage": "Represents a virtual machine",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-volume",
     "React_name": "VolumeIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a volume"
+    "Contextual_usage": "Represents a volume",
   },
   {
     "Style": "pf-icon",
     "Name": "pf-icon-zone",
     "React_name": "ZoneIcon",
     "Type": "Object",
-    "Contextual_usage": "Represents a zone; a grouping of servers based on geographic location, network location, or function"
+    "Contextual_usage": "Represents a zone; a grouping of servers based on geographic location, network location, or function",
   }
 ]


### PR DESCRIPTION
Closes #2223 

This PR:
- Adds new `Tooltip labels` column
- Adds tooltip labels to a handful of icons
- Hides the `Type` column, but still allows it to be searchable