### PR TITLE
2713 Community page background color mismatch

### DIFF
--- a/packages/v4/src/pages/community.css
+++ b/packages/v4/src/pages/community.css
@@ -1,3 +1,7 @@
+.pf-c-page__main-section {
+  background-color: var(--pf-global--BackgroundColor--light-200);
+}
+
 .ws-community-page .ws-building-grid > * {
   padding: var(--pf-global--spacer--md);
   border: 1px solid var(--pf-global--palette--black-300);

--- a/packages/v4/src/pages/community.js
+++ b/packages/v4/src/pages/community.js
@@ -13,7 +13,7 @@ import MailBulkIcon from '@patternfly/react-icons/dist/esm/icons/mail-bulk-icon'
 import TwitterIcon from '@patternfly/react-icons/dist/esm/icons/twitter-icon';
 
 const CommunityPage = () => (
-    <PageSection variant={PageSectionVariants.light}>
+    <PageSection>
         <div className="ws-community-page">
             <Title size="4xl" className="pf-u-mb-lg ws-page-title" headingLevel="h2">Community</Title>
             <p>At the core of PatternFly is our community of people—in other words, our Flyers. Together, we celebrate creativity and foster a sense of teamwork and unity.</p>


### PR DESCRIPTION
Changes the background of the community page from white to light 200

<img width="1792" alt="Screen Shot 2021-10-05 at 12 45 03 PM" src="https://user-images.githubusercontent.com/21317056/136069539-b0c4ab42-8519-4b44-8874-c89910585965.png">

@evwilkin FYI

Resolves https://github.com/patternfly/patternfly-org/issues/2713