### PR TITLE
fix(docs): fixed to allow cmd/ctrl+click opening in new tab

### DIFF
--- a/packages/theme-patternfly-org/components/link/link.js
+++ b/packages/theme-patternfly-org/components/link/link.js
@@ -51,12 +51,14 @@ export const Link = ({
         };
         // Wait up to an extra 500ms on click before showing 'Loading...'
         props.onClick = ev => {
-          ev.preventDefault();
-          if (typeof window !== 'undefined' && url !== location.pathname) {
-            Promiseany([
-              preloadPromise,
-              new Promise(res => setTimeout(res, 500))
-            ]).then(() => navigate(url));
+          if (!(ev.ctrlKey || ev.metaKey)) { // avoid disallowing cmnd/ctrl+click opening in new tab
+            ev.preventDefault();
+            if (typeof window !== 'undefined' && url !== location.pathname) {
+              Promiseany([
+                preloadPromise,
+                new Promise(res => setTimeout(res, 500))
+              ]).then(() => navigate(url));
+            }
           }
         };
       }


### PR DESCRIPTION
Closes #2836 

This PR reinstates default link behavior of detecting cmd/ctrl+click on links, fixing the current inability to cmd/ctrl+click on a sidenav link to open it in a new tab.