### PR TITLE
Update link text for Beta component alert

### DIFF
--- a/packages/theme-patternfly-org/templates/mdx.js
+++ b/packages/theme-patternfly-org/templates/mdx.js
@@ -55,7 +55,7 @@ const MDXChildTemplate = ({
         <InlineAlert title="Beta feature">
           This Beta component is currently under review and is still open for further evolution. It is available for use in product.
           Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
-          Learn more about Beta components <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">here</a>.
+          To learn more go to our <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">Beta components</a> page on GitHub.
         </InlineAlert>
       )}
       {katacodaBroken && (


### PR DESCRIPTION
Closes #2925

[Date and time picker demo](https://patternfly-org-pr-2926-v4.surge.sh/v4/demos/date-and-time-picker/) for convenience.

As noted in the issue's additional information, the icons page also has a case of a link using "here" as link text, but that is something I plan to look into before another issue is opened.