### PR TITLE
updated link to use history.pushState to avoid route change

### DIFF
--- a/packages/theme-patternfly-org/components/link/link.js
+++ b/packages/theme-patternfly-org/components/link/link.js
@@ -31,7 +31,8 @@ export const Link = ({
       if (referencedElement) {
         referencedElement.scrollIntoView();
       }
-      window.location.hash = url;
+      // update URL without triggering route change
+      history.pushState({}, '', url);
     };
   }
   if (url.includes('//') || url.startsWith('#')) {


### PR DESCRIPTION
Fixes #2615 

This PR replaces `window.location.hash` with `history.pushState` which updates the URL but does not trigger route change which was causing a re-render of the page and breaking the jumplinks.

This fixes the issue of clicking an autolinkheader (link icon beside a section/example heading corresponding with a jumplink) would break the jumplinks, always causing the first jumplink to show as active and no longer following the user's scrolling on the page.