### PR TITLE
feat(propsTable): Convert interface names referenced in prop types on the same page into links

### DIFF
--- a/packages/theme-patternfly-org/components/propsTable/propTypeWithLinks.js
+++ b/packages/theme-patternfly-org/components/propsTable/propTypeWithLinks.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { slugger } from "../../helpers/slugger";
+
+export const PropTypeWithLinks = ({ type, allPropComponents }) => {
+  // If this type contains the names of any other components on this page as full words, turn them into links.
+  const referencedComponentNames = allPropComponents
+    .filter((component) => type.match(new RegExp(`\\b${component.name}\\b`)))
+    .map((component) => component.name);
+  if (referencedComponentNames.length > 0) {
+    return (
+      <React.Fragment>
+        {type
+          .split(new RegExp(`\\b(${referencedComponentNames.join("|")})\\b`))
+          .map((segment) =>
+            referencedComponentNames.includes(segment) ? (
+              <a
+                key={segment}
+                onClick={(event) => {
+                  event.preventDefault();
+                  document.getElementById(slugger(segment)).scrollIntoView();
+                }}
+              >
+                {segment}
+              </a>
+            ) : (
+              segment
+            )
+          )}
+      </React.Fragment>
+    );
+  }
+  return type;
+};

--- a/packages/theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/theme-patternfly-org/components/propsTable/propsTable.js
@@ -8,10 +8,12 @@ import {
   cellWidth
 } from '@patternfly/react-table';
 import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
+import { PropTypeWithLinks } from './propTypeWithLinks';
 
 export const PropsTable = ({
   title,
-  rows
+  rows,
+  allPropComponents
 }) => {
   const columns = [
     { title: 'Name', transforms: [cellWidth(15)] },
@@ -44,7 +46,7 @@ export const PropsTable = ({
               )}
             </div>,
             <div className="pf-m-break-word">
-              {row.type}
+              <PropTypeWithLinks type={row.type} allPropComponents={allPropComponents} />
             </div>,
             <div>
               {row.required ? 'Yes' : 'No'}

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -83,7 +83,9 @@ const MDXChildTemplate = ({
                 <PropsTable
                   key={component.name}
                   title={component.name}
-                  rows={component.props} />
+                  rows={component.props}
+                  allPropComponents={propComponents}
+                />
               ))}
             </React.Fragment>
           )}


### PR DESCRIPTION
Resolves #2608.

@redallen I had a hunch this would work and couldn't help myself.

Followup to #2586. When rendering each row of the `PropsTable`, this new `PropTypeWithLinks` component will look at the type name for that row and see if it contains full words matching any of the other component/interface names on the page. If so, it will split the type name into pieces isolating those matches and render the matched segments as links using the existing `slugger()` helper to generate the ids. This `slugger()` is what the `AutoLinkHeader` already uses to generate the ids of the referenced prop tables, so we know the ids being linked will always be consistent.

See the prop type for `customSteps` at v4/components/slider/#slider:

![tUm5lnawHl](https://user-images.githubusercontent.com/811963/126537406-e9fca3ab-11e2-4791-955b-2fab42fb1a15.gif)

Several examples can also be seen in the new v4/components/table/ which has lots of these normalized interfaces.