### PR TITLE
Update copyright year

### DIFF
--- a/packages/theme-patternfly-org/components/footer/footer.js
+++ b/packages/theme-patternfly-org/components/footer/footer.js
@@ -231,7 +231,7 @@ export const Footer = () => (
         </GridItem>
         <GridItem md={4} lg={3} xl={2}>
           <span className="ws-org-pfsite-site-copyright">
-            Copyright &copy; 2021 Red Hat, Inc.
+            Copyright &copy; 2022 Red Hat, Inc.
           </span>
         </GridItem>
         <GridItem md={4} lg={5} className="pf-u-ml-xl-on-xl">


### PR DESCRIPTION
A programmatic way to use the current year would probably be best, but for now just updating the year to 2022.