### PR TITLE
Feat/Enable build and development for Windows users

### DIFF
--- a/packages/theme-patternfly-org/scripts/md/mdx-hast-to-jsx.js
+++ b/packages/theme-patternfly-org/scripts/md/mdx-hast-to-jsx.js
@@ -69,7 +69,7 @@ function serializeRoot(node, options) {
 
   const importStatements = groups.import
     .map(node => node.value)
-    .map(imp => imp.replace(/(['"])\./g, (_, match) => `${match}${getRelPath()}${path.sep}\.`))
+    .map(imp => imp.replace(/(['"])\./g, (_, match) => `${match}${getRelPath()}${path.posix.sep}\.`))
     .concat(thumbnailImports)
     .join('\n')
 

--- a/packages/theme-patternfly-org/scripts/md/parseMD.js
+++ b/packages/theme-patternfly-org/scripts/md/parseMD.js
@@ -26,7 +26,7 @@ function toReactComponent(mdFilePath, source, buildMode) {
   // vfiles allow for nicer error messages and have native `unified` support
   const vfile = toVfile.readSync(mdFilePath);
 
-  const relPath = path.relative(path.join(process.cwd(), '../..'), vfile.path);
+  const relPath = path.relative(path.join(process.cwd(), '../..'), vfile.path).split(path.sep).join(path.posix.sep);
 
   let jsx;
   let outPath;
@@ -212,7 +212,7 @@ function toReactComponent(mdFilePath, source, buildMode) {
     // Transform HAST object to JSX string
     .use(require('./mdx-hast-to-jsx'), {
       getOutPath: () => outPath,
-      getRelPath: () => path.relative(path.dirname(outPath), vfile.dirname), // for imports
+      getRelPath: () => path.relative(path.dirname(outPath), vfile.dirname).split(path.sep).join(path.posix.sep), // for imports
       getPageData: () => pageData // For @reach/router routing
     })
     .process(vfile, (err, file) => {

--- a/packages/theme-patternfly-org/scripts/webpack/webpack.base.config.js
+++ b/packages/theme-patternfly-org/scripts/webpack/webpack.base.config.js
@@ -36,7 +36,8 @@ module.exports = (_env, argv) => {
           include: [
             path.resolve(process.cwd(), 'src'),
             path.resolve(__dirname, '../..'), // Temporarily compile theme using webpack for development
-            /react-[\w-]+\/src\/.*\/examples/
+            /react-[\w-]+\/src\/.*\/examples/,
+            /react-[\w-]+\\src\\.*\\examples/ // fix for Windows
           ],
           exclude: [
             path.resolve(__dirname, '../../node_modules'), // Temporarily compile theme using webpack for development


### PR DESCRIPTION
Windows has a different string for path separator `\`, we need to replace those to POSIX standard separator `/` to correctly import all the resources in the markdown files. Also, update the webpack config to correctly apply the babel loader.