### PR TITLE
docs(button): add a11y documentation

### DIFF
--- a/packages/v4/src/content/accessibility/button/button.md
+++ b/packages/v4/src/content/accessibility/button/button.md
@@ -3,9 +3,6 @@ id: Button
 section: components
 ---
 
-# Button
-Accessibility
-
 A **button** is a box area or text that communicates and triggers user actions when clicked or selected. Buttons are interactive elements.
 
 **Keyboard users** should be able to focus on the button using **Tab** to move forward and **Tab + Shift** to move backwards through interactive elements. They should be able to select a focused button using **Space** or **Enter**.
@@ -20,10 +17,10 @@ A **button** is a box area or text that communicates and triggers user actions w
 - Screen readers may read buttons to users out of context. For example, screen reader users can navigate a page specifically by form controls. So button text should be unique and easily understood on its own. Refer to PatternFly's accessibility guide for more information.
 
 The following props/attributes have been added for you or are customizable in PatternFly:
-| Reason used | React prop used to customize | HTML attribute | React component that it should be applied to | Which HTML element it appears on in markup |
-| -- | -- | -- | -- | -- |
-| Adds accessible text to the button if the button doesn’t contain descriptive text on its own. | `aria-label` | aria-label="[button or icon description]" | Button | .pf-c-button.pf-m-plain |
-| Indicates that a button is unavailable to use but doesn’t prevent keyboard or screen reader interactions. Used when a disabled button provides interactive elements like a tooltip. | `aria-disabled` | aria-disabled="true" | Button | button.pf-c-button |
+| Reason used | React prop used to customize | React component that it should be applied to | Which HTML element it appears on in markup |
+| -- | -- | -- | -- |
+| Adds accessible text to the button if the button doesn’t contain descriptive text on its own. | `aria-label` | Button | .pf-c-button.pf-m-plain |
+| Indicates that a button is unavailable to use but doesn’t prevent keyboard or screen reader interactions. Used when a disabled button provides interactive elements like a tooltip. | `aria-disabled` | Button | button.pf-c-button |
 
 
 

