### PR TITLE
docs(beta): linked to beta promotion schedule in beta alert

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -54,7 +54,8 @@ const MDXChildTemplate = ({
       {beta && (
         <InlineAlert title="Beta feature">
           This Beta component is currently under review and is still open for further evolution. It is available for use in product.
-          Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>  Learn more about Beta components <a href="https://github.com/patternfly/patternfly-org/blob/main/beta-component-promotion/README.md">here</a>.
+          Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
+          Learn more about Beta components <a href="https://github.com/patternfly/patternfly-org/blob/main/beta-component-promotion/README.md">here</a>.
         </InlineAlert>
       )}
       {katacodaBroken && (

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -55,7 +55,7 @@ const MDXChildTemplate = ({
         <InlineAlert title="Beta feature">
           This Beta component is currently under review and is still open for further evolution. It is available for use in product.
           Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
-          Learn more about Beta components <a href="https://github.com/patternfly/patternfly-org/blob/main/beta-component-promotion/README.md">here</a>.
+          Learn more about Beta components <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">here</a>.
         </InlineAlert>
       )}
       {katacodaBroken && (

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -54,7 +54,7 @@ const MDXChildTemplate = ({
       {beta && (
         <InlineAlert title="Beta feature">
           This Beta component is currently under review and is still open for further evolution. It is available for use in product.
-          Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
+          Beta components are considered for promotion on a <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">quarterly basis</a>. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
         </InlineAlert>
       )}
       {katacodaBroken && (

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -54,7 +54,7 @@ const MDXChildTemplate = ({
       {beta && (
         <InlineAlert title="Beta feature">
           This Beta component is currently under review and is still open for further evolution. It is available for use in product.
-          Beta components are considered for promotion on a <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">quarterly basis</a>. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
+          Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>  Learn more about Beta components <a href="https://github.com/patternfly/patternfly-org/blob/main/beta-component-promotion/README.md">here</a>.
         </InlineAlert>
       )}
       {katacodaBroken && (


### PR DESCRIPTION
Closes #1541 

This PR adds a link to the beta promotion schedule within the beta alert at the top of beta components.

@nicolethoen let me know if you know of a better place to link to, or if we'd like to add a README to this linked page with a little context.