### PR TITLE
feat(docs): add dark theme switcher

### DIFF
--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -72,7 +72,7 @@ const HeaderTools = ({
     <PageHeaderTools>
       {hasDarkThemeSwitcher && (
         <PageHeaderToolsItem>
-          <Switch id="uncontrolled-switch-on" label="Disable dark theme" labelOff="Enable dark theme" defaultChecked={false} onChange={() => 
+          <Switch id="uncontrolled-switch-on" label="Dark theme" defaultChecked={false} onChange={() => 
           document.querySelector('html').classList.toggle('pf-theme-dark')} />
         </PageHeaderToolsItem>
       )}

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -13,9 +13,8 @@ import {
   DropdownItem,
   DropdownGroup,
   Divider,
-  Text,
-  TextVariants,
-  SkipToContent
+  SkipToContent,
+  Switch
 } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
@@ -30,6 +29,7 @@ const HeaderTools = ({
   versions,
   hasVersionSwitcher,
   hasSearch,
+  hasDarkThemeSwitcher,
   pathPrefix
 }) => {
   const initialVersion = staticVersions.Releases.find(release => release.latest);
@@ -70,6 +70,12 @@ const HeaderTools = ({
 
   return (
     <PageHeaderTools>
+      {hasDarkThemeSwitcher && (
+        <PageHeaderToolsItem>
+          <Switch id="uncontrolled-switch-on" label="Disable dark theme" labelOff="Enable dark theme" defaultChecked={false} onChange={() => 
+          document.querySelector('html').classList.toggle('pf-theme-dark')} />
+        </PageHeaderToolsItem>
+      )}
       {hasSearch && (
         <PageHeaderToolsItem id="ws-global-search-wrapper" className={isSearchExpanded ? '' : 'ws-hide-search-input'}>
           <TextInput id="ws-global-search" ref={searchRef} placeholder="Search" />
@@ -171,6 +177,7 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
   const algolia = process.env.algolia;
   const hasGdprBanner = process.env.hasGdprBanner;
   const hasVersionSwitcher = process.env.hasVersionSwitcher;
+  const hasDarkThemeSwitcher = process.env.hasDarkThemeSwitcher;
   const sideNavItems = process.env.sideNavItems;
   const topNavItems = process.env.topNavItems;
   const prnum = process.env.prnum;
@@ -209,6 +216,7 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
         versions={versions}
         hasSearch={algolia}
         hasVersionSwitcher={hasVersionSwitcher}
+        hasDarkThemeSwitcher={hasDarkThemeSwitcher}
         pathPrefix={pathPrefix} />}
       logo={prnum ? `PR #${prnum}` : <Brand src={logo} alt="Patternfly Logo" />}
       logoProps={{ href: prurl || pathPrefix || '/' }}

--- a/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/theme-patternfly-org/layouts/sideNavLayout/sideNavLayout.js
@@ -72,7 +72,7 @@ const HeaderTools = ({
     <PageHeaderTools>
       {hasDarkThemeSwitcher && (
         <PageHeaderToolsItem>
-          <Switch id="uncontrolled-switch-on" label="Dark theme" defaultChecked={false} onChange={() => 
+          <Switch id="ws-theme-switch" label="Dark theme" defaultChecked={false} onChange={() => 
           document.querySelector('html').classList.toggle('pf-theme-dark')} />
         </PageHeaderToolsItem>
       )}

--- a/packages/theme-patternfly-org/scripts/webpack/webpack.base.config.js
+++ b/packages/theme-patternfly-org/scripts/webpack/webpack.base.config.js
@@ -13,6 +13,7 @@ module.exports = (_env, argv) => {
     hasFooter = false,
     hasVersionSwitcher = false,
     hasDesignGuidelines = false,
+    hasDarkThemeSwitcher = false,
     sideNavItems = [],
     topNavItems = [],
   } = argv;
@@ -131,6 +132,7 @@ module.exports = (_env, argv) => {
         'process.env.hasFooter': JSON.stringify(hasFooter),
         'process.env.hasVersionSwitcher': JSON.stringify(hasVersionSwitcher),
         'process.env.hasDesignGuidelines': JSON.stringify(hasDesignGuidelines),
+        'process.env.hasDarkThemeSwitcher': JSON.stringify(hasDarkThemeSwitcher),
         'process.env.sideNavItems': JSON.stringify(sideNavItems),
         'process.env.topNavItems': JSON.stringify(topNavItems),
         'process.env.prnum': JSON.stringify(process.env.CIRCLE_PR_NUMBER || process.env.PR_NUMBER || ''),

--- a/packages/v4/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs.config.js
@@ -11,7 +11,7 @@ module.exports = {
   hasFooter: true,
   hasVersionSwitcher: true,
   hasDesignGuidelines: true,
-  hasDarkThemeSwitcher: true,
+  hasDarkThemeSwitcher: false,
   sideNavItems: [
     { section: 'get-started' },
     { section: 'developer-resources' },

--- a/packages/v4/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs.config.js
@@ -11,6 +11,7 @@ module.exports = {
   hasFooter: true,
   hasVersionSwitcher: true,
   hasDesignGuidelines: true,
+  hasDarkThemeSwitcher: true,
   sideNavItems: [
     { section: 'get-started' },
     { section: 'developer-resources' },


### PR DESCRIPTION
Closes #2885 
Closes #2959

This PR adds a dark theme switcher to the website.  No designs to work from so open to feedback.

Note:  current code will expose switcher on the live site & not in the workspaces.  Once design is confirmed & approved, we'll need to edit the `patternfly-docs.config.js` file in each repo separately to add the `hasDarkThemeSwitcher` property to the exports & set it to true (to show the switcher) or false (to not render the switcher).