### PR TITLE
feat(docs): added back to top button to site

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -305,3 +305,8 @@
   flex-grow: 1;
   padding: 0;
 }
+
+/* Overlay the footer */
+.ws-back-to-top {
+  z-index: 2;
+}

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PageSection, Title, PageNavigation, PageGroup, PageSectionVariants, Nav, NavList, NavItem } from '@patternfly/react-core';
+import { PageSection, Title, PageSectionVariants, BackToTop } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Router, useLocation } from '@reach/router';
@@ -176,6 +176,7 @@ export const MDXTemplate = ({
           </Router>
         )}
       </PageSection>
+      <BackToTop className="ws-back-to-top" scrollableSelector="#ws-page-main" />
     </React.Fragment>
   );
 }


### PR DESCRIPTION
Closes #2654 

This PR adds the new back to top button to the site, as well as custom css to set the z-index so that the button does not disappear behind the footer.