### PR TITLE
fix(docs): hid overflow in HTML examples

### DIFF
--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -34,6 +34,10 @@
   transition: width .2s ease-in-out;
 }
 
+.ws-preview-html {
+  overflow: hidden;
+}
+
 .ws-editor {
   font-size: 16px;
 }


### PR DESCRIPTION
Closes #2970 

This PR applies `overflow: hidden` to the HTML examples on the site to fix the problem of items meant to scroll off of a full page view still being visible when scrolling off of a contained example.