### PR TITLE
fix(example): added alt text to full-screen screenshots

### DIFF
--- a/packages/theme-patternfly-org/components/example/example.js
+++ b/packages/theme-patternfly-org/components/example/example.js
@@ -172,7 +172,7 @@ export const Example = ({
               target="_blank"
               aria-label={`Open fullscreen ${title} example`}
             >
-              <img src={thumbnail.src} width={thumbnail.width} height={thumbnail.height} />
+              <img src={thumbnail.src} width={thumbnail.width} height={thumbnail.height} alt={`${title} screenshot`} />
             </a>
           </div>
         : <div


### PR DESCRIPTION
Closes #2968 

This PR:
- Adds an `alt` attribute to each full-screen snapshot which resolves a11y bug thrown for each image currently