### PR TITLE
chore(docs): added mobile jumplinks and example styling

### DIFF
--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -9,6 +9,12 @@
   border-bottom: var(--pf-global--BorderWidth--sm) solid #f8f8f8;
 }
 
+.ws-example > .ws-example-header,
+.pf-c-code-editor__header,
+#ws-react-c-card-modifiers > div:first-child {
+  background-color: var(--pf-global--BackgroundColor--200);
+}
+
 .ws-example-header > .ws-example-heading:not(:last-child) {
   margin-bottom: var(--pf-global--spacer--md);
 }

--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -9,6 +9,11 @@
   border-bottom: var(--pf-global--BorderWidth--sm) solid #f8f8f8;
 }
 
+.ws-example > .ws-example-header,
+.ws-example > .pf-c-code-editor > .pf-c-code-editor__header {
+  background-color: var(--pf-global--BackgroundColor--200);
+}
+
 .ws-example-header > .ws-example-heading:not(:last-child) {
   margin-bottom: var(--pf-global--spacer--md);
 }

--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -12,21 +12,24 @@
   margin-bottom: var(--pf-global--spacer--md);
 }
 
-.ws-code-editor > .pf-c-code-editor__header::before {
-  content: none;
+.ws-code-editor:not(.ws-example-code-expanded) > .pf-c-code-editor__header::before {
+  --pf-c-code-editor__header--before--BorderBottomWidth: 0;
 }
 
-.ws-code-editor-control::after {
-  display: none;
+.ws-code-editor-control {
+  --pf-c-button--m-control--BackgroundColor: transparent;
+  --pf-c-button--m-control--active--BackgroundColor: transparent;
+  --pf-c-button--m-control--focus--BackgroundColor: transparent;
+  --pf-c-button--m-control--hover--BackgroundColor: transparent;
 }
 
 .ws-code-editor-control.pf-c-button {
-  background: none;
+  --pf-c-button--after--BorderWidth: 0;
 }
 
 .ws-preview {
   padding: 1rem;
-  background-color: white;
+  background-color: var(--pf-global--BackgroundColor--100);
   border-bottom: 1px solid #f8f8f8;
   transition: width .2s ease-in-out;
 }

--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -1,5 +1,4 @@
 .ws-example {
-  background-color: white;
   margin-top: 25px;
   margin-bottom: 25px;
 }
@@ -9,13 +8,20 @@
   border-bottom: var(--pf-global--BorderWidth--sm) solid #f8f8f8;
 }
 
-.ws-example > .ws-example-header,
-.ws-example > .pf-c-code-editor > .pf-c-code-editor__header {
-  background-color: var(--pf-global--BackgroundColor--200);
-}
-
 .ws-example-header > .ws-example-heading:not(:last-child) {
   margin-bottom: var(--pf-global--spacer--md);
+}
+
+.ws-code-editor > .pf-c-code-editor__header::before {
+  content: none;
+}
+
+.ws-code-editor-control::after {
+  display: none;
+}
+
+.ws-code-editor-control.pf-c-button {
+  background: none;
 }
 
 .ws-preview {

--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -9,12 +9,6 @@
   border-bottom: var(--pf-global--BorderWidth--sm) solid #f8f8f8;
 }
 
-.ws-example > .ws-example-header,
-.pf-c-code-editor__header,
-#ws-react-c-card-modifiers > div:first-child {
-  background-color: var(--pf-global--BackgroundColor--200);
-}
-
 .ws-example-header > .ws-example-heading:not(:last-child) {
   margin-bottom: var(--pf-global--spacer--md);
 }

--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -29,7 +29,7 @@
 
 .ws-preview {
   padding: 1rem;
-  background-color: var(--pf-global--BackgroundColor--100);
+  background-color: white;
   border-bottom: 1px solid #f8f8f8;
   transition: width .2s ease-in-out;
 }

