### PR TITLE
chore(docs): enabled algolia search analytics

### DIFF
--- a/packages/v4/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs.config.js
@@ -3,7 +3,8 @@ module.exports = {
   pathPrefix: '/v4',
   googleAnalyticsID: 'UA-47523816-6',
   algolia: {
-    apiKey: '06941733239da4f8617d272cf2ed4d5c',
+    apiKey: 'a8fb1726b78594ff97a3418757514404',
+    appId: '79P4ZBH7A3',
     indexName: 'patternfly'
   },
   hasGdprBanner: true,


### PR DESCRIPTION
Closes #2754 

Rather than track searches through Google Analytics, this PR enables the default search analytics automatically tracked by Algolia & accessible through the user dashboard in our account.

No analytics were previously being tracked, but these have been enabled by simply updating our API key to the current key & providing the `appId` as well - this last step is not clearly laid out in the docsearch docs as a requirement for analytics but was key in getting this working.

Note: confirming it is okay for this API key to be publicly viewable, per Algolia:

> This is the public API key which can be safely used in your frontend code.This key is usable for search queries and it's also able to list the indices you've got access to.

Result showing test searches coming through:
![Screen Shot 2022-02-11 at 11 24 14 AM](https://user-images.githubusercontent.com/8651509/153634666-002f052a-9417-49b6-afbb-0448d831e559.png)

