### PR TITLE
fix(buble): perfect JSXText regex?

### DIFF
--- a/packages/theme-patternfly-org/helpers/buble.js
+++ b/packages/theme-patternfly-org/helpers/buble.js
@@ -58,7 +58,7 @@ const generator = Object.assign({}, baseGenerator, {
     }
     if (node.value) {
       state.write(',"');
-      state.write(node.value.replace(/"/g, '\\"').replace(/^\s+/, '').replace(/\s*\n\s*/g, ''));
+      state.write(node.value.replace(/"/g, '\\"').replace(/\n\s*/g, ''));
       state.write('"');
     }
   },
@@ -105,9 +105,11 @@ function transform(code) {
     allowReturnOutsideFunction: true
   });
   code = generate(ast, { generator });
+  console.log(code);
   return { code };
 }
 
 module.exports = {
   transform
 };
+

--- a/packages/theme-patternfly-org/helpers/buble.js
+++ b/packages/theme-patternfly-org/helpers/buble.js
@@ -105,7 +105,6 @@ function transform(code) {
     allowReturnOutsideFunction: true
   });
   code = generate(ast, { generator });
-  console.log(code);
   return { code };
 }
 


### PR DESCRIPTION
Makes
```jsx
<div>
  1 <span>2</span> 3
</div>
```
into
```js
return React.createElement("div",{},"1 ",React.createElement("span",{},"2")," 3");
```
just like [the Babel compiler!](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&spec=false&loose=false&code_lz=DwEwlgbgfAUABHAjHYBnADgQwHZQEzAD0GOUcAzDEeNEA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=react&prettier=false&targets=&version=7.13.11&externalPlugins=%40babel%2Fplugin-proposal-class-properties%407.12.1)

Related: #2284