--- a/packages/theme-patternfly-org/components/example/exampleToolbar.js
+++ b/packages/theme-patternfly-org/components/example/exampleToolbar.js
@@ -38,22 +38,16 @@ export const ExampleToolbar = ({
   setCode
 }) => {
   const [isEditorOpen, setIsEditorOpen] = React.useState(false);
-  const [copied, setCopied] = React.useState(false);
-  let timer;
+  const [isCopied, setCopied] = React.useState(false);
 
   const copyCode = () => {
     copy(code);
 
-    if (timer) {
-      clearTimeout(timer);
+    setCopied(true);
+    // Reset isCopied after Tooltip fades out
+    setTimeout(() => {
       setCopied(false);
-    }
-    setCopied(true, () => {
-      timer = setTimeout(() => {
-        setCopied(false);
-        timer = null;
-      }, 2500);
-    });
+    }, 2500);
   };
 
   const copyLabel = 'Copy code to clipboard';
@@ -83,8 +77,8 @@ export const ExampleToolbar = ({
       />
       <Tooltip
         trigger="mouseenter"
-        content={<div>{copied ? 'Code copied' : copyLabel}</div>}
-        exitDelay={copied ? 1600 : 300}
+        content={<div>{isCopied ? 'Code copied' : copyLabel}</div>}
+        exitDelay={isCopied ? 1600 : 300}
         entryDelay={300}
         maxWidth="100px"
         position="top"
@@ -92,7 +86,7 @@ export const ExampleToolbar = ({
         <Button onClick={() => {
           copyCode();
           trackEvent('code_editor_control_click', 'click_event', 'COPY_CODE');
-        }} variant="plain" aria-label={copyLabel} className="ws-code-editor-control">
+        }} variant="control" aria-label={copyLabel} className="ws-code-editor-control">
           <CopyIcon />
         </Button>
       </Tooltip>
@@ -114,7 +108,7 @@ export const ExampleToolbar = ({
           >
             <Button
               aria-label={codesandboxLabel}
-              variant="plain"
+              variant="control"
               type="submit"
               onClick={() => {
                 trackEvent('code_editor_control_click', 'click_event', 'CODESANDBOX_LINK');
@@ -198,7 +192,7 @@ export const ExampleToolbar = ({
       onChange={newCode => setCode(newCode)}
       onEditorDidMount={onEditorDidMount}
       isReadOnly={isFullscreen}
-      className="ws-code-editor"
+      className={`${isEditorOpen ? 'ws-example-code-expanded ' : ''}ws-code-editor`}
     />
   );
 }

--- a/packages/theme-patternfly-org/components/example/exampleToolbar.js
+++ b/packages/theme-patternfly-org/components/example/exampleToolbar.js
@@ -79,6 +79,7 @@ export const ExampleToolbar = ({
         aria-label={languageLabel}
         toolTipText={languageLabel}
         aria-expanded={isEditorOpen}
+        className="ws-code-editor-control"
       />
       <Tooltip
         trigger="mouseenter"
@@ -91,7 +92,7 @@ export const ExampleToolbar = ({
         <Button onClick={() => {
           copyCode();
           trackEvent('code_editor_control_click', 'click_event', 'COPY_CODE');
-        }} variant="control" aria-label={copyLabel}>
+        }} variant="plain" aria-label={copyLabel} className="ws-code-editor-control">
           <CopyIcon />
         </Button>
       </Tooltip>
@@ -113,11 +114,12 @@ export const ExampleToolbar = ({
           >
             <Button
               aria-label={codesandboxLabel}
-              variant="control"
+              variant="plain"
               type="submit"
               onClick={() => {
                 trackEvent('code_editor_control_click', 'click_event', 'CODESANDBOX_LINK');
               }}
+              className="ws-code-editor-control"
             >
               <input type="hidden" name="parameters" value={codeBoxParams} />
               <CodepenIcon />
@@ -137,6 +139,7 @@ export const ExampleToolbar = ({
           onClick={() => {
             trackEvent('code_editor_control_click', 'click_event', 'FULLSCREEN_LINK');
           }}
+          className="ws-code-editor-control"
         />
       }
       {isEditorOpen && lang === 'ts' &&
@@ -152,6 +155,7 @@ export const ExampleToolbar = ({
             setCode(convertToJSX(code).code);
             trackEvent('code_editor_control_click', 'click_event', 'TS_TO_JS');
           }}
+          className="ws-code-editor-control"
         />
       }
       {code !== originalCode &&
@@ -163,6 +167,7 @@ export const ExampleToolbar = ({
             setCode(originalCode);
             trackEvent('code_editor_control_click', 'click_event', 'RESET_CODE');
           }}
+          className="ws-code-editor-control"
         />
       }
     </React.Fragment>
@@ -193,6 +198,7 @@ export const ExampleToolbar = ({
       onChange={newCode => setCode(newCode)}
       onEditorDidMount={onEditorDidMount}
       isReadOnly={isFullscreen}
+      className="ws-code-editor"
     />
   );
 }

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
@@ -7,6 +7,11 @@
   z-index: 1;
   margin: calc(var(--pf-c-page__main-section--PaddingTop) * -1) calc(var(--pf-c-page__main-section--PaddingRight) * -2) var(--pf-global--spacer--md) calc(var(--pf-c-page__main-section--PaddingLeft) * -1);
   padding: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) var(--pf-global--spacer--md);
+  box-shadow: var(--pf-global--BoxShadow--lg-bottom);
+}
+
+.ws-toc.pf-m-expanded {
+  box-shadow: var(--pf-global--BoxShadow--sm-bottom)
 }
 
 /* Hide TOC scrollbar Chrome, Safari & Opera */
@@ -27,6 +32,11 @@
     flex-grow: 1;
     background: none;
     margin: 0;
+  }
+
+  .ws-toc,
+  .ws-toc.pf-m-expanded {
+    box-shadow: none;
   }
 }
 

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
@@ -46,8 +46,3 @@
 .ws-toc-item.pf-m-current .pf-c-jump-links__link::before {
   z-index: 1;
 }
-
-/* Hide left border */
-.ws-toc > .pf-c-expandable-section.pf-m-expanded::after {
-  content: none;
-}

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
@@ -1,16 +1,12 @@
 .ws-toc {
   top: 0;
-  order: 1;
-  flex-grow: 1;
-  position: sticky;
-  padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--2xl);
   align-self: flex-start;
-  width: 280px;
-  max-height: calc(100vh - 76px);
-  overflow-y: auto;
-  /* Hide TOC scrollbar IE, Edge & Firefox */
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  position: sticky;
+  width: calc(100% + var(--pf-c-page__main-section--PaddingLeft) + var(--pf-c-page__main-section--PaddingRight));
+  background-color: var(--pf-global--BackgroundColor--200);
+  z-index: 1;
+  margin: calc(var(--pf-c-page__main-section--PaddingTop) * -1) calc(var(--pf-c-page__main-section--PaddingRight) * -2) var(--pf-global--spacer--md) calc(var(--pf-c-page__main-section--PaddingLeft) * -1);
+  padding: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) var(--pf-global--spacer--md);
 }
 
 /* Hide TOC scrollbar Chrome, Safari & Opera */
@@ -18,21 +14,20 @@
   display: none;
 }
 
-@media (max-width: 1450px) {
+@media (min-width: 1451px) {
   .ws-toc {
-    display: none;
-    visibility: hidden;
+    width: 280px;
+    max-height: calc(100vh - 76px);
+    overflow-y: auto;
+    /* Hide TOC scrollbar IE, Edge & Firefox */
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    order: 1;
+    padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--2xl);
+    flex-grow: 1;
+    background: none;
+    margin: 0;
   }
-}
-
-.ws-toc-list {
-  position: relative;
-  margin-top: var(--pf-global--spacer--sm);
-}
-
-.ws-toc-list .pf-c-jump-links__list {
-  padding-top: 0;
-  padding-bottom: 0;
 }
 
 /* .ws-toc-link { */
@@ -50,4 +45,9 @@
 
 .ws-toc-item.pf-m-current .pf-c-jump-links__link::before {
   z-index: 1;
+}
+
+/* Hide left border */
+.ws-toc > .pf-c-expandable-section.pf-m-expanded::after {
+  content: none;
 }

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
@@ -4,8 +4,6 @@ import './tableOfContents.css';
 import { trackEvent } from '../../helpers';
 
 export const TableOfContents = ({ items }) => {
-  const WrapperComponent = window.innerWidth > 1450 ? React.Fragment : ExpandableSection;
-
   function renderItem(item, index) {
     return Array.isArray(item)
       ? (
@@ -20,29 +18,16 @@ export const TableOfContents = ({ items }) => {
       )
   }
 
-  function getToc () {
-    return window.innerWidth > 1450
-      ? (
-        <>
-          <Title headingLevel="h2" size="lg">
-            Table of contents
-          </Title>
-          <JumpLinks isVertical scrollableSelector="#ws-page-main" className="ws-toc-list" offset={92}>
-            {items.map(renderItem)}
-          </JumpLinks>
-        </>
-      ) : (
-        <ExpandableSection displaySize='large' title='Table of contents'>
-          <JumpLinks isVertical scrollableSelector="#ws-page-main" className="ws-toc-list" offset={92}>
-            {items.map(renderItem)}
-          </JumpLinks>
-        </ExpandableSection>
-      )
-  }  
-
   return (
-    <nav className="ws-toc">
-      {getToc()}
-    </nav>
+    <JumpLinks
+      label="Table of contents"
+      isVertical
+      scrollableSelector="#ws-page-main"
+      className="ws-toc"
+      offset={148}
+      expandable={{ default: 'expandable', '2xl': 'nonExpandable' }}
+    >
+      {items.map(renderItem)}
+    </JumpLinks>
   );
 }

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
@@ -1,17 +1,30 @@
 import React from 'react';
-import { Title, JumpLinks, JumpLinksItem, JumpLinksList, ExpandableSection } from '@patternfly/react-core';
+import { JumpLinks, JumpLinksItem, JumpLinksList } from '@patternfly/react-core';
 import './tableOfContents.css';
 import { trackEvent } from '../../helpers';
 
 export const TableOfContents = ({ items }) => {
-  function renderItem(item, index) {
+  const [width, setWidth] = React.useState(window.innerWidth);
+
+  const updateWidth = () => {
+    const { innerWidth } = window;
+    innerWidth !== width && setWidth(innerWidth);
+  }
+
+  const renderItem = (item, index) => {
     return Array.isArray(item)
       ? (
         <JumpLinksList key={index} className="ws-toc-sublist">
           {item.map(renderItem)}
         </JumpLinksList>
       ) : (
-        <JumpLinksItem key={item.id} href={`#${item.id}`} className="ws-toc-item" onClick={() => trackEvent('jump_link_click', 'click_event', item.id.toUpperCase())
+        <JumpLinksItem
+          key={item.id}
+          href={`#${item.id}`}
+          className="ws-toc-item"
+          onKeyDown={updateWidth}
+          onMouseDown={updateWidth}
+          onClick={() => trackEvent('jump_link_click', 'click_event', item.id.toUpperCase())
         }>
           {item.text}
         </JumpLinksItem>
@@ -24,7 +37,7 @@ export const TableOfContents = ({ items }) => {
       isVertical
       scrollableSelector="#ws-page-main"
       className="ws-toc"
-      offset={148}
+      offset={width > 1450 ? 92 : 148}
       expandable={{ default: 'expandable', '2xl': 'nonExpandable' }}
     >
       {items.map(renderItem)}

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Title, JumpLinks, JumpLinksItem, JumpLinksList } from '@patternfly/react-core';
+import { Title, JumpLinks, JumpLinksItem, JumpLinksList, ExpandableSection } from '@patternfly/react-core';
 import './tableOfContents.css';
 import { trackEvent } from '../../helpers';
 
 export const TableOfContents = ({ items }) => {
+  const WrapperComponent = window.innerWidth > 1450 ? React.Fragment : ExpandableSection;
+
   function renderItem(item, index) {
     return Array.isArray(item)
       ? (
@@ -16,16 +18,31 @@ export const TableOfContents = ({ items }) => {
           {item.text}
         </JumpLinksItem>
       )
+  }
+
+  function getToc () {
+    return window.innerWidth > 1450
+      ? (
+        <>
+          <Title headingLevel="h2" size="lg">
+            Table of contents
+          </Title>
+          <JumpLinks isVertical scrollableSelector="#ws-page-main" className="ws-toc-list" offset={92}>
+            {items.map(renderItem)}
+          </JumpLinks>
+        </>
+      ) : (
+        <ExpandableSection displaySize='large' title='Table of contents'>
+          <JumpLinks isVertical scrollableSelector="#ws-page-main" className="ws-toc-list" offset={92}>
+            {items.map(renderItem)}
+          </JumpLinks>
+        </ExpandableSection>
+      )
   }  
 
   return (
     <nav className="ws-toc">
-      <Title headingLevel="h2" size="lg">
-        Table of contents
-      </Title>
-      <JumpLinks isVertical scrollableSelector="#ws-page-main" className="ws-toc-list" offset={92}>
-        {items.map(renderItem)}
-      </JumpLinks>
+      {getToc()}
     </nav>
   );
 }

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
@@ -4,8 +4,8 @@ import './tableOfContents.css';
 import { trackEvent } from '../../helpers';
 
 export const TableOfContents = ({ items }) => {
+  // Used to recalculate JumpLinks offset if screen size changes
   const [width, setWidth] = React.useState(window.innerWidth);
-
   const updateWidth = () => {
     const { innerWidth } = window;
     innerWidth !== width && setWidth(innerWidth);

--- a/packages/theme-patternfly-org/templates/mdx.css
+++ b/packages/theme-patternfly-org/templates/mdx.css
@@ -292,6 +292,12 @@
   border-width: 0;
 }
 
+@media screen and (max-width: 1450px) {
+  .ws-mdx-child-template {
+    flex-direction: column;
+  }
+}
+
 .ws-mdx-content {
   flex-grow: 1;
 }

--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -67,7 +67,7 @@ const MDXChildTemplate = ({
   );
   // Create dynamic component for @reach/router
   const ChildComponent = () => (
-    <div className="pf-u-display-flex">
+    <div className="pf-u-display-flex ws-mdx-child-template">
       {toc.length > 1 && (
         <TableOfContents items={toc} />
       )}


### PR DESCRIPTION
Closes #2843 

This PR:
- Unhides the jumplinks which are currently hidden at <=1450px and utilizes the component's mobile layout plus custom styles from designs in #2843 
- Removes background from example headers/controls
- Remove borders from CodeEditorControls below each example, except for the blue bottom border on hover/focus/active
- Remove border below `.pf-c-code-editor__header` above example code except when example code is expanded
- Simplifies copy function for example code to fix console error currently being thrown