### PR TITLE
fix(docs): added React drag and drop page

### DIFF
--- a/packages/v4/patternfly-docs.source.js
+++ b/packages/v4/patternfly-docs.source.js
@@ -50,7 +50,7 @@ module.exports = (sourceMD, sourceProps) => {
   sourceProps(path.join(reactLogViewerPath, '/**/*.tsx'), reactPropsIgnore);
 
   // React MD
-  sourceMD(path.join(reactCorePath, '/**/examples/*.md'), 'react', '/**/DragDrop/examples/*.md');
+  sourceMD(path.join(reactCorePath, '/**/examples/*.md'), 'react');
   sourceMD(path.join(reactCorePath, '/**/demos/**/*.md'), 'react-demos');
 
   // React-table MD


### PR DESCRIPTION
Closes #2734 

This PR adds the react drag and drop docs to the Org build by removing the exclusion of this doc from the react markdown source file.