### PR TITLE
Add information about contributing custom icons

### DIFF
--- a/packages/v4/src/content/contribute/design/design.md
+++ b/packages/v4/src/content/contribute/design/design.md
@@ -31,4 +31,12 @@ __Example__
 
 To open an issue or browse existing issues, visit the [patternfly-design-kit repo](https://github.com/patternfly/patternfly-design-kit/) on GitHub.
 
+### Contributing new icons
+We encourage designers to work with the existing PatternFly icon set when choosing icons to use in their project. These include both custom and existing Font Awesome icons that cover most common use cases. To see what's available, vist our [Icons page](https://www.patternfly.org/v4/guidelines/icons). There may be occasions where you want to propose a new icon to be added to PatternFly.
+
+__Example__
+*I want to add a new custom icon to PatternFly to meet my project specific need.*
+
+Start by opening an issue in the [patternfly-design]([open a new issue](https://github.com/patternfly/patternfly-design/issues) repo proposing a new icon and why it's needed. To contribute a new icon, you can follow the procedure outlined here for [creating custom icons](https://github.com/patternfly/patternfly-design/wiki/Creating-custom-icons) and adding them to the PatternFly icon set.
+
 **If you are interested in contributing to any of the projects above, feel free to reach out to us on the patternfly-design channel on [Slack](https://slack.patternfly.org/).**


### PR DESCRIPTION
This PR exposes the newly documented icon creation process in the Contribute section of the website here: https://www.patternfly.org/v4/contribute/design. This includes a brief introduction and link to the detailed process that exists in the patternfly-design repo.