### PR TITLE
fix(docs): fixed font awesome typos

### DIFF
--- a/packages/v4/src/content/get-started/develop.md
+++ b/packages/v4/src/content/get-started/develop.md
@@ -140,7 +140,7 @@ PatternFly uses Font Awesome 5. Font Awesome 5 can be utilized in two different 
 
   * **Used as a CDN**
 
-  If you wish to use the CDN for Font Awesome 5 rather than the default approach, you need to update the ```utilities/variables.scss``` file (from source ```node_modules/@patternfly/patternfly/```) and build PatternFly as part of your build process.
+  If you wish to use the CDN for Font Awesome 5 rather than the default approach, you need to update the ```sass-utilities/scss-variables.scss``` file (from source ```node_modules/@patternfly/patternfly/```) and build PatternFly as part of your build process.
 
   To use the CDN vs the standard build, update the ```sass-utilities/scss-variables.scss``` file as follows:
 

--- a/packages/v4/src/content/get-started/develop.md
+++ b/packages/v4/src/content/get-started/develop.md
@@ -114,21 +114,9 @@ Use these files to consume the library. The recommended consumption approach wil
 ### Using styles
 **Typography**
 
-PatternFly uses the Overpass font family. Overpass can be utilized in two different ways:
+PatternFly uses the Red Hat font family. By default, Red Hat fonts are included as part of the PatternFly distributed CSS file. You do not need to do anything with your configuration to use this font family.
 
-  * **Built into PatternFly**
-
-  By default, Overpass is included as part of the PatternFly distributed CSS file. You do not need to do anything with your configuration to use this font family.
-
-  * **Used as a CDN**
-
-  If you wish to use the CDN for Overpass rather than the default approach, you need to update the ```sass-utilities/scss-variables.scss``` file and build PatternFly as part of your build process.
-
-  To use the CDN vs the standard build, update the ```sass-utilities/scss-variables.scss``` file as follows:
-
-  ```scss
-  $pf-global--enable-font-overpass-cdn: true !default;
-  ```
+The official documentation for the Red Hat font family can be found at the [RedHatOfficial/RedHatFont repo](https://github.com/RedHatOfficial/RedHatFont). A number of opt-in classes to expand the feature set of the default Red Hat font family within PatternFly, including variable font files and updated monospace fonts, can be found on the [Red Hat font page](/developer-resources/red-hat-font/). For additional guidelines on typography implementation in PatternFly see the [PatternFly typography guidelines](/guidelines/typography/).
 
 **Icons**
 

--- a/packages/v4/src/content/get-started/develop.md
+++ b/packages/v4/src/content/get-started/develop.md
@@ -136,7 +136,7 @@ PatternFly uses Font Awesome 5. Font Awesome 5 can be utilized in two different 
 
   * **Built into PatternFly**
 
-  By default, Overpass is included as part of the PatternFly distributed CSS file. You do not need to do anything with your configuration to use this font family.
+  By default, Font Awesome is included as part of the PatternFly distributed CSS file. You do not need to do anything with your configuration to use this icon font family.
 
   * **Used as a CDN**
 


### PR DESCRIPTION
Closes #2832 

This PR fixes typos in the getting started for developers page around font awesome implementation instructions.