### PR TITLE
chore(docs): send GA tracking event w/URL when redirected to 404 page

### DIFF
--- a/packages/theme-patternfly-org/app.js
+++ b/packages/theme-patternfly-org/app.js
@@ -5,15 +5,20 @@ import { SideNavLayout } from 'theme-patternfly-org/layouts';
 import { Footer } from 'theme-patternfly-org/components';
 import { MDXTemplate } from 'theme-patternfly-org/templates/mdx';
 import { routes, groupedRoutes, fullscreenRoutes, getAsyncComponent } from './routes';
+import { trackEvent } from './helpers';
 import 'client-styles';
 
-const AppRoute = ({ child, katacodaLayout, title }) => {
-  const location = useLocation();
+const AppRoute = ({ child, katacodaLayout, title, path }) => {
+  const pathname = useLocation().pathname;
   if (typeof window !== 'undefined' && window.gtag) {
     gtag('config', 'UA-47523816-6', {
-      'page_path': location.pathname,
-      'page_title': (title || location.pathname)
+      'page_path': pathname,
+      'page_title': (title || pathname)
     });
+  }
+  // Send 404 event if redirected to 404 page
+  if (path === '/404' && pathname.split('/').pop() !== '404') {
+    trackEvent('404_redirect', 'redirect', pathname);
   }
   return (
     <React.Fragment>


### PR DESCRIPTION
Closes #2827 

This PR checks the visited URL vs the matched path - if user is sent to 404 page but didn't specifically visit 404 page, sends Google Analytics event tracking original page URL.

<details>
<summary>For testing:</summary>
Unfortunately surge doesn't redirect to the 404 page so to test the code needs to be pulled, updated, and run locally.

1. pull code
2. change [this line](https://github.com/patternfly/patternfly-org/blob/main/packages/theme-patternfly-org/scripts/webpack/getHtmlWebpackPlugins.js#L25) to the following to enable google analytics calls to fire in dev mode: `googleAnalyticsID: googleAnalyticsID,`
3. goto a nonexisting URL (e.g. http://localhost:8003/v4/404-test) and filter the `Network` tab in developer tools by the text 'collect'.

A network call should go out under the `Payload` tab with the following info:

```
ec: redirect
ea: 404_redirect
el: /v4/404-test
```

Example screenshot:
<img width="473" alt="Screen Shot 2022-04-12 at 9 17 13 PM" src="https://user-images.githubusercontent.com/8651509/163079971-b84b01ae-b9ce-43ab-8d01-f02b2117dc8c.png">
 
For additional confirmation due to differences in localhost testing, surge, and our hosted site, this update should be testing in staging one PR is merged.
</details>