### PR TITLE
fixed accessibility guide link on community page

### DIFF
--- a/packages/v4/src/pages/community.js
+++ b/packages/v4/src/pages/community.js
@@ -59,7 +59,7 @@ const CommunityPage = () => (
                         A community isn’t really a community unless everyone is included, so accessible UX is important to us. We regularly test and audit PatternFly’s accessibility and share guidance whenever we can.
                     </p>
                     <Title size="xl" className="ws-title" headingLevel="h4">
-                        <Link to="/developer-resources/accessibility-guide">
+                        <Link to="/accessibility/accessibility-fundamentals">
                             <strong>Read our accessibility guide</strong>
                         </Link>
                     </Title>


### PR DESCRIPTION
Closes #2620 

Fixes accessibility guide link on Community page, points it to Accessibility fundamentals page.