### PR TITLE
Adding custom alert guidance

### DIFF
--- a/packages/v4/src/content/design-guidelines/components/alert/alert.md
+++ b/packages/v4/src/content/design-guidelines/components/alert/alert.md
@@ -83,6 +83,12 @@ Toast alerts are commonly used in the following situations:
 - Informing the user that their action was completed successfully
 - Informing the user that their action was completed with errors
 
+## Customizing alerts
+
+If your use case falls outside of PatternFly's standard alert variations, use [icons](/guidelines/icons) and [colors](/guidelines/colors) to create custom alerts that meet your needs.
+
+View custom alerts in action in our [custom alert examples](https://www.patternfly.org/v4/components/alert#custom-icons).
+
 ## Content
 
 


### PR DESCRIPTION
Adding a "Customizing alerts" section as per #1953 

@mmenestr should we also include a visual example of what custom alerts might look like, or does the link to the examples suffice?

Thanks for your patience on this PR! :)

