### PR TITLE
fix(workspace): vertically align docs tables

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -78,6 +78,9 @@
 .ws-table tr > code {
   white-space: normal;
 }
+.ws-table tbody > tr > td {
+  vertical-align: top;
+}
 
 /*
  * Copied from pf-c-content.


### PR DESCRIPTION
This changes cell alignment to `top` for workspace tables so that multi-line code snippets don't throw off the vertical alignment. The high specificity is required to get past the `.pf-c-table` cell style.

Fixes #2605 