### PR TITLE
Fix nested type parameters in TS example

### DIFF
--- a/packages/ast-helpers/acorn-typescript.js
+++ b/packages/ast-helpers/acorn-typescript.js
@@ -100,6 +100,10 @@ module.exports = Parser => class TSParser extends Parser {
     return this.value && this.value.charCodeAt(0) === 62 // >
   }
 
+  _isEndOfNestedTypeParameters() {
+    return this._isEndOfTypeParameters() && this.value.charCodeAt(1) === 62// >>
+  }
+
   _hasPrecedingLineBreak() {
     return acorn.lineBreak.test(this.input.slice(this.lastTokEnd, this.start))
   }
@@ -845,6 +849,14 @@ module.exports = Parser => class TSParser extends Parser {
     }
     node.params = params
     return this.finishNode(node, 'TSTypeParameterInstantiation')
+  }
+
+  readToken(code) {
+    if (this._isEndOfNestedTypeParameters()) {
+      return this.finishToken(tt.relational, this.value[1]);
+    } else {
+      return super.readToken(code)
+    }
   }
 
   parseMaybeTSTypeParameterInstantiation() {

--- a/packages/ast-helpers/acorn.js
+++ b/packages/ast-helpers/acorn.js
@@ -13,5 +13,12 @@ module.exports = {
       sourceType: 'module',
       allowReturnOutsideFunction: true
     });
+  },
+  tokenize(code) {
+    return jsxParser.tokenizer(code, {
+      ecmaVersion: 2018,
+      sourceType: 'module',
+      allowReturnOutsideFunction: true
+    })
   }
 };

--- a/packages/ast-helpers/test.js
+++ b/packages/ast-helpers/test.js
@@ -1,0 +1,21 @@
+const { parse, tokenize } = require('./acorn.js');
+const { convertToReactComponent } = require('./stringify')
+
+const testString = `export const AboutModalBasic: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+    const [isModalOpen, setIsModalOpen] = React.useState(false);
+  
+    const toggleModal = () => {
+      setIsModalOpen(!isModalOpen);
+    };
+  
+    return (
+      <React.Fragment>
+       <div></div>
+      </React.Fragment>
+    );
+  };`
+
+
+const out = parse(testString);
+console.log(convertToReactComponent(testString).code);
+console.log(out);


### PR DESCRIPTION
Re: https://github.com/patternfly/patternfly-react/pull/7219

Fix nested type parameters

- acorn (and the acorn-typescript extension) treated `>>` as a single token
- There is likely a better way to do this, but this seems to fix the problem
  - Potential issue would be someone using `>>` in a bitwise operation, but very unlikely that bitwise operations are happening in our react examples