### PR TITLE
fix(docs): increased TOC z-index to 501 to fix overlapping examples

### DIFF
--- a/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
+++ b/packages/theme-patternfly-org/components/tableOfContents/tableOfContents.css
@@ -4,7 +4,7 @@
   position: sticky;
   width: calc(100% + var(--pf-c-page__main-section--PaddingLeft) + var(--pf-c-page__main-section--PaddingRight));
   background-color: var(--pf-global--BackgroundColor--200);
-  z-index: 1;
+  z-index: 501;
   margin: calc(var(--pf-c-page__main-section--PaddingTop) * -1) calc(var(--pf-c-page__main-section--PaddingRight) * -2) var(--pf-global--spacer--md) calc(var(--pf-c-page__main-section--PaddingLeft) * -1);
   padding: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) var(--pf-global--spacer--md);
   box-shadow: var(--pf-global--BoxShadow--lg-bottom);


### PR DESCRIPTION
Closes #2941 

This PR increases the z-index on the `.ws-toc` jumplinks to 501 to avoid overlapping examples

Note that 501 was chosen to ensure TOC displays over `.ws-preview__thumbnail-link::before, .ws-preview__thumbnail-link::after`.  There are a few elements that are assigned `ZIndex--2xl` in core where`z-index` equals 600, but I believe those elements should still overlap the TOC (for example, modal close button).  Other elements, such as `Menu` demos, have inline z-index of 9999 which cannot be overridden.