### PR TITLE
fix(docs): Export TypeScript examples to CodeSandbox with the correct configuration

### DIFF
--- a/packages/theme-patternfly-org/components/example/example.js
+++ b/packages/theme-patternfly-org/components/example/example.js
@@ -144,7 +144,7 @@ export const Example = ({
   const codeBoxParams = getParameters(
     lang === 'html'
       ? getStaticParams(title, editorCode)
-      : getReactParams(title, editorCode, scope)
+      : getReactParams(title, editorCode, scope, lang)
   );
   const fullscreenLink = loc.pathname.replace(/\/$/, '')
     + (loc.pathname.endsWith(source) ? '' : `/${source}`)

--- a/packages/theme-patternfly-org/helpers/codesandbox.js
+++ b/packages/theme-patternfly-org/helpers/codesandbox.js
@@ -106,7 +106,7 @@ function prettyExampleCode(title, code, declaration, identifier) {
 }
 
 // TODO: Make React examples work and use a template that has our assets.
-function getReactParams(title, code, scope) {
+function getReactParams(title, code, scope, lang) {
   let toRender = null;
   try {
     let declaration = getExampleDeclaration(code);
@@ -141,6 +141,10 @@ function getReactParams(title, code, scope) {
     '@patternfly/react-core': versions.Releases[0].versions['@patternfly/react-core']
   };
 
+  if (lang === 'ts') {
+    dependencies['@babel/runtime'] = 'latest';
+  }
+
   Object.entries(versions.Releases[0].versions)
     .filter(([pkg]) => code.includes(pkg))
     .forEach(([pkg, version]) => dependencies[pkg] = version);
@@ -163,7 +167,7 @@ function getReactParams(title, code, scope) {
 </body>
 </html>`,
       },
-      'index.js': {
+      [lang === 'ts' ? 'index.tsx' : 'index.js']: {
         content: `import ReactDOM from 'react-dom';
 import "@patternfly/react-core/dist/styles/base.css";
 import './fonts.css';
@@ -186,7 +190,7 @@ ReactDOM.render(<${toRender} />, rootElement);`
         },
       },
       'sandbox.config.json': {
-        content: { template: 'create-react-app' }
+        content: { template: lang === 'ts' ? 'create-react-app-typescript' : 'create-react-app' }
       }
     },
   }


### PR DESCRIPTION
Found when testing https://github.com/patternfly/patternfly-react/pull/6168.

Currently, the codesandbox export code assumes any non-HTML examples are JS, and uses `index.js` for the filename and `create-react-app` for the codesandbox template.

This PR checks if the example being exported is written in TypeScript, and if so it will use `index.tsx` for the filename and `create-react-app-typescript` for the template.

It also adds the `@babel/runtime` dependency for TS sandboxes, because I was getting errors without that. It's strange because that dependency is not present when manually creating a sandbox with the CRA-typescript template, but that template also does not explicitly import React or ReactDOM or call render(). Instead it just makes the component the default export and codesandbox does the rendering. Since our example code does already contain a React import and does not use default exports, it would be a pain to try and parse out those pieces when converting to a codesandbox. Using `@babel/runtime` in the sandbox dependencies solves this, I assume because it is letting the sandbox code itself do the transpiling so the imports work as expected. I'm not 100% certain there, so there may be a better way.