--- a/packages/v4/src/content/accessibility/button/button.md
+++ b/packages/v4/src/content/accessibility/button/button.md
@@ -1,0 +1,35 @@
+---
+id: Button
+section: components
+---
+
+# Button
+Accessibility
+
+A **button** is a box area or text that communicates and triggers user actions when clicked or selected. Buttons are interactive elements.
+
+**Keyboard users** should be able to focus on the button using **Tab** to move forward and **Tab + Shift** to move backwards through interactive elements. They should be able to select a focused button using **Space** or **Enter**.
+
+**Screen reader users** should be able to navigate to the button and it should have text that can be read by a screen reader, or alternative text if it only contains an icon. For alternative text, `aria-label` is the most common choice.
+
+
+## Accessibility application:
+
+- A button containing only an icon without supporting text should be labeled with the `aria-label` prop.
+- A regular disabled button is not focusable, but an aria-disabled button is. Aria-disabled should be used when a disabled button provides interactive elements (like a tooltip).
+- Screen readers may read buttons to users out of context. For example, screen reader users can navigate a page specifically by form controls. So button text should be unique and easily understood on its own. Refer to PatternFly's accessibility guide for more information.
+
+The following props/attributes have been added for you or are customizable in PatternFly:
+| Reason used | React prop used to customize | HTML attribute | React component that it should be applied to | Which HTML element it appears on in markup |
+| -- | -- | -- | -- | -- |
+| Adds accessible text to the button if the button doesn’t contain descriptive text on its own. | `aria-label` | aria-label="[button or icon description]" | Button | .pf-c-button.pf-m-plain |
+| Indicates that a button is unavailable to use but doesn’t prevent keyboard or screen reader interactions. Used when a disabled button provides interactive elements like a tooltip. | `aria-disabled` | aria-disabled="true" | Button | button.pf-c-button |
+
+
+
+
+Use [available design guidelines](https://docs.google.com/spreadsheets/d/1wLkKcW99lhkNXsClUa0ihkdl2W7G_eRTY0wGK6_ah60/edit#gid=0) to reference usage.
+
+[Examples of other design systems](https://docs.google.com/document/d/1ihMLWsJk0Nop9vJtD_YMyAMDd6Tpq0hqqHWRd-AWUEk/edit) a11y documentation examples. 
+
+

--- a/packages/v4/src/content/accessibility/button/button.md
+++ b/packages/v4/src/content/accessibility/button/button.md
@@ -18,7 +18,7 @@ A **button** is a box area or text that communicates and triggers user actions w
 
 The following props/attributes have been added for you or are customizable in PatternFly:
 
-| Reason used | React prop used to customize | React component that it should be applied to | Which HTML element it appears on in markup |
+| React prop | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
 | -- | -- | -- | -- |
-| Adds accessible text to the button if the button doesn’t contain descriptive text on its own. | `aria-label` | Button | .pf-c-button.pf-m-plain |
-| Adds disabled styling and communicates that the button is disabled using the aria-disabled html attribute | `isAriaDisabled` | Button | button.pf-c-button |
+| `aria-label` | Button | .pf-c-button.pf-m-plain | Adds accessible text to the button if the button doesn’t contain descriptive text on its own. |
+| `isAriaDisabled` | Button | button.pf-c-button | Adds disabled styling and communicates that the button is disabled using the aria-disabled html attribute |

--- a/packages/v4/src/content/accessibility/button/button.md
+++ b/packages/v4/src/content/accessibility/button/button.md
@@ -16,7 +16,7 @@ A **button** is a box area or text that communicates and triggers user actions w
 - A regular disabled button is not focusable, but an aria-disabled button is. `isAriaDisabled` should be used when a disabled button provides interactive elements (like a tooltip).
 - Screen readers may read buttons to users out of context. For example, screen reader users can navigate a page specifically by form controls. So button text should be unique and easily understood on its own. Refer to PatternFly's accessibility guide for more information.
 
-The following props/attributes have been added for you or are customizable in PatternFly:
+The following props can be added or are customizable in PatternFly:
 
 | React prop | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
 | -- | -- | -- | -- |

--- a/packages/v4/src/content/accessibility/button/button.md
+++ b/packages/v4/src/content/accessibility/button/button.md
@@ -13,20 +13,12 @@ A **button** is a box area or text that communicates and triggers user actions w
 ## Accessibility application:
 
 - A button containing only an icon without supporting text should be labeled with the `aria-label` prop.
-- A regular disabled button is not focusable, but an aria-disabled button is. Aria-disabled should be used when a disabled button provides interactive elements (like a tooltip).
+- A regular disabled button is not focusable, but an aria-disabled button is. `isAriaDisabled` should be used when a disabled button provides interactive elements (like a tooltip).
 - Screen readers may read buttons to users out of context. For example, screen reader users can navigate a page specifically by form controls. So button text should be unique and easily understood on its own. Refer to PatternFly's accessibility guide for more information.
 
 The following props/attributes have been added for you or are customizable in PatternFly:
+
 | Reason used | React prop used to customize | React component that it should be applied to | Which HTML element it appears on in markup |
 | -- | -- | -- | -- |
 | Adds accessible text to the button if the button doesn’t contain descriptive text on its own. | `aria-label` | Button | .pf-c-button.pf-m-plain |
-| Indicates that a button is unavailable to use but doesn’t prevent keyboard or screen reader interactions. Used when a disabled button provides interactive elements like a tooltip. | `aria-disabled` | Button | button.pf-c-button |
-
-
-
-
-Use [available design guidelines](https://docs.google.com/spreadsheets/d/1wLkKcW99lhkNXsClUa0ihkdl2W7G_eRTY0wGK6_ah60/edit#gid=0) to reference usage.
-
-[Examples of other design systems](https://docs.google.com/document/d/1ihMLWsJk0Nop9vJtD_YMyAMDd6Tpq0hqqHWRd-AWUEk/edit) a11y documentation examples. 
-
-
+| Adds disabled styling and communicates that the button is disabled using the aria-disabled html attribute | `isAriaDisabled` | Button | button.pf-c-button |


### PR DESCRIPTION
A11y documentation for the Button PF component
Closes #2557