### PR TITLE
docs(Tooltip): add a11y docs

### DIFF
--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -17,20 +17,19 @@ The preferred method of using the tooltip is by wrapping it around its trigger v
 
 To ensure the tooltip is used accessibly, follow these steps when applicable:
 
-- When adding a tooltip to a static element, such as a `span` or `div`, you must ensure:
-    - The static element has `tabindex="0"` passed in, so that keyboard users can place focus on it to trigger the tooltip, and there is some form of styling to visually let users know the element can be focused/hovered (usually an underline on the text).
-    - When using the `children` prop, `aria-live="polite"` and `aria="none"` are passed into the tooltip. Tooltips on static elements do not always get announced by assistive technologies by default, so passing in `aria-live` allows the tooltip contents to be announced while `aria="none"` ensures the tooltip does not get announced more than once.
-- When the tooltip content is expected or intended to dynamically update and the `children` prop is being used, you must also pass in `aria-live="polite"` and `aria="none"` to ensure the updated content gets announced to users and that the the tooltip does not get announced more than once.
-- When passing in the `id` prop and using the `children` prop you should also pass in `aria="none"`, and then either `aria-describedby` or `aria-labelledby` to the tooltips' trigger. The aria attribute passed into the trigger should have the tooltips' `id` prop passed in as a value.
+- Tooltips should not be added to static elements, such as a `div` or `span`.
+- When a tooltip should act as the primary label for an element, pass in `aria="labelledby"`. When a tooltip should act as supplementary information, keep the default `aria="describedby"`.
+    - This pattern should also be followed when manually passing in the `aria-labelledby` or `aria-describedby` attribute to a trigger.
+- When using the `reference` prop, you should also pass in the `id` prop and then manually pass in `aria-labelledby` or `aria-describedby` to the trigger. The aria attribute passed into the trigger should have the tooltip `id` passed in as a value.
+    - If you are instead using the `children` prop and you want to manually pass in `aria-describedby` or `aria-labelledby` to a trigger, you should also pass in `aria="none"` to the tooltip.
+- When the tooltip content is expected or intended to dynamically update and the `children` prop is being used, you must also pass in `aria-live="polite"` to ensure the updated content gets announced to users. This functionality gets set by default when using the `reference` prop.
 - A tooltip must be dismissable without needing to move the mouse pointer or remove focus from the trigger, such as by pressing the **Escape** key.
 - A tooltip must be automatically dismissed if its content is no longer valid.
-
-<br/>
 
 The following props/attributes have been added for you or are customizable in PatternFly:
 
 | React prop/attribute | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
 | -- | -- | -- | -- |
-| `aria-live` | Tooltip | .pf-c-tooltip | Used when a tooltips' content is expected or intended to dynamically update, or when a tooltip is placed on a static element. Only use a value of "polite" and only when also using the `children` prop (`aria-live="polite"` is set by default when using the `reference` prop). |
-| `aria` | Tooltip | .pf-c-tooltip | Used to decide whether the trigger is described by the tooltip (default behavior) or is labelled by it (`aria="labelledby"`). A value of "none" can also be passed in to prevent the tooltip from being announced or to set `aria-describedby` or `aria-labelledby`manually on the trigger. |
-| `id` | Tooltip | .pf-c-tooltip | Used to manually pass in the `id` attribute, which can be then be passed in as a value to a triggers' `aria-describedby` or `aria-labelledby` attribute. |
+| `aria-live` | Tooltip | .pf-c-tooltip | Used when a tooltips' content is expected or intended to dynamically update. Only use a value of "polite" and only when also using the `children` prop (`aria-live="polite"` is set by default when using the `reference` prop). |
+| `aria` | Tooltip | .pf-c-tooltip | Used to decide whether the tooltip acts as supplementary information (default behavior with `aria="describedby"`) or acts as a primary label (`aria="labelledby"`). A value of "none" can also be passed in to prevent the tooltip from being announced or to set `aria-describedby` or `aria-labelledby`manually on a trigger. |
+| `id` | Tooltip | .pf-c-tooltip | Used to manually pass in the `id` attribute, which can then be passed in as a value to a triggers' `aria-describedby` or `aria-labelledby` attribute. |

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -1,0 +1,22 @@
+---
+id: Tooltip
+section: components
+---
+
+A **tooltip** is in-app messaging used to identify elements on a page with short, clarifying text. The contents of a tooltip should be accessible to all users, regardless of the device or method used to navigate to the element that triggers the tooltip.
+
+**Mouse users** should be able to trigger a tooltip by hovering over the triggering element. The tooltip should also be hoverable and persist until the mouse pointer is no longer hovering over the triggering element or the tooltip itself.
+
+**Keyboard users** should be able to place focus on the triggering element in order to trigger the tooltip. The tooltip should persist as long as the triggering element has focus.
+
+**Screen reader users** should have the contents of the tooltip announced to them when it is triggered. This can be best achieved by using the `children` prop and wrapping the tooltip around the intended trigger.
+
+<br/>
+
+The Tooltip must also meet the following criteria in order to be accessible:
+
+- It must be dismissable without needing to move the mouse pointer or remove focus from the trigger, such as by pressing the **Escape** key.
+- It must be dismissed if the content of the tooltip is no longer valid.
+
+<br/>
+

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -9,14 +9,28 @@ A **tooltip** is in-app messaging used to identify elements on a page with short
 
 **Keyboard users** should be able to place focus on the triggering element in order to trigger the tooltip. The tooltip should persist as long as the triggering element has focus.
 
