### PR TITLE
fix: stop example widths from being wider than parent on mobile viewports

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -294,7 +294,7 @@
 
 .ws-mdx-content {
   flex-grow: 1;
-  width: 100%;
+  min-width: 0;
 }
 
 /* Design asked for this. A nice side effect is that the TOC doesn't "jump" between pages */

--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -294,6 +294,7 @@
 
 .ws-mdx-content {
   flex-grow: 1;
+  width: 100%;
 }
 
 /* Design asked for this. A nice side effect is that the TOC doesn't "jump" between pages */


### PR DESCRIPTION
to test, make your viewport width very narrow.
before this change, notice the examples are spilling over to the right like in the screenshot below from the Table with actions example where the actions kabob is completely off screen to the right. After this change, the examples don't spill over.


before:
![Screen Shot 2022-03-03 at 8 43 55 AM](https://user-images.githubusercontent.com/26305082/156577158-ab95aa63-fa14-4717-9202-90623087121a.png)

