### PR TITLE
sentence case and fix code blocks

### DIFF
--- a/packages/v4/src/content/developer-resources/accessibility-development.md
+++ b/packages/v4/src/content/developer-resources/accessibility-development.md
@@ -61,28 +61,28 @@ The meaning of a semantic icon must be provided in alternative ways to the user.
 
   Example: 
 
-     ```html noLive
-      <button class="..." aria-label="Close Dialog">
-        <i class="..." aria-hidden="true"></i>
-      </button>
-      ```
+    ```html noLive
+    <button class="..." aria-label="Close Dialog">
+      <i class="..." aria-hidden="true"></i>
+    </button>
+    ```
 
 - For **non-interactive icons**, include .pf-screen-reader text near the icon. Depending on the component, the .pf-screen-reader text might not be a direct sibling to the icon element.  
 
   Example: In the alert component, the icon label text is adjacent to the message. This way, when role="alert" is added to .pf-c-alert__body for dynamically displayed alerts, the type of message is announced along with the message text.
 
-  ```html noLive
-      <div class="pf-c-alert pf-m-success" aria-label="Success Alert">
-        <div aria-hidden="true" class="pf-c-alert__icon">
-          <i class="fas fa-check-circle"></i>
-        </div>
-        <div class="pf-c-alert__body">
-          <h4 class="pf-c-alert__title">
-            {{#> screen-reader}}Success:{{/screen-reader}} Success alert title
-          </h4>
-        </div>
+    ```html noLive
+    <div class="pf-c-alert pf-m-success" aria-label="Success Alert">
+      <div aria-hidden="true" class="pf-c-alert__icon">
+        <i class="fas fa-check-circle"></i>
       </div>
-      ```
+      <div class="pf-c-alert__body">
+        <h4 class="pf-c-alert__title">
+          {{#> screen-reader}}Success:{{/screen-reader}} Success alert title
+        </h4>
+      </div>
+    </div>
+    ```
 
 ### Images
 All images should have alt text so that assistive technology can provide an image description. This will help your site’s SEO, too. When an image contains words that are important to understanding the content, the alt text should include those words. This allows the alt text to play the same function on the page as the image. 

--- a/packages/v4/src/content/developer-resources/accessibility-guide.md
+++ b/packages/v4/src/content/developer-resources/accessibility-guide.md
@@ -1,5 +1,5 @@
 ---
-id: Accessibility Fundamentals
+id: Accessibility fundamentals
 section: accessibility
 redirectFrom: /developer-resources/accessibility-guide
 ---

--- a/packages/v4/src/content/developer-resources/patternfly-accessibility.md
+++ b/packages/v4/src/content/developer-resources/patternfly-accessibility.md
@@ -1,5 +1,5 @@
 ---
-id: PatternFly's Accessibility
+id: PatternFly's accessibility
 section: accessibility
 ---
 


### PR DESCRIPTION
Fix some odd code styling and use sentence case for titles:
![image](https://user-images.githubusercontent.com/47335686/123823123-e6aca680-d8ca-11eb-9e96-ee2d9effcd14.png)
