### PR TITLE
few more a11y fixes

### DIFF
--- a/packages/theme-patternfly-org/components/cssVariables/cssVariables.js
+++ b/packages/theme-patternfly-org/components/cssVariables/cssVariables.js
@@ -164,9 +164,16 @@ export class CSSVariables extends React.Component {
 
   onCollapse = (event, rowKey, isOpen) => {
     const { rows } = this.state;
-    rows[rowKey].isOpen = isOpen;
+    const collapseAll = rowKey === undefined;
+    let newRows = Array.from(rows);
+
+    if (collapseAll) {
+      newRows = newRows.map(r => (r.isOpen === undefined ? r : { ...r, isOpen }));
+    } else {
+      newRows[rowKey] = { ...newRows[rowKey], isOpen };
+    }
     this.setState({
-      rows
+      rows: newRows,
     });
   };
 
@@ -213,6 +220,8 @@ export class CSSVariables extends React.Component {
           cells={this.columns}
           rows={this.state.rows}
           onCollapse={this.onCollapse}
+          canCollapseAll={true}
+          collapseAllAriaLabel="expand all css variables"
           gridBreakPoint="grid-lg"
           contentId="css-variables-content"
           expandId="css-variables-toggle"

--- a/packages/theme-patternfly-org/components/inlineAlert/inlineAlert.js
+++ b/packages/theme-patternfly-org/components/inlineAlert/inlineAlert.js
@@ -12,6 +12,7 @@ export const InlineAlert = ({
     className="pf-u-my-md"
     style={{ marginBottom: '1rem' }}
     isInline
+    titleHeadingLevel="h2"
   >
     {children}
   </Alert>

--- a/packages/theme-patternfly-org/components/topNav/topNav.js
+++ b/packages/theme-patternfly-org/components/topNav/topNav.js
@@ -7,7 +7,7 @@ import './topNav.css';
 export const TopNav = ({ navItems }) => (
   <Location>
     {({ location }) => 
-      <Nav aria-label="Nav" variant="horizontal">
+      <Nav aria-label="Patternfly top nav" variant="horizontal">
         <NavList>
           {navItems.map(({ path, text }) => (
             <NavItem


### PR DESCRIPTION
Updates include:

- more descriptive aria-label on the nav (to avoid conflicts with examples' navs more generic aria-labels)
- remove empty `<th>` in CSS variables table on react example pages by adding expand/collapse all toggle
- change the headingLevel in beta tag alerts to `<h2>` to maintain valid html heading level order