-**Screen reader users** should have the contents of the tooltip announced to them when it is triggered. This can be best achieved by using the `children` prop and wrapping the tooltip around the intended trigger.
+**Screen reader users** should have the contents of the tooltip announced to them when it is triggered. This can be best achieved by using the `children` prop and wrapping the tooltip around the intended trigger. Additionally, if a tooltip's contents is expected or intended to dynamically update (such as in response to a user action), the updated content should be announced to users.
+
+## Accessibility application
+
+The preferred method of using the tooltip is by wrapping it around its trigger via the `children` prop. However, there are situations where additional props must be passed in or where using the `reference` prop is needed or desired.
+
+To ensure the tooltip is used accessibly, follow these steps when applicable:
+
+- When adding a tooltip to a static element, such as a `span` or `div`, you must ensure:
+    - The static element has `tabindex="0"` passed in, so that keyboard users can place focus on it to trigger the tooltip, and there is some form of styling to visually let users know the element can be focused/hovered (usually an underline on the text).
+    - When using the `children` prop, `aria-live="polite"` and `aria="none"` are passed into the tooltip. Tooltips on static elements do not always get announced by assistive technologies by default, so passing in `aria-live` allows the tooltip contents to be announced while `aria="none"` ensures the tooltip does not get announced more than once.
+- When the tooltip content is expected or intended to dynamically update and the `children` prop is being used, you must also pass in `aria-live="polite"` and `aria="none"` to ensure the updated content gets announced to users and that the the tooltip does not get announced more than once.
+- When passing in the `id` prop and using the `children` prop you should also pass in `aria="none"`, and then either `aria-describedby` or `aria-labelledby` to the tooltips' trigger. The aria attribute passed into the trigger should have the tooltips' `id` prop passed in as a value.
+- A tooltip must be dismissable without needing to move the mouse pointer or remove focus from the trigger, such as by pressing the **Escape** key.
+- A tooltip must be automatically dismissed if its content is no longer valid.
 
 <br/>
 
-The Tooltip must also meet the following criteria in order to be accessible:
+The following props/attributes have been added for you or are customizable in PatternFly:
 
-- It must be dismissable without needing to move the mouse pointer or remove focus from the trigger, such as by pressing the **Escape** key.
-- It must be dismissed if the content of the tooltip is no longer valid.
-
-<br/>
-
+| React prop/attribute | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
+| -- | -- | -- | -- |
+| `aria-live` | Tooltip | .pf-c-tooltip | Used when a tooltips' content is expected or intended to dynamically update, or when a tooltip is placed on a static element. Only use a value of "polite" and only when also using the `children` prop (`aria-live="polite"` is set by default when using the `reference` prop). |
+| `aria` | Tooltip | .pf-c-tooltip | Used to decide whether the trigger is described by the tooltip (default behavior) or is labelled by it (`aria="labelledby"`). A value of "none" can also be passed in to prevent the tooltip from being announced or to set `aria-describedby` or `aria-labelledby`manually on the trigger. |
+| `id` | Tooltip | .pf-c-tooltip | Used to manually pass in the `id` attribute, which can be then be passed in as a value to a triggers' `aria-describedby` or `aria-labelledby` attribute. |

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -3,33 +3,126 @@ id: Tooltip
 section: components
 ---
 
-A **tooltip** is in-app messaging used to identify elements on a page with short, clarifying text. The contents of a tooltip should be accessible to all users, regardless of the device or method used to navigate to the element that triggers the tooltip.
+import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
-**Mouse users** should be able to trigger a tooltip by hovering over the triggering element. The tooltip should also be hoverable and persist until the mouse pointer is no longer hovering over the triggering element or the tooltip itself.
+## Accessibility
 
