### PR TITLE
fix(example): show readonly code for fullscreen example

### DIFF
--- a/packages/theme-patternfly-org/components/example/exampleToolbar.js
+++ b/packages/theme-patternfly-org/components/example/exampleToolbar.js
@@ -60,7 +60,7 @@ export const ExampleToolbar = ({
   const fullscreenLabel = 'Open example in new window';
   const convertLabel = 'Convert example from Typescript to JavaScript';
   const undoAllLabel = 'Undo all changes';
-  const customControls = isFullscreen ? null : (
+  const customControls = (
     <React.Fragment>
       <CodeEditorControl
         icon={


### PR DESCRIPTION
Accidentally was hiding on https://www.patternfly.org/v4/components/background-image