### PR TITLE
fix(toc): fixed jumplinks in TOC to resolve a11y nesting issue

### DIFF
--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
@@ -10,25 +10,57 @@ export const TableOfContents = ({ items }) => {
     const { innerWidth } = window;
     innerWidth !== width && setWidth(innerWidth);
   }
+  let wasSublistRendered = false;
 
-  const renderItem = (item, index) => {
-    return Array.isArray(item)
-      ? (
-        <JumpLinksList key={index} className="ws-toc-sublist">
-          {item.map(renderItem)}
+  const renderSublist = (item, nextItem, idx) => {
+    wasSublistRendered = true;
+    return (
+      <>
+        {item.text}
+        <JumpLinksList>
+          {nextItem.map(curItem => (
+            <JumpLinksItem
+              key={curItem.id}
+              href={`#${curItem.id}`}
+              className="ws-toc-item"
+              onKeyDown={updateWidth}
+              onMouseDown={updateWidth}
+              onClick={() => trackEvent('jump_link_click', 'click_event', curItem.id.toUpperCase())}
+            >
+              {curItem.text}
+            </JumpLinksItem>
+          ))}
         </JumpLinksList>
-      ) : (
+      </>
+    );
+  }
+
+  let jumpLinksItems = [];
+
+  const renderJumpLinksItems = () => {
+    items.forEach((item, index) => {
+      let cur = item;
+      let next = items[index + 1];
+      // Don't render empty <JumpLinksItem> for an array of sublist items
+      if (wasSublistRendered) {
+        wasSublistRendered = false;
+        return null;
+      }
+
+      jumpLinksItems.push(
         <JumpLinksItem
           key={item.id}
           href={`#${item.id}`}
           className="ws-toc-item"
           onKeyDown={updateWidth}
           onMouseDown={updateWidth}
-          onClick={() => trackEvent('jump_link_click', 'click_event', item.id.toUpperCase())
-        }>
-          {item.text}
+          onClick={() => trackEvent('jump_link_click', 'click_event', item.id.toUpperCase())}
+        >
+          { Array.isArray(next) ? renderSublist(item, next, index) : item.text }
         </JumpLinksItem>
-      )
+      );
+    })
+    return jumpLinksItems;
   }
 
   return (
@@ -40,7 +72,7 @@ export const TableOfContents = ({ items }) => {
       offset={width > 1450 ? 92 : 148}
       expandable={{ default: 'expandable', '2xl': 'nonExpandable' }}
     >
-      {items.map(renderItem)}
+      { renderJumpLinksItems() }
     </JumpLinks>
   );
 }

--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.js
@@ -10,15 +10,16 @@ export const TableOfContents = ({ items }) => {
     const { innerWidth } = window;
     innerWidth !== width && setWidth(innerWidth);
   }
+  let jumpLinksItems = [];
   let wasSublistRendered = false;
 
-  const renderSublist = (item, nextItem, idx) => {
+  const renderSublist = (item, nextItemArr) => {
     wasSublistRendered = true;
     return (
       <>
         {item.text}
         <JumpLinksList>
-          {nextItem.map(curItem => (
+          {nextItemArr.map(curItem => (
             <JumpLinksItem
               key={curItem.id}
               href={`#${curItem.id}`}
@@ -35,16 +36,13 @@ export const TableOfContents = ({ items }) => {
     );
   }
 
-  let jumpLinksItems = [];
-
   const renderJumpLinksItems = () => {
     items.forEach((item, index) => {
-      let cur = item;
-      let next = items[index + 1];
+      let nextItem = items[index + 1];
       // Don't render empty <JumpLinksItem> for an array of sublist items
       if (wasSublistRendered) {
         wasSublistRendered = false;
-        return null;
+        return;
       }
 
       jumpLinksItems.push(
@@ -56,7 +54,7 @@ export const TableOfContents = ({ items }) => {
           onMouseDown={updateWidth}
           onClick={() => trackEvent('jump_link_click', 'click_event', item.id.toUpperCase())}
         >
-          { Array.isArray(next) ? renderSublist(item, next, index) : item.text }
+          { Array.isArray(nextItem) ? renderSublist(item, nextItem) : item.text }
         </JumpLinksItem>
       );
     })


### PR DESCRIPTION
closes #2969 

This PR:
- Mirrors the structure of the [nested jump links example](https://www.patternfly.org/v4/components/jump-links#expandable-vertical-with-subsection) from our docs to fix a11y error of a `<ul>` nested directly inside another `<ul>`.

Fix:
Previously we were either rendering `<JumpLinksList>` directly inside the `<JumpLinks>` component:
```
<JumpLinks>
  <JumpLinksItem><JumpLinksItem>
  <JumpLinksList><JumpLinksList/>
</JumpLinks>
```

We should always render a `<JumpLinksItem>` and place any needed `<JumpLinksList>`s within them where needed.
```
<JumpLinks>
  <JumpLinksItem></JumpLinksItem>
  <JumpLinksItem>
    <JumpLinksList><JumpLinksList/>
  </JumpLinksItem>
</JumpLinks>
```