### PR TITLE
fix(docs): fixed footer floats up the page by making #main-content flex-grow

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -9,6 +9,10 @@
   background-color: var(--pf-global--BackgroundColor--light-200);
 }
 
+#main-content {
+  flex-grow: 1;
+}
+
 .ws-release-notes-toc {
   margin-bottom: var(--pf-global--spacer--lg);
 }

--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -9,10 +9,6 @@
   background-color: var(--pf-global--BackgroundColor--light-200);
 }
 
-#main-content {
-  flex-grow: 1;
-}
-
 .ws-release-notes-toc {
   margin-bottom: var(--pf-global--spacer--lg);
 }

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -160,7 +160,7 @@ export const MDXTemplate = ({
           </div>
         </PageSection>
       )}
-      <PageSection id="main-content" className={isSinglePage ? 'pf-m-fill' : 'pf-m-light'}>
+      <PageSection id="main-content" className={isSinglePage ? 'pf-m-fill' : 'pf-m-fill pf-m-light'}>
         {isSinglePage && (
             <MDXChildTemplate {...sources[0]} />
         )}


### PR DESCRIPTION
Closes #2691 

This PR:
- adds `flex-grow: 1` to `#main-content` to cause it to expand to fill the space when the contained content doesn't fill the screen.  This fixes the problem of the footer rising on the page.