### PR TITLE
updated GA to gtag.js, manually set Community page title

### DIFF
--- a/packages/theme-patternfly-org/app.js
+++ b/packages/theme-patternfly-org/app.js
@@ -5,13 +5,16 @@ import { SideNavLayout } from 'theme-patternfly-org/layouts';
 import { Footer } from 'theme-patternfly-org/components';
 import { MDXTemplate } from 'theme-patternfly-org/templates/mdx';
 import { routes, groupedRoutes, fullscreenRoutes, getAsyncComponent } from './routes';
+import { googleAnalyticsID } from '../v4/patternfly-docs.config';
 import 'client-styles';
 
-const AppRoute = ({ child, katacodaLayout }) => {
+const AppRoute = ({ child, katacodaLayout, title }) => {
   const location = useLocation();
-  if (typeof window !== 'undefined' && window.ga) {
-    window.ga('set', 'page', location.pathname);
-    window.ga('send', 'pageview');
+  if (typeof window !== 'undefined' && window.gtag) {
+    gtag('config', googleAnalyticsID, {
+      'page_path': location.pathname,
+      'page_title': (title || location.pathname)
+    });
   }
   return (
     <React.Fragment>
@@ -35,6 +38,7 @@ const SideNavRouter = () => {
                 default={path === '/404'}
                 child={<Component />}
                 katacodaLayout={katacodaLayout}
+                title={title}
               />
             : <AppRoute
                 key={path}
@@ -47,6 +51,7 @@ const SideNavRouter = () => {
                   />
                 }
                 katacodaLayout={katacodaLayout}
+                title={title}
               />
           )
         }

--- a/packages/theme-patternfly-org/templates/html.ejs
+++ b/packages/theme-patternfly-org/templates/html.ejs
@@ -36,17 +36,17 @@
     >
     <% } %>
     <% if (googleAnalyticsID) { %>
-    <script>
-      if(!(parseInt(navigator.doNotTrack) === 1 || parseInt(window.doNotTrack) === 1 || parseInt(navigator.msDoNotTrack) === 1 || navigator.doNotTrack === "yes")) {
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      }
-      if (typeof ga === 'function') {
-        ga('create', '<%= googleAnalyticsID %>', 'auto', {});
-      }
-    </script>
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-47523816-1"></script>
+      <script>
+        if(!(parseInt(navigator.doNotTrack) === 1 || parseInt(window.doNotTrack) === 1 || parseInt(navigator.msDoNotTrack) === 1 || navigator.doNotTrack === "yes")) {
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '<%= googleAnalyticsID %>');
+        }
+      </script>
     <% } %>
   </body>
 </html>

--- a/packages/theme-patternfly-org/templates/html.ejs
+++ b/packages/theme-patternfly-org/templates/html.ejs
@@ -37,7 +37,7 @@
     <% } %>
     <% if (googleAnalyticsID) { %>
       <!-- Global site tag (gtag.js) - Google Analytics -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-47523816-1"></script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= googleAnalyticsID %>"></script>
       <script>
         if(!(parseInt(navigator.doNotTrack) === 1 || parseInt(window.doNotTrack) === 1 || parseInt(navigator.msDoNotTrack) === 1 || navigator.doNotTrack === "yes")) {
           window.dataLayer = window.dataLayer || [];

--- a/packages/v3/source/_includes/google-analytics.html
+++ b/packages/v3/source/_includes/google-analytics.html
@@ -1,8 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-47523816-1"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-47523816-1', 'auto');
-  ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-47523816-1');
 </script>

--- a/packages/v4/src/pages/community.js
+++ b/packages/v4/src/pages/community.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'theme-patternfly-org/components';
 import { Grid, GridItem, PageSection, Split, SplitItem, Title } from '@patternfly/react-core';
 import './community.css';
+import { getTitle } from 'theme-patternfly-org/helpers/getTitle';
 import communityPageHeader from './community-page-header.svg';
 import community1 from './community-1.svg';
 import community2 from './community-2.svg';
@@ -13,129 +14,135 @@ import MailBulkIcon from '@patternfly/react-icons/dist/esm/icons/mail-bulk-icon'
 import TwitterIcon from '@patternfly/react-icons/dist/esm/icons/twitter-icon';
 import CalendarIcon from '@patternfly/react-icons/dist/esm/icons/calendar-alt-icon';
 
-const CommunityPage = () => (
+const CommunityPage = () => {
+  if (typeof document !== 'undefined') {
+    document.title = getTitle('Community');
+  }
+
+  return (
     <PageSection className="ws-community-page">
-        <Title size="4xl" className="pf-u-mb-lg ws-page-title" headingLevel="h2">Community</Title>
-        <p>At the core of PatternFly is our community of people—in other words, our Flyers. Together, we celebrate creativity and foster a sense of teamwork and unity.</p>
+      <Title size="4xl" className="pf-u-mb-lg ws-page-title" headingLevel="h2">Community</Title>
+      <p>At the core of PatternFly is our community of people—in other words, our Flyers. Together, we celebrate creativity and foster a sense of teamwork and unity.</p>
 
-        <Grid sm={12} md={6} gutter="sm" className="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter pf-u-mt-3xl">
-            <GridItem className="pf-u-pr-xl">
-                <img src={communityPageHeader} alt="Website collaboration" />
-            </GridItem>
-            <GridItem>
-                <Title size="3xl" className="ws-title" headingLevel="h3">Who we are</Title>
-                <p>We’re made of designers, developers, and other UX professionals with a passion for open source. We each have different ways of working with others and supporting the community—there’s no one way to be a Flyer. Whether we’re contributing to PatternFly or just staying up to date on new releases, we work together to make PatternFly a vibrant community of passionate people.</p>
-            </GridItem>
-        </Grid>
+      <Grid sm={12} md={6} gutter="sm" className="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter pf-u-mt-3xl">
+        <GridItem className="pf-u-pr-xl">
+          <img src={communityPageHeader} alt="Website collaboration" />
+        </GridItem>
+        <GridItem>
+          <Title size="3xl" className="ws-title" headingLevel="h3">Who we are</Title>
+          <p>We’re made of designers, developers, and other UX professionals with a passion for open source. We each have different ways of working with others and supporting the community—there’s no one way to be a Flyer. Whether we’re contributing to PatternFly or just staying up to date on new releases, we work together to make PatternFly a vibrant community of passionate people.</p>
+        </GridItem>
+      </Grid>
 
-        <Title size="3xl" className="pf-u-mb-sm ws-page-title pf-u-mt-3xl" headingLevel="h3">What we're building</Title>
-        <p>Our work extends beyond products and apps. We’re always exploring new ways we can welcome ideas and build better experiences for the very people who make PatternFly what it is today. </p>
+      <Title size="3xl" className="pf-u-mb-sm ws-page-title pf-u-mt-3xl" headingLevel="h3">What we're building</Title>
+      <p>Our work extends beyond products and apps. We’re always exploring new ways we can welcome ideas and build better experiences for the very people who make PatternFly what it is today. </p>
 
-        <Grid sm={12} md={4} className="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-4-col-on-md pf-u-text-align-center ws-building-grid">
-            <GridItem>
-                <img src={community1} alt="Globe" className="ws-community-grid-img" />
-                <Title size="xl" className="ws-title" headingLevel="h4">Building global connections</Title>
-                <p>
-                    Flyers may be spread all over the globe, but we make sure to come together once a month to share updates and collect feedback. All meetings are recorded and published on <a href="https://www.youtube.com/channel/UCqLT0IEvYmb8z__9IFLSVyQ">PatternFly’s YouTube channel</a>, and you can join PatternFly’s mailing list for the invites.
-                </p>
-                <Title size="xl" className="ws-title" headingLevel="h4">
-                    <a href="https://www.redhat.com/mailman/listinfo/patternfly"><strong>Join our mailing list</strong></a>
-                </Title>
-            </GridItem>
-            <GridItem>
-                <img src={community2} alt="Map" className="ws-community-grid-img" />
-                <Title size="xl" className="ws-title" headingLevel="h4">Building PatternFly roadmaps</Title>
-                <p>
-                    To stay on top of all changes and keep everyone informed, we regularly update PatternFly roadmaps. This gives us an opportunity to share what Flyers are working on and what updates we’re planning.
-                </p>
-                <Title size="xl" className="ws-title" headingLevel="h4">
-                    <a href="https://github.com/orgs/patternfly/projects/4?fullscreen=true"><strong>Explore PatternFly roadmaps</strong></a>
-                </Title>
-            </GridItem>
-            <GridItem>
-                <img src={community3} alt="Figure of a person" className="ws-community-grid-img" />
-                <Title size="xl" className="ws-title" headingLevel="h4">Building accessible experiences</Title>
-                <p>
-                    A community isn’t really a community unless everyone is included, so accessible UX is important to us. We regularly test and audit PatternFly’s accessibility and share guidance whenever we can.
-                </p>
-                <Title size="xl" className="ws-title" headingLevel="h4">
-                    <Link to="/accessibility/accessibility-fundamentals">
-                        <strong>Read our accessibility guide</strong>
-                    </Link>
-                </Title>
-            </GridItem>
-        </Grid>
+      <Grid sm={12} md={4} className="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-4-col-on-md pf-u-text-align-center ws-building-grid">
+        <GridItem>
+          <img src={community1} alt="Globe" className="ws-community-grid-img" />
+          <Title size="xl" className="ws-title" headingLevel="h4">Building global connections</Title>
+          <p>
+            Flyers may be spread all over the globe, but we make sure to come together once a month to share updates and collect feedback. All meetings are recorded and published on <a href="https://www.youtube.com/channel/UCqLT0IEvYmb8z__9IFLSVyQ">PatternFly’s YouTube channel</a>, and you can join PatternFly’s mailing list for the invites.
+          </p>
+          <Title size="xl" className="ws-title" headingLevel="h4">
+            <a href="https://www.redhat.com/mailman/listinfo/patternfly"><strong>Join our mailing list</strong></a>
+          </Title>
+        </GridItem>
+        <GridItem>
+          <img src={community2} alt="Map" className="ws-community-grid-img" />
+          <Title size="xl" className="ws-title" headingLevel="h4">Building PatternFly roadmaps</Title>
+          <p>
+            To stay on top of all changes and keep everyone informed, we regularly update PatternFly roadmaps. This gives us an opportunity to share what Flyers are working on and what updates we’re planning.
+          </p>
+          <Title size="xl" className="ws-title" headingLevel="h4">
+            <a href="https://github.com/orgs/patternfly/projects/4?fullscreen=true"><strong>Explore PatternFly roadmaps</strong></a>
+          </Title>
+        </GridItem>
+        <GridItem>
+          <img src={community3} alt="Figure of a person" className="ws-community-grid-img" />
+          <Title size="xl" className="ws-title" headingLevel="h4">Building accessible experiences</Title>
+          <p>
+            A community isn’t really a community unless everyone is included, so accessible UX is important to us. We regularly test and audit PatternFly’s accessibility and share guidance whenever we can.
+          </p>
+          <Title size="xl" className="ws-title" headingLevel="h4">
+            <Link to="/accessibility/accessibility-fundamentals">
+              <strong>Read our accessibility guide</strong>
+            </Link>
+          </Title>
+        </GridItem>
+      </Grid>
 
-        <Title size="3xl" className="pf-u-mb-sm ws-page-title pf-u-mt-3xl" headingLevel="h3">Creating new communities</Title>
-        <p>Sometimes Flyers branch out and build groups of their own, which is how new communities are born. While PatternFly communities are separate from PatternFly and not supported as part of the design system, we still love seeing our Flyers forming new groups and developing their visions into actions.</p>
-        <br/>
+      <Title size="3xl" className="pf-u-mb-sm ws-page-title pf-u-mt-3xl" headingLevel="h3">Creating new communities</Title>
+      <p>Sometimes Flyers branch out and build groups of their own, which is how new communities are born. While PatternFly communities are separate from PatternFly and not supported as part of the design system, we still love seeing our Flyers forming new groups and developing their visions into actions.</p>
+      <br/>
 
-        <Title size="xl" className="pf-u-mb-sm ws-page-title pf-u-mt-xl" headingLevel="h4"><a href="https://patternflyelements.org">PatternFly Elements</a></Title>
-        <p> PatternFly Elements is a community created by Red Hat's web-based developers. It focuses on creating web components for use across Red Hat's sites and SaaS products and features theming options available for your own brand library.</p>
+      <Title size="xl" className="pf-u-mb-sm ws-page-title pf-u-mt-xl" headingLevel="h4"><a href="https://patternflyelements.org">PatternFly Elements</a></Title>
+      <p> PatternFly Elements is a community created by Red Hat's web-based developers. It focuses on creating web components for use across Red Hat's sites and SaaS products and features theming options available for your own brand library.</p>
 
-        <Title size="xl" className="pf-u-mb-sm ws-page-title pf-u-mt-xl" headingLevel="h4"><a href="https://github.com/patternfly-kotlin/patternfly-fritz2">PatternFly Fritz2</a></Title>
-        <p>PatternFly Fritz2 is a Kotlin implementation of PatternFly based on fritz2 targeting Kotlin/JS. The goal of this project is to provide all PatternFly components in Kotlin. This is done in a way that matches the reactive nature of fritz2. In particular, the components use stores, handlers, and other elements from the fritz2 API. To get a quick overview what this is all about head over to the <a href="https://patternfly-kotlin.github.io/patternfly-fritz2-showcase/#home">PatternFly Fritz2 showcase</a>.</p>
+      <Title size="xl" className="pf-u-mb-sm ws-page-title pf-u-mt-xl" headingLevel="h4"><a href="https://github.com/patternfly-kotlin/patternfly-fritz2">PatternFly Fritz2</a></Title>
+      <p>PatternFly Fritz2 is a Kotlin implementation of PatternFly based on fritz2 targeting Kotlin/JS. The goal of this project is to provide all PatternFly components in Kotlin. This is done in a way that matches the reactive nature of fritz2. In particular, the components use stores, handlers, and other elements from the fritz2 API. To get a quick overview what this is all about head over to the <a href="https://patternfly-kotlin.github.io/patternfly-fritz2-showcase/#home">PatternFly Fritz2 showcase</a>.</p>
 
-        <Title size="4xl" className="pf-u-mb-lg ws-page-title ws-keep-growing pf-u-mt-3xl" headingLevel="h2">Let's keep growing</Title>
-        <p>The PatternFly community is never finished growing, and we want to keep it that way. Feel free to reach out whenever — we’re always open.</p>
+      <Title size="4xl" className="pf-u-mb-lg ws-page-title ws-keep-growing pf-u-mt-3xl" headingLevel="h2">Let's keep growing</Title>
+      <p>The PatternFly community is never finished growing, and we want to keep it that way. Feel free to reach out whenever — we’re always open.</p>
 
-        <Grid sm={12} md={6} gutter="sm" className="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter" style={{ maxWidth: '450px' }}>
-            <GridItem>
-                <Split>
-                    <SplitItem style={{ marginRight: '12px' }}><ChatIcon /></SplitItem>
-                    <SplitItem isFilled>
-                        <Title size="lg" className="ws-title" headingLevel="h4">Chat with us</Title>
-                        <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>
-                    </SplitItem>
-                </Split>
-            </GridItem>
-            <GridItem>
-                <Split>
-                    <SplitItem style={{ marginRight: '12px' }}><MailBulkIcon /></SplitItem>
-                    <SplitItem isFilled>
-                        <Title size="lg" className="ws-title" headingLevel="h4">Stay in the loop</Title>
-                        <a href="//www.redhat.com/mailman/listinfo/patternfly" target="_blank" rel="noopener noreferrer">PatternFly mailing list</a>
-                    </SplitItem>
-                </Split>
-            </GridItem>
-            <GridItem>
-                <Split>
-                    <SplitItem style={{ marginRight: '12px' }}><QuestionIcon /></SplitItem>
-                    <SplitItem isFilled>
-                        <Title size="lg" className="ws-title" headingLevel="h4">Ask a question</Title>
-                        <a href="//forum.patternfly.org/" target="_blank" rel="noopener noreferrer">PatternFly forum</a>
-                    </SplitItem>
-                </Split>
-            </GridItem>
-            <GridItem>
-                <Split>
-                    <SplitItem style={{ marginRight: '12px' }}><CatalogIcon /></SplitItem>
-                    <SplitItem isFilled>
-                        <Title size="lg" className="ws-title" headingLevel="h4">Read the latest</Title>
-                        <a href="//medium.com/patternfly" target="_blank" rel="noopener noreferrer">PatternFly Medium</a>
-                    </SplitItem>
-                </Split>
-            </GridItem>
-            <GridItem>
-                <Split>
-                    <SplitItem style={{ marginRight: '12px' }}><TwitterIcon /></SplitItem>
-                    <SplitItem isFilled>
-                        <Title size="lg" className="ws-title" headingLevel="h4">Send us a Tweet</Title>
-                        <a href="//twitter.com/patternfly" target="_blank" rel="noopener noreferrer">PatternFly Twitter</a>
-                    </SplitItem>
-                </Split>
-            </GridItem>
-            <GridItem>
-                <Split>
-                    <SplitItem style={{ marginRight: '12px' }}><CalendarIcon /></SplitItem>
-                    <SplitItem isFilled>
-                        <Title size="lg" className="ws-title" headingLevel="h4">Attend office hours</Title>
-                        <a href="//calendar.google.com/calendar/embed?src=patternflyteam%40gmail.com&ctz=America%2FNew_York" target="_blank" rel="noopener noreferrer">PatternFly calendar</a>
-                    </SplitItem>
-                </Split>
-            </GridItem>
-        </Grid>
+      <Grid sm={12} md={6} gutter="sm" className="pf-u-my-lg pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter" style={{ maxWidth: '450px' }}>
+        <GridItem>
+          <Split>
+            <SplitItem style={{ marginRight: '12px' }}><ChatIcon /></SplitItem>
+            <SplitItem isFilled>
+              <Title size="lg" className="ws-title" headingLevel="h4">Chat with us</Title>
+              <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>
+            </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem>
+          <Split>
+            <SplitItem style={{ marginRight: '12px' }}><MailBulkIcon /></SplitItem>
+            <SplitItem isFilled>
+              <Title size="lg" className="ws-title" headingLevel="h4">Stay in the loop</Title>
+              <a href="//www.redhat.com/mailman/listinfo/patternfly" target="_blank" rel="noopener noreferrer">PatternFly mailing list</a>
+            </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem>
+          <Split>
+            <SplitItem style={{ marginRight: '12px' }}><QuestionIcon /></SplitItem>
+            <SplitItem isFilled>
+              <Title size="lg" className="ws-title" headingLevel="h4">Ask a question</Title>
+              <a href="//forum.patternfly.org/" target="_blank" rel="noopener noreferrer">PatternFly forum</a>
+            </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem>
+          <Split>
+            <SplitItem style={{ marginRight: '12px' }}><CatalogIcon /></SplitItem>
+            <SplitItem isFilled>
+              <Title size="lg" className="ws-title" headingLevel="h4">Read the latest</Title>
+              <a href="//medium.com/patternfly" target="_blank" rel="noopener noreferrer">PatternFly Medium</a>
+            </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem>
+          <Split>
+            <SplitItem style={{ marginRight: '12px' }}><TwitterIcon /></SplitItem>
+            <SplitItem isFilled>
+              <Title size="lg" className="ws-title" headingLevel="h4">Send us a Tweet</Title>
+              <a href="//twitter.com/patternfly" target="_blank" rel="noopener noreferrer">PatternFly Twitter</a>
+            </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem>
+          <Split>
+            <SplitItem style={{ marginRight: '12px' }}><CalendarIcon /></SplitItem>
+            <SplitItem isFilled>
+              <Title size="lg" className="ws-title" headingLevel="h4">Attend office hours</Title>
+              <a href="//calendar.google.com/calendar/embed?src=patternflyteam%40gmail.com&ctz=America%2FNew_York" target="_blank" rel="noopener noreferrer">PatternFly calendar</a>
+            </SplitItem>
+          </Split>
+        </GridItem>
+      </Grid>
     </PageSection>
-);
+  )
+};
 
 export default CommunityPage;


### PR DESCRIPTION
Closes #2793 
Closes #2792 

This PR:
- Replaces analytics.js tag with new gtag.js tag
  - [Reference docs](https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs): see [Replace the analytics.js snippet with the gtag.js snippet](https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs#analyticsjs_2_gtagjs) and [Measure pageviews](https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs#measure_pageviews) sections.
- Manually sets the page title for the `Community` page which is not updating when navigating from another page
  - note: only change is `if` statement and adding `return` keyword at the top (diff shows much larger due to these updates pushing around the rest of the code)

Tested in PF's GA account by editing [this line](https://github.com/patternfly/patternfly-org/blob/main/packages/theme-patternfly-org/scripts/webpack/getHtmlWebpackPlugins.js#L25) to enable analytics to fire in local dev build & compare incoming analytics to those fired by current site implementation.