### PR TITLE
fix(docs): update props table column widths & word breaks

### DIFF
--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -83,3 +83,7 @@
   --pf-c-badge--m-unread--Color: var(--pf-global--primary-color--100);
   border: 1px solid var(--pf-global--primary-color--100);
 }
+
+.ws-prop-required {
+  color: var(--pf-global--danger-color--100);
+}

--- a/packages/theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/theme-patternfly-org/components/propsTable/propsTable.js
@@ -32,10 +32,7 @@ export const PropsTable = ({
         className="pf-u-mt-md pf-u-mb-lg"
         variant="compact"
         aria-label={title}
-        caption={(rows.some(prop => prop.required))
-          ? <div><span className="ws-prop-required">*</span>required</div>
-          : null
-        }
+        caption={<div><span className="ws-prop-required">*</span>required</div>}
         cells={columns}
         gridBreakPoint="grid-lg"
         rows={rows

--- a/packages/theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/theme-patternfly-org/components/propsTable/propsTable.js
@@ -5,7 +5,8 @@ import {
   TableHeader,
   TableBody,
   fitContent,
-  cellWidth
+  cellWidth,
+  breakWord
 } from '@patternfly/react-table';
 import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
 import { PropTypeWithLinks } from './propTypeWithLinks';
@@ -17,7 +18,7 @@ export const PropsTable = ({
 }) => {
   const columns = [
     { title: 'Name', transforms: [cellWidth(15)] },
-    { title: 'Type', transforms: [cellWidth(15)] },
+    { title: 'Type', transforms: [cellWidth(20)] },
     { title: 'Required', transforms: [fitContent] },
     { title: 'Default', transforms: [] },
     { title: 'Description', transforms: [] }
@@ -54,7 +55,9 @@ export const PropsTable = ({
             <div className="pf-m-break-word">
               {row.defaultValue}
             </div>,
-            row.description
+            <div className="pf-m-break-word">
+              {row.description}
+            </div>
           ]
         }))}
       >

--- a/packages/theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/theme-patternfly-org/components/propsTable/propsTable.js
@@ -8,6 +8,8 @@ import {
 } from '@patternfly/react-table';
 import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
 import { PropTypeWithLinks } from './propTypeWithLinks';
+import { css } from '@patternfly/react-styles';
+import accessibleStyles from '@patternfly/react-styles/css/utilities/Accessibility/accessibility';
 
 export const PropsTable = ({
   title,
@@ -15,7 +17,7 @@ export const PropsTable = ({
   allPropComponents
 }) => {
   const columns = [
-    { title: 'Name', transforms: [cellWidth(15)] },
+    { title: 'Name', transforms: [cellWidth(20)] },
     { title: 'Type', transforms: [cellWidth(20)] },
     { title: 'Default', transforms: [] },
     { title: 'Description', transforms: [] }
@@ -30,32 +32,50 @@ export const PropsTable = ({
         className="pf-u-mt-md pf-u-mb-lg"
         variant="compact"
         aria-label={title}
-        caption={<div><span className="ws-prop-required">*</span> indicates prop is required</div>}
+        caption={(rows.some(prop => prop.required))
+          ? <div><span className="ws-prop-required">*</span>required</div>
+          : null
+        }
         cells={columns}
         gridBreakPoint="grid-lg"
-        rows={rows.map((row, idx) => ({
-          cells: [
-            <div className="pf-m-break-word">
-              {row.deprecated && 'Deprecated: '}
-              {row.name}
-              {row.required ? <span key={row.name} className="ws-prop-required">*</span> : ''}
-              {row.beta && (
-                <Badge key={`${row.name}-${idx}`} className="ws-beta-badge pf-u-ml-sm">
-                  Beta
-                </Badge>
-              )}
-            </div>,
-            <div className="pf-m-break-word">
-              <PropTypeWithLinks type={row.type} allPropComponents={allPropComponents} />
-            </div>,
-            <div className="pf-m-break-word">
-              {row.defaultValue}
-            </div>,
-            <div className="pf-m-break-word">
-              {row.description}
-            </div>
-          ]
-        }))}
+        rows={rows
+          // Sort required rows first
+          .sort((a,b) => a.required === b.required
+            ? 0
+            : a.required ? -1 : 1)
+          .map((row, idx) => ({
+            cells: [
+              <div className="pf-m-break-word">
+                {row.deprecated && 'Deprecated: '}
+                {row.name}
+                {row.required ? (
+                  <React.Fragment key={`${row.name}-required-prop`}>
+                    <span aria-hidden="true" key={`${row.name}-asterisk`} className="ws-prop-required">
+                      *
+                    </span>
+                    <span key={`${row.name}-required`} className={css(accessibleStyles.screenReader)}>
+                      required
+                    </span>
+                  </React.Fragment>
+                ) : ''}
+                {row.beta && (
+                  <Badge key={`${row.name}-${idx}`} className="ws-beta-badge pf-u-ml-sm">
+                    Beta
+                  </Badge>
+                )}
+              </div>,
+              <div className="pf-m-break-word">
+                <PropTypeWithLinks type={row.type} allPropComponents={allPropComponents} />
+              </div>,
+              <div className="pf-m-break-word">
+                {row.defaultValue}
+              </div>,
+              <div className="pf-m-break-word">
+                {row.description}
+              </div>
+            ]
+          }))
+        }
       >
         <TableHeader />
         <TableBody />

--- a/packages/theme-patternfly-org/components/propsTable/propsTable.js
+++ b/packages/theme-patternfly-org/components/propsTable/propsTable.js
@@ -4,9 +4,7 @@ import {
   Table,
   TableHeader,
   TableBody,
-  fitContent,
-  cellWidth,
-  breakWord
+  cellWidth
 } from '@patternfly/react-table';
 import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
 import { PropTypeWithLinks } from './propTypeWithLinks';
@@ -19,7 +17,6 @@ export const PropsTable = ({
   const columns = [
     { title: 'Name', transforms: [cellWidth(15)] },
     { title: 'Type', transforms: [cellWidth(20)] },
-    { title: 'Required', transforms: [fitContent] },
     { title: 'Default', transforms: [] },
     { title: 'Description', transforms: [] }
   ];
@@ -33,6 +30,7 @@ export const PropsTable = ({
         className="pf-u-mt-md pf-u-mb-lg"
         variant="compact"
         aria-label={title}
+        caption={<div><span className="ws-prop-required">*</span> indicates prop is required</div>}
         cells={columns}
         gridBreakPoint="grid-lg"
         rows={rows.map((row, idx) => ({
@@ -40,6 +38,7 @@ export const PropsTable = ({
             <div className="pf-m-break-word">
               {row.deprecated && 'Deprecated: '}
               {row.name}
+              {row.required ? <span key={row.name} className="ws-prop-required">*</span> : ''}
               {row.beta && (
                 <Badge key={`${row.name}-${idx}`} className="ws-beta-badge pf-u-ml-sm">
                   Beta
@@ -48,9 +47,6 @@ export const PropsTable = ({
             </div>,
             <div className="pf-m-break-word">
               <PropTypeWithLinks type={row.type} allPropComponents={allPropComponents} />
-            </div>,
-            <div>
-              {row.required ? 'Yes' : 'No'}
             </div>,
             <div className="pf-m-break-word">
               {row.defaultValue}

--- a/packages/theme-patternfly-org/scripts/md/styled-tags.js
+++ b/packages/theme-patternfly-org/scripts/md/styled-tags.js
@@ -27,7 +27,7 @@ function styledTags() {
         // Match pf-c-table implementation
         // https://pf4.patternfly.org/components/table/html/basic-table/
         if (node.tagName === 'table') {
-          node.properties.className += ' pf-c-table pf-m-grid-lg';
+          node.properties.className += ' pf-c-table pf-m-grid-lg pf-m-compact';
           node.properties.role = 'grid';
           let columnHeaders = [];
           for (let child of node.children) {


### PR DESCRIPTION
Closes #2645 

This PR:
- Increases the "Type" column on component props tables from 15% to 20% width to help with text wrapping.
- Adds `breakWord` transform to the "Description" column on component props tables to fix long strings causing table to exceed parent container's width, such as with the URL in the `locale` prop description for calendar month [seen here](https://www.patternfly.org/v4/components/calendar-month/#props).
- Removes the "Required" column from the react props tables, replacing this with a red asterisk beside required prop names.
  - For components with required props, instructional text at the top of the table explains that the asterisk marks required props, and those props are listed first in alphabetical order before the rest of the optional props.