-**Keyboard users** should be able to place focus on the triggering element in order to trigger the tooltip. The tooltip should persist as long as the triggering element has focus.
+To implement an accessible PatternFly **tooltip**:
 
-**Screen reader users** should have the contents of the tooltip announced to them when it is triggered. This can be best achieved by using the `children` prop and wrapping the tooltip around the intended trigger. Additionally, if a tooltip's contents is expected or intended to dynamically update (such as in response to a user action), the updated content should be announced to users.
+- Avoid using tooltips on static elements such as a `div` or `span`, except in cases of truncation.
+- Pass in `role="tooltip"` (HTML/CSS) to the element acting as the tooltip component.
+- Pass in `aria="labelledby"` to the tooltip component (PatternFly React) or the `aria-labelledby` attribute to the trigger (HTML/CSS) when the tooltip should act as the primary label for its trigger:
+  ```noLive
+  // PatternFly React
+  <Tooltip content="Copy to clipboard" aria="labelledby">
+    <button>
+      <CopyIcon />
+    </button>
+  </Tooltip>
 
-## Accessibility application
+  // HTML/CSS
+  <div class="pf-c-tooltip pf-m-top" role="tooltip">
+    <div class="pf-c-tooltip__arrow"></div>
+    <div class="pf-c-tooltip__content" id="tooltip-label-content">
+      Copy to clipboard
+    </div>
+  </div>
+  <button aria-labelledby="tooltip-label-content">
+    <CopyIcon />
+  </button>
+  ```
+- Pass in the `aria-describedby` attribute to the trigger (HTML/CSS) when the tooltip should act as supplementary information (this is the default behavior for PatternFly React):
+  ```noLive
+  // HTML/CSS
+  <div class="pf-c-tooltip pf-m-top" role="tooltip">
+    <div class="pf-c-tooltip__arrow"></div>
+    <div class="pf-c-tooltip__content" id="tooltip-description-content">
+      Supplementary information within a tooltip
+    </div>
+  </div>
+  <button aria-describedby="tooltip-description-content">
+    Button text label
+  </button>
+  ```
 
-The preferred method of using the tooltip is by wrapping it around its trigger via the `children` prop. However, there are situations where additional props must be passed in or where using the `reference` prop is needed or desired.
+## Testing
 
-To ensure the tooltip is used accessibly, follow these steps when applicable:
+At a minimumm, a tooltip should meet the following criteria:
 
-- Tooltips should not be added to static elements, such as a `div` or `span`.
-- When a tooltip should act as the primary label for an element, pass in `aria="labelledby"`. When a tooltip should act as supplementary information, keep the default `aria="describedby"`.
-    - This pattern should also be followed when manually passing in the `aria-labelledby` or `aria-describedby` attribute to a trigger.
-- When using the `reference` prop, you should also pass in the `id` prop and then manually pass in `aria-labelledby` or `aria-describedby` to the trigger. The aria attribute passed into the trigger should have the tooltip `id` passed in as a value.
-    - If you are instead using the `children` prop and you want to manually pass in `aria-describedby` or `aria-labelledby` to a trigger, you should also pass in `aria="none"` to the tooltip.
-- When the tooltip content is expected or intended to dynamically update and the `children` prop is being used, you must also pass in `aria-live="polite"` to ensure the updated content gets announced to users. This functionality gets set by default when using the `reference` prop.
-- A tooltip must be dismissable without needing to move the mouse pointer or remove focus from the trigger, such as by pressing the **Escape** key.
-- A tooltip must be automatically dismissed if its content is no longer valid.
+<List isPlain>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-1" label="Unless it is a case of truncation, the tooltip is not placed on a static element." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-2" label={<span>If using the HTML/CSS library, <code class="ws-code">role="tooltip"</code> is passed into the tooltip component.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-3" label={<span>If the tooltip is meant to act as a primary label, the trigger has the <code class="ws-code">aria-labelledby</code> attribute linked to the tooltip contents.</span>} description="One use-case for this is when a button contains only an icon and no visible text label." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-4" label={<span>If the tooltip is meant to act as supplementary information, the trigger has the <code class="ws-code">aria-describedby</code> attribute linked to the tooltip contents.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-5" label="Using a mouse to hover over the triggering element causes the tooltip to trigger, and the tooltip persists when hovering over the tooltip contents." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-6" label="The triggering element can receive focus via keyboard in order to trigger the tooltip, and the tooltip persists as long as the triggering element has focus." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-7" label="Users navigating via screen reader have the contents of the tooltip announced to them when it is triggered." description="This is best achieved by wrapping the tooltip component around the trigger." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-8" label={<span>The tooltip can be dismissed by pressing <kbd>Escape</kbd>.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tooltip-a11y-checkbox-9" label="If the tooltip content is no longer valid, the tooltip automatically gets dismissed." />
+  </ListItem>
+</List>
 
-The following props/attributes have been added for you or are customizable in PatternFly:
+## React customization
 
-| React prop/attribute | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
-| -- | -- | -- | -- |
-| `aria-live` | Tooltip | .pf-c-tooltip | Used when a tooltips' content is expected or intended to dynamically update. Only use a value of "polite" and only when also using the `children` prop (`aria-live="polite"` is set by default when using the `reference` prop). |
-| `aria` | Tooltip | .pf-c-tooltip | Used to decide whether the tooltip acts as supplementary information (default behavior with `aria="describedby"`) or acts as a primary label (`aria="labelledby"`). A value of "none" can also be passed in to prevent the tooltip from being announced or to set `aria-describedby` or `aria-labelledby`manually on a trigger. |
-| `id` | Tooltip | .pf-c-tooltip | Used to manually pass in the `id` attribute, which can then be passed in as a value to a triggers' `aria-describedby` or `aria-labelledby` attribute. |
+Various React props have been provided for more fine-tuned control over accessibility.
+
+| Prop | Applied to | Reason | 
+|---|---|---|
+| aria-live | Tooltip | When a value of "polite" is passed in, allows screen readers to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. This should only be passed in when the `children` prop is also used on the tooltip. <br/><br/> `aria-live="polite"` is set by default when using the `reference` prop in order to allow screen readers to correctly announce tooltip contents regardless if it will dynamically update or not. |
+| aria | Tooltip | When a value of "describedby" (default behavior) or "labelledby" is passed in, allows screen readers to announce the tooltip contents when it is triggered. A value of "describedby" sets the trigger's `aria-describedby` attribute and should be used when the tooltip should act as supplementary information. A value of "labelledby" sets the trigger's `aria-labelledby` attribute and should be used when the tooltip should act as a primary label. <br/><br/> When a value of "none" is passed in, prevents `aria-labelledby` and `aria-describedby` from being set on the trigger. Only pass in a value of "none" when either `aria-labelledby` or `aria-describedby` is manually set on the trigger and the `id` prop is manually passed into the tooltip. <br/><br/> This prop should only be passed in when the `children` prop is also used on the tooltip. |
+| id | Tooltip | Sets the `id` attribute on the tooltip, which can be passed in as the value to a trigger's `aria-labelledby` or `aria-describedby` attribute. **Required** when either `aria-labelledby` or `aria-describedby` is manually set on the trigger or when the `reference` prop is passed into the tooltip. |
+| reference | Tooltip | Links the tooltip to a trigger when the `children` prop cannot be used. When passing in this prop, the `id` prop must also be passed in, and either `aria-labelledby` or `aria-describedby` must be set on the trigger with a value of the tooltip's `id`. |
+
+### Aria-live
+
+```noLive
+const [tooltipContent, setTooltipContent] = React.useState("Copy to clipboard");
+
+const onClick = () => {
+  setTooltipContent('Successfully copied to clipboard!")
+}
+
+<Tooltip aria-live="polite" content={tooltipContent}>
+  <button onClick={onClick}>
+    <CopyIcon />
+  </button>
+</Tooltip>
+```
+
+### Aria
+
+```noLive
+<Tooltip id="tooltip-without-aria" aria="none" content="Copy to clipboard">
+  <button aria-labelledby="tooltip-without-aria">
+    <CopyIcon />
+  </button>
+</Tooltip>
+```
+
+### Reference
+
+```noLive
+const tooltipRef = React.useRef();
+
+<Tooltip id="tooltip-with-reference" content="Copy to clipboard" reference={tooltipRef} />
+<button ref={tooltipRef} aria-labelledby="tooltip-with-reference">
+  <CopyIcon />
+</button>
+```

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -31,8 +31,15 @@ To implement an accessible PatternFly **tooltip**:
     <CopyIcon />
   </button>
   ```
-- Pass in the `aria-describedby` attribute to the trigger (HTML/CSS) when the tooltip should act as supplementary information (this is the default behavior for PatternFly React):
+- Pass in the `aria-describedby` attribute to the trigger (HTML/CSS) when the tooltip should act as supplementary information (this is the default behavior for PatternFly React when the tooltip wraps the trigger):
   ```noLive
+  // PatternFly React
+  <Tooltip content="Supplementary information within a tooltip">
+    <button>
+      Button text label
+    </button>
+  </Tooltip>
+
   // HTML/CSS
   <div class="pf-c-tooltip pf-m-top" role="tooltip">
     <div class="pf-c-tooltip__arrow"></div>
@@ -63,16 +70,16 @@ At a minimumm, a tooltip should meet the following criteria:
     <Checkbox id="tooltip-a11y-checkbox-4" label={<span>If the tooltip is meant to act as supplementary information, the trigger has the <code class="ws-code">aria-describedby</code> attribute linked to the tooltip contents.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="tooltip-a11y-checkbox-5" label="Using a mouse to hover over the triggering element causes the tooltip to trigger, and the tooltip persists when hovering over the tooltip contents." />
+    <Checkbox id="tooltip-a11y-checkbox-5" label="Using a mouse to hover over the triggering element causes the tooltip to trigger, and the tooltip persists while hovering over the trigger or the tooltip itself." />
   </ListItem>
   <ListItem>
     <Checkbox id="tooltip-a11y-checkbox-6" label="The triggering element can receive focus via keyboard in order to trigger the tooltip, and the tooltip persists as long as the triggering element has focus." />
   </ListItem>
   <ListItem>
-    <Checkbox id="tooltip-a11y-checkbox-7" label="Users navigating via screen reader have the contents of the tooltip announced to them when it is triggered." description="This is best achieved by wrapping the tooltip component around the trigger." />
+    <Checkbox id="tooltip-a11y-checkbox-7" label="Users navigating via screen reader have the contents of the tooltip announced to them when it is triggered." description="This is best achieved by wrapping the tooltip component around the trigger. This is best checked by using a screen reader." />
   </ListItem>
   <ListItem>
-    <Checkbox id="tooltip-a11y-checkbox-8" label={<span>The tooltip can be dismissed by pressing <kbd>Escape</kbd>.</span>} />
+    <Checkbox id="tooltip-a11y-checkbox-8" label="The tooltip can be dismissed without having to move the mouse pointer or remove focus from the trigger." description={<span>This is commonly done by pressing <kbd>Escape</kbd>.</span>} />
   </ListItem>
   <ListItem>
     <Checkbox id="tooltip-a11y-checkbox-9" label="If the tooltip content is no longer valid, the tooltip automatically gets dismissed." />
@@ -85,12 +92,14 @@ Various React props have been provided for more fine-tuned control over accessib
 
 | Prop | Applied to | Reason | 
 |---|---|---|
-| aria-live | Tooltip | When a value of "polite" is passed in, allows screen readers to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. This should only be passed in when the `children` prop is also used on the tooltip. <br/><br/> `aria-live="polite"` is set by default when using the `reference` prop in order to allow screen readers to correctly announce tooltip contents regardless if it will dynamically update or not. |
-| aria | Tooltip | When a value of "describedby" (default behavior) or "labelledby" is passed in, allows screen readers to announce the tooltip contents when it is triggered. A value of "describedby" sets the trigger's `aria-describedby` attribute and should be used when the tooltip should act as supplementary information. A value of "labelledby" sets the trigger's `aria-labelledby` attribute and should be used when the tooltip should act as a primary label. <br/><br/> When a value of "none" is passed in, prevents `aria-labelledby` and `aria-describedby` from being set on the trigger. Only pass in a value of "none" when either `aria-labelledby` or `aria-describedby` is manually set on the trigger and the `id` prop is manually passed into the tooltip. <br/><br/> This prop should only be passed in when the `children` prop is also used on the tooltip. |
+| aria-live | Tooltip | When a value of "polite" is passed in, allows assistive technologies to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. This should only be passed in when the `children` prop is also used on the tooltip. <br/><br/> `aria-live="polite"` is set by default when using the `reference` prop in order to allow assistive technologies to correctly announce tooltip contents regardless if it will dynamically update or not. |
+| aria | Tooltip | When a value of "describedby" (default behavior) or "labelledby" is passed in, allows assistive technologies to announce the tooltip contents when it is triggered. A value of "describedby" sets the trigger's `aria-describedby` attribute and should be used when the tooltip should act as supplementary information. A value of "labelledby" sets the trigger's `aria-labelledby` attribute and should be used when the tooltip should act as a primary label. <br/><br/> When a value of "none" is passed in, prevents `aria-labelledby` and `aria-describedby` from being set on the trigger. Only pass in a value of "none" when either `aria-labelledby` or `aria-describedby` is manually set on the trigger and the `id` prop is manually passed into the tooltip. <br/><br/> This prop should only be passed in when the `children` prop is also used on the tooltip. |
 | id | Tooltip | Sets the `id` attribute on the tooltip, which can be passed in as the value to a trigger's `aria-labelledby` or `aria-describedby` attribute. **Required** when either `aria-labelledby` or `aria-describedby` is manually set on the trigger or when the `reference` prop is passed into the tooltip. |
 | reference | Tooltip | Links the tooltip to a trigger when the `children` prop cannot be used. When passing in this prop, the `id` prop must also be passed in, and either `aria-labelledby` or `aria-describedby` must be set on the trigger with a value of the tooltip's `id`. |
 
 ### Aria-live
+
+The following code block shows how you should generally use the `aria-live` prop when the tooltip contents is intended or expected to dynamically update.
 
 ```noLive
 const [tooltipContent, setTooltipContent] = React.useState("Copy to clipboard");
@@ -108,6 +117,8 @@ const onClick = () => {
 
 ### Aria
 
+When passing in `aria="none"` in the following code block, the `id` is passed into the tooltip and `aria-labelledby` is passed into the trigger with a value of the tooltip's `id`.
+
 ```noLive
 <Tooltip id="tooltip-without-aria" aria="none" content="Copy to clipboard">
   <button aria-labelledby="tooltip-without-aria">
@@ -118,6 +129,8 @@ const onClick = () => {
 
 ### Reference
 
+When using the `reference` prop in the following code block, a React ref is created and passed into the tooltip and the trigger as the `reference` and `ref` props, respectively. Additionally, the `id` is passed into the tooltip and `aria-labelledby` is passed into the trigger with a value of the tooltip's `id`.
+
 ```noLive
 const tooltipRef = React.useRef();
 
@@ -126,3 +139,27 @@ const tooltipRef = React.useRef();
   <CopyIcon />
 </button>
 ```
+
+## HTML/CSS customization
+
+Various HTML attributes and PatternFly classes can be used for more fine-tuned control over accessibility.
+
+| Attribute or class | Applied to | Reason | 
+|---|---|---|
+| aria-live="polite" | .pf-c-tooltip | Allows assistive technologies to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. |
+| id | .pf-c-tooltip | Used to link the tooltip to a trigger by passing in the tooltip's `id` as the value to the trigger's `aria-describedby` or `aria-labelledby` attribute. **Required**. |
+| role="tooltip" | .pf-c-tooltip | Adds a tooltip role to the component. **Required**. |
+| aria-describedby | element that triggers the tooltip | Allows assistive technologies to announce the tooltip contents when it is triggered. **Required** when the tooltip should act as supplementary information. |
+| aria-labelledby | element that triggers the tooltip | Allows assistive technologies to announce the tooltip contents when it is triggered. **Required** when the tooltip should act as the primarly label of the trigger. |
+
+## Additional considerations
+
+Consumers must ensure they take any additional considerations when customizing a tooltip, using it in a way not described or recommended by PatternFly, or in various other specific use-cases not outlined elsewhere on this page.
+
+- If a tooltip is added to a trigger that is disabled, the trigger must still be able to receive focus. This can often be achieved by using the `aria-disabled` attribute instead of the `disabled` attribute.
+
+## Further reading
+
+To read more about accessibility with tooltips, refer to the resources listed below.
+
+- [ARIA Authoring Practices Guide - Tooltip widget](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -10,17 +10,23 @@ import { Checkbox, List, ListItem } from '@patternfly/react-core';
 To implement an accessible PatternFly **tooltip**:
 
 - Avoid using tooltips on static elements such as a `div` or `span`, except in cases of truncation.
-- Pass in `role="tooltip"` (HTML/CSS) to the element acting as the tooltip component.
-- Pass in `aria="labelledby"` to the tooltip component (PatternFly React) or the `aria-labelledby` attribute to the trigger (HTML/CSS) when the tooltip should act as the primary label for its trigger:
+
+For the PatternFly React library:
+
+- Pass in `aria="labelledby"` to the tooltip component when the tooltip should act as the primary label for its trigger:
   ```noLive
-  // PatternFly React
   <Tooltip content="Copy to clipboard" aria="labelledby">
     <button>
       <CopyIcon />
     </button>
   </Tooltip>
+  ```
 
-  // HTML/CSS
+For the HTML/CSS library:
+
+- Pass in `role="tooltip"` to the element acting as the tooltip component.
+- Pass in the `aria-labelledby` attribute to the trigger when the tooltip should act as the primary label for its trigger:
+  ```noLive
   <div class="pf-c-tooltip pf-m-top" role="tooltip">
     <div class="pf-c-tooltip__arrow"></div>
     <div class="pf-c-tooltip__content" id="tooltip-label-content">
@@ -31,16 +37,9 @@ To implement an accessible PatternFly **tooltip**:
     <CopyIcon />
   </button>
   ```
-- Pass in the `aria-describedby` attribute to the trigger (HTML/CSS) when the tooltip should act as supplementary information (this is the default behavior for PatternFly React when the tooltip wraps the trigger):
-  ```noLive
-  // PatternFly React
-  <Tooltip content="Supplementary information within a tooltip">
-    <button>
-      Button text label
-    </button>
-  </Tooltip>
+- Pass in the `aria-describedby` attribute to the trigger when the tooltip should act as supplementary information:
 
-  // HTML/CSS
+  ```noLive
   <div class="pf-c-tooltip pf-m-top" role="tooltip">
     <div class="pf-c-tooltip__arrow"></div>
     <div class="pf-c-tooltip__content" id="tooltip-description-content">
@@ -61,7 +60,7 @@ At a minimumm, a tooltip should meet the following criteria:
     <Checkbox id="tooltip-a11y-checkbox-1" label="Unless it is a case of truncation, the tooltip is not placed on a static element." />
   </ListItem>
   <ListItem>
-    <Checkbox id="tooltip-a11y-checkbox-2" label={<span>If using the HTML/CSS library, <code class="ws-code">role="tooltip"</code> is passed into the tooltip component.</span>} />
+    <Checkbox id="tooltip-a11y-checkbox-2" label={<span>The tooltip component has the <code class="ws-code">role="tooltip"</code> attribute.</span>} />
   </ListItem>
   <ListItem>
     <Checkbox id="tooltip-a11y-checkbox-3" label={<span>If the tooltip is meant to act as a primary label, the trigger has the <code class="ws-code">aria-labelledby</code> attribute linked to the tooltip contents.</span>} description="One use-case for this is when a button contains only an icon and no visible text label." />
@@ -92,10 +91,10 @@ Various React props have been provided for more fine-tuned control over accessib
 
 | Prop | Applied to | Reason | 
 |---|---|---|
-| aria-live | Tooltip | When a value of "polite" is passed in, allows assistive technologies to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. This should only be passed in when the `children` prop is also used on the tooltip. <br/><br/> `aria-live="polite"` is set by default when using the `reference` prop in order to allow assistive technologies to correctly announce tooltip contents regardless if it will dynamically update or not. |
-| aria | Tooltip | When a value of "describedby" (default behavior) or "labelledby" is passed in, allows assistive technologies to announce the tooltip contents when it is triggered. A value of "describedby" sets the trigger's `aria-describedby` attribute and should be used when the tooltip should act as supplementary information. A value of "labelledby" sets the trigger's `aria-labelledby` attribute and should be used when the tooltip should act as a primary label. <br/><br/> When a value of "none" is passed in, prevents `aria-labelledby` and `aria-describedby` from being set on the trigger. Only pass in a value of "none" when either `aria-labelledby` or `aria-describedby` is manually set on the trigger and the `id` prop is manually passed into the tooltip. <br/><br/> This prop should only be passed in when the `children` prop is also used on the tooltip. |
-| id | Tooltip | Sets the `id` attribute on the tooltip, which can be passed in as the value to a trigger's `aria-labelledby` or `aria-describedby` attribute. **Required** when either `aria-labelledby` or `aria-describedby` is manually set on the trigger or when the `reference` prop is passed into the tooltip. |
-| reference | Tooltip | Links the tooltip to a trigger when the `children` prop cannot be used. When passing in this prop, the `id` prop must also be passed in, and either `aria-labelledby` or `aria-describedby` must be set on the trigger with a value of the tooltip's `id`. |
+| `aria-live` | `Tooltip` | When a value of "polite" is passed in, allows assistive technologies to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. This should only be passed in when the `children` prop is also used on the tooltip. <br/><br/> `aria-live="polite"` is set by default when using the `reference` prop in order to allow assistive technologies to correctly announce tooltip contents regardless if it will dynamically update or not. |
+| `aria` | `Tooltip` | When a value of "describedby" (default behavior) or "labelledby" is passed in, allows assistive technologies to announce the tooltip contents when it is triggered. A value of "describedby" sets the trigger's `aria-describedby` attribute and should be used when the tooltip should act as supplementary information. A value of "labelledby" sets the trigger's `aria-labelledby` attribute and should be used when the tooltip should act as a primary label. <br/><br/> When a value of "none" is passed in, prevents `aria-labelledby` and `aria-describedby` from being set on the trigger. Only pass in a value of "none" when either `aria-labelledby` or `aria-describedby` is manually set on the trigger and the `id` prop is manually passed into the tooltip. <br/><br/> This prop should only be passed in when the `children` prop is also used on the tooltip. |
+| `id` | `Tooltip` | Sets the `id` attribute on the tooltip, which can be passed in as the value to a trigger's `aria-labelledby` or `aria-describedby` attribute. **Required** when either `aria-labelledby` or `aria-describedby` is manually set on the trigger or when the `reference` prop is passed into the tooltip. |
+| `reference` | `Tooltip` | Links the tooltip to a trigger when the `children` prop cannot be used. When passing in this prop, the `id` prop must also be passed in, and either `aria-labelledby` or `aria-describedby` must be set on the trigger with a value of the tooltip's `id`. |
 
 ### Aria-live
 
@@ -146,11 +145,11 @@ Various HTML attributes and PatternFly classes can be used for more fine-tuned c
 
 | Attribute or class | Applied to | Reason | 
 |---|---|---|
-| aria-live="polite" | .pf-c-tooltip | Allows assistive technologies to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. |
-| id | .pf-c-tooltip | Used to link the tooltip to a trigger by passing in the tooltip's `id` as the value to the trigger's `aria-describedby` or `aria-labelledby` attribute. **Required**. |
-| role="tooltip" | .pf-c-tooltip | Adds a tooltip role to the component. **Required**. |
-| aria-describedby | element that triggers the tooltip | Allows assistive technologies to announce the tooltip contents when it is triggered. **Required** when the tooltip should act as supplementary information. |
-| aria-labelledby | element that triggers the tooltip | Allows assistive technologies to announce the tooltip contents when it is triggered. **Required** when the tooltip should act as the primarly label of the trigger. |
+| `aria-live="polite"` | `.pf-c-tooltip` | Allows assistive technologies to announce the tooltip contents when it is expected or intended to dynamically update, such as in response to a user action. |
+| `id` | `.pf-c-tooltip` | Used to link the tooltip to a trigger by passing in the tooltip's `id` as the value to the trigger's `aria-describedby` or `aria-labelledby` attribute. **Required**. |
+| `role="tooltip"` | `.pf-c-tooltip` | Adds a tooltip role to the component. **Required**. |
+| `aria-describedby` | element that triggers the tooltip | Allows assistive technologies to announce the tooltip contents when it is triggered. **Required** when the tooltip should act as supplementary information. |
+| `aria-labelledby` | element that triggers the tooltip | Allows assistive technologies to announce the tooltip contents when it is triggered. **Required** when the tooltip should act as the primarly label of the trigger. |
 
 ## Additional considerations
 
@@ -160,6 +159,6 @@ Consumers must ensure they take any additional considerations when customizing a
 
 ## Further reading
 
-To read more about accessibility with tooltips, refer to the resources listed below.
+To read more about accessibility with tooltips, refer to the following resources:
 
 - [ARIA Authoring Practices Guide - Tooltip widget](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)

--- a/packages/v4/patternfly-docs/content/design-guidelines/components/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/design-guidelines/components/tooltip/tooltip.md
@@ -38,7 +38,8 @@ Both tooltips and [popovers](/components/popover/design-guidelines) provide more
 - Don’t use tooltips with question-circle icons to present contextual information in forms and other areas. Instead, use a [popover](/components/popover/design-guidelines).  
 
 ## Accessibility
-Every time a user with a screen reader tabs into a field with a tooltip, the screen reader reads the tooltip aloud.
+
+For information regarding accessibility, visit the [tooltip accessibility](/components/tooltip/accessibility) tab.
 
 
 


### PR DESCRIPTION
Closes #2596

[Tooltip a11y tab](https://patternfly-org-pr-2892-v4.surge.sh/v4/components/tooltip/accessibility)

Current implementation for a11y docs on the tooltip. This is based off of the current changes made in https://github.com/patternfly/patternfly-react/pull/7332 and https://github.com/patternfly/patternfly-react/pull/7335.

Additionally, I added in some verbiage in regards to tooltips on static elements. In https://github.com/patternfly/patternfly-org/issues/1108#issuecomment-495262558 it was mentioned that tooltips on static elements shouldn't be recommended. However, utilizing the pattern of `aria-live` instead of `aria-describedby` does seem to resolve the gaps mentioned.


Original comment:

One proposal I want to put out there is whether we should include verbiage for when a tooltip *shouldn't* be announced to screen reader users. Specifically, if an element already has a label (such as via `aria-label`), and the tooltip contents is essentially the same thing, should the tooltip then be prevented from being announced to screen reader users to avoid redundant/duplicate announcements? Or would the better approach be to avoid adding an `aria-label` if a tooltip is to be attached (as we've seen with using React refs, tooltips may not always be announced, though I've noticed a possible fix could be using `aria-live` on tooltips attached via ref)?

Using the [Tooltip on icon example](https://www.patternfly.org/v4/components/tooltip#on-icon), if the example code was changed so that the button had `aria-label="Copy contents to clipboard"`, a screen reader could announce both that and the tooltip contents, which would be redundant information. This could also be trying to solve a problem that may not really exist or not be a significant issue, though.