### PR TITLE
chore(docs): added opt-in font classes

### DIFF
--- a/packages/theme-patternfly-org/templates/html.ejs
+++ b/packages/theme-patternfly-org/templates/html.ejs
@@ -15,7 +15,7 @@
     <meta name="application-name" content="PatternFly docs">
     <%= htmlWebpackPlugin.tags.headTags %>
   </head>
-  <body>
+  <body class="pf-m-redhat-updated-font pf-m-redhatmono-font">
     <div id="root">
       <%= prerendering %>
     </div>


### PR DESCRIPTION
Closes #2881 

This PR adds the following opt-in fonts to the `<body>` tag in theme-patternfly-org, which trickles to the Core, React, and Org workspaces and the website:

- `.pf-m-redhat-updated-font`
- `.pf-m-redhatmono-font`