### PR TITLE
fix(docs): narrowed scope of rule hiding overflow on page examples

### DIFF
--- a/packages/theme-patternfly-org/components/example/example.css
+++ b/packages/theme-patternfly-org/components/example/example.css
@@ -33,7 +33,8 @@
   transition: width .2s ease-in-out;
 }
 
-.ws-preview-html {
+.ws-core-c-page.ws-preview > .ws-preview-html,
+.ws-react-c-page.ws-preview > .pf-c-page {
   overflow: hidden;
 }
 


### PR DESCRIPTION
Closes #3036 

This PR replaces the rule hiding all overflow on Core examples:
```
.ws-preview-html {
  overflow: hidden;
}
```

with a more narrowly-scoped rule hiding overflow specifically on the Page examples, for both Core & React examples:
```
.ws-core-c-page.ws-preview > .ws-preview-html,
.ws-react-c-page.ws-preview > .pf-c-page {
  overflow: hidden;
}
```