### PR TITLE
don't hang on node16 after finish

### DIFF
--- a/packages/theme-patternfly-org/scripts/cli/buildClient.js
+++ b/packages/theme-patternfly-org/scripts/cli/buildClient.js
@@ -20,4 +20,4 @@ buildClient()
     console.error(err);
     process.exit(3);
   })
-  .then();
+  .then(() => process.exit(0));

--- a/packages/theme-patternfly-org/scripts/cli/buildServer.js
+++ b/packages/theme-patternfly-org/scripts/cli/buildServer.js
@@ -20,5 +20,5 @@ buildServer()
     console.error(err);
     process.exit(2);
   })
-  .then();
+  .then(() => process.exit(0));
 


### PR DESCRIPTION
On node16 after building process wouldn't exit because `prerender` may have some timers still running