### PR TITLE
feat(icons): added FileIcon to icons page

### DIFF
--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.js
@@ -339,6 +339,13 @@ export const iconsData = [
   },
   {
     "Style": "fas",
+    "Name": "fa-file",
+    "React_name": "FileIcon",
+    "Type": " ",
+    "Contextual_usage": " ",
+  },
+  {
+    "Style": "fas",
     "Name": "fa-filter",
     "React_name": "FilterIcon",
     "Type": "Action",

--- a/packages/v4/src/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/src/content/design-guidelines/styles/icons/icons.js
@@ -341,8 +341,8 @@ export const iconsData = [
     "Style": "fas",
     "Name": "fa-file",
     "React_name": "FileIcon",
-    "Type": " ",
-    "Contextual_usage": " ",
+    "Type": "Framework",
+    "Contextual_usage": "Represents a file type",
   },
   {
     "Style": "fas",


### PR DESCRIPTION
Closes #2805 

This PR: 
- Adds the font awesome `FileIcon` to our [Icons page](https://patternfly-org-pr-2834-v4.surge.sh/v4/guidelines/icons) (it was already included in our code base but was not one of the icons displayed on our site [here](https://github.com/patternfly/patternfly-org/blob/main/packages/v4/src/content/design-guidelines/styles/icons/icons.js))
- TODO:  @doruskova - need to add "Type" (Framework/Brands/Status/Action/Object/View Type) and "Contextual usage" copy to add to this icon listing.