### PR TITLE
docs(Tabs): update a11y doc to new template

### DIFF
--- a/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
@@ -31,8 +31,54 @@ At a minimumm, tabs should meet the following criteria:
   <ListItem>
     <Checkbox id="tabs-a11y-checkbox-5" label={<span>Each tab can be selected via keyboard by pressing <kbd>Space</kbd> or <kbd>Enter</kbd>.</span>} description={<span>If a tab has the <code class="ws-code">href</code> attribute, then only <kbd>Enter</kbd> should activate the tab.</span>} />
   </ListItem>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-6" label={<span>When a set of tabs creates an overflow and one of the tabs has focus, pressing <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> scrolls the tablist container.</span>} />
+  </ListItem>
 </List>
 
+## React customization
+
+Various React props have been provided for more fine-tuned control over accessibility.
+
+| Prop | Applied to | Reason | 
+|---|---|---|
+| `title` | `Tab` | Sets the title of the tab. Each tab within a set of tabs should have a unique title. |
+| `isDisabled` | `Tab` | Disables the tab and prevents it from being perceivable and operable by users navigating via assistive technologies. Use this prop to disable a tab if you don't expect or intend for the tab to ever receive need to receive focus. For example, if the tab will never have a tooltip, you should pass this prop in to disable it. |
+| `isAriaDisabled` | `Tab` | Disables the tab, but keeps the tab perceivable to users. Use this prop instead of `isDisabled` when you want users to still be aware of the tab and that it is disabled, or when you expect or intend for the tab to receive focus despite being disabled. For example, if the disabled tab has a tooltip, you should pass this prop in to disable it. |
+| `inoperableEvents` | `Tab` | Prevents events from firing when the `isAriaDisabled` prop is also passed in. Since the `aria-disabled` attribute doesn't change the behavior of an element, any events must be manually prevented. By default the value is `["onClick", "onKeyPress"]`. |
+| `closeButtonAriaLabel` | `Tab` | Adds an accessible name to the close button of a closeable tab when the `onClose` prop is passed into the Tabs sub-component. The value passed in should indicate that the button will close a tab and which tab will be closed. For example, "Close users tab". |
+| `aria-label` | `TabContent` | Adds an accessible name to the tab content when this sub-component is used outside the Tabs sub-component. The value passed in should generally indicate the title of the tab that the content is related to. For example, if a `TabContent` is related to a tab with a title of "Users", you could pass in "Content for users tab" as a value to this prop. |
+| `addButtonAriaLabel` | `Tabs` | Adds an accessible name to the add button when the `onAdd` prop is also passed in. The value passed in should generally indicate that the button will add a tab to the tablist, and optionally which tablist the tab will be added to. When this prop is not passed in and an add button is rendered, the default `aria-label` on the button will be set to "Add tab". |
+| `aria-label` | `Tabs` | Adds an accessible name to the entire set of tabs. Each set of tabs should have a unique accessible name on a page. The value passed in should generally indicate the primary purpose or content of the tablist. |
+| `isExpanded` | `Tabs` | Adds styling to visually determine whether the toggle for a tablist is expanded or collapsed when the `isVertical` prop is also passed in. Also sets the accessibility attribute `aria-expanded` with a value of "true" or "false", which notifies screen readers whether the toggle is expanded ("true") or collapsed ("false"). |
+| `leftScrollAriaLabel` | `Tabs` | Adds an accessible name to the left scroll button when an overflow of tabs occurs. The value passed in should indicate that the button will scroll the tablist left. The default value is "Scroll left". |
+| `rightScrollAriaLabel` | `Tabs` | Adds an accessible name to the right scroll button when an overflow of tabs occurs. The value passed in should indicate that the button will scroll the tablist right. The default value is "Scroll right". |
+| `toggleAriaLabel` | `Tabs` | Adds an accessible name to the expandable toggle when the `isVertical` prop is also passed in. If the `toggleText` prop is not passed in, this prop must be passed in. |
+| `toggleText` | `Tabs` | Sets the visible text label for the expandable toggle when the `isVertical` prop is also passed in. |
+
+### Tab icons
+
+When adding an icon to a tab's `title` prop, you should ensure the icon has the `aria-hidden="true"` attribute if there is accompanying title text so that the icon will be removed from the accessibility tree. This will prevent assistive technologies from potentially announcing duplicate or unnecessary information without visually hiding it.
+
+## HTML/CSS customization
+
+Various HTML attributes and PatternFly classes can be used for more fine-tuned control over accessibility.
+
+| Attribute or class | Applied to | Reason | 
+|---|---|---|
+
+
+## Additional considerations
+
+Consumers must ensure they take any additional considerations when customizing tabs, using them in a way not described or recommended by PatternFly, or in various other specific use-cases not outlined elsewhere on this page.
+
+- If a tab's title consists of only an icon without any accompanying title text, the tab sub-component should have an `aria-label` to provide an accessible name and the `tooltip` prop passed in to provide visual context. Without both of these props, users will have no context as to which tab they are currently focused on or what the tab name is. 
+
+## Further reading
+
+To read more about accessibility with tabs, refer to the following resources:
+
+- [ARIA Authoring Practices Guide - Tabs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
 
 **Keyboard users** should be able to use standard keyboard user navigation (**Tab** and **Shift + Tab**) to move to and between tabs.
 Keyboard users should also be able to select a tab using **Enter** and **Space**. Disabled tabs cannot receive

--- a/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
@@ -9,7 +9,7 @@ import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
 To implement accessible PatternFly **tabs**:
 
-- Give each tab within a set of tabs a unique title.
+- Ensure each tab within a set of tabs contains unique text.
 
 ## Testing
 
@@ -17,7 +17,7 @@ At a minimumm, tabs should meet the following criteria:
 
 <List isPlain>
   <ListItem>
-    <Checkbox id="tabs-a11y-checkbox-1" label="Each tab within a set of tabs has a unique title." />
+    <Checkbox id="tabs-a11y-checkbox-1" label="Each tab within a set of tabs contains unique text." />
   </ListItem>
   <ListItem>
     <Checkbox id="tabs-a11y-checkbox-2" label={<span>The active tab has the attribute <code class="ws-code">aria-selected</code> with a value of "true", while all other tabs within a set of tabs have a value of "false".</span>} description="This notifies users navigating via screen readers which tab is currently selected and when a new tab has been selected." />
@@ -34,6 +34,9 @@ At a minimumm, tabs should meet the following criteria:
   <ListItem>
     <Checkbox id="tabs-a11y-checkbox-6" label={<span>When a set of tabs creates an overflow and one of the tabs has focus, pressing <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> scrolls the tablist.</span>} />
   </ListItem>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-7" label={<span>If there are multiple sets of tabs on a page, each set of tabs has a unique <code class="ws-code">aria-label</code>.</span>} description="This provides better context to users navigating via landmarks with a screen reader, as it will differentiate each set of tabs." />
+  </ListItem>
 </List>
 
 ## React customization
@@ -42,7 +45,7 @@ Various React props have been provided for more fine-tuned control over accessib
 
 | Prop | Applied to | Reason | 
 |---|---|---|
-| `title` | `Tab` | Sets the title of the tab. Each tab within a set of tabs should have a unique title. |
+| `title` | `Tab` | Sets the text label of the tab. Each tab within a set of tabs should have unique text passed into its `title` prop. |
 | `isDisabled` | `Tab` | Disables the tab and prevents it from being perceivable and operable by users navigating via assistive technologies. Use this prop to disable a tab if you don't expect or intend for the tab to ever need to receive focus. For example, if the tab will never have a tooltip, you should pass this prop in to disable it. |
 | `isAriaDisabled` | `Tab` | Disables the tab, but keeps the tab perceivable to users. Use this prop instead of `isDisabled` when you want users to still be aware of the tab and that it is disabled, or when you expect or intend for the tab to receive focus despite being disabled. For example, if the disabled tab has a tooltip, you should pass this prop in to disable it. |
 | `inoperableEvents` | `Tab` | Prevents events from firing when the `isAriaDisabled` prop is also passed in. Since the `aria-disabled` attribute doesn't change the behavior of an element, any events must be manually prevented. By default the value is `["onClick", "onKeyPress"]`. |

--- a/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
@@ -3,7 +3,36 @@ id: Tabs
 section: components
 ---
 
-**Tabs** allow users to navigate between views within the same page or context.
+import { Checkbox, List, ListItem } from '@patternfly/react-core';
+
+## Accessibility
+
+To implement accessible PatternFly **tabs**:
+
+- Give each tab within a set of tabs a unique title.
+
+## Testing
+
+At a minimumm, tabs should meet the following criteria:
+
+<List isPlain>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-1" label="Each tab within a set of tabs has a unique title." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-2" label={<span>The active tab has the attribute <code class="ws-code">aria-selected</code> with a value of "true", while all other tabs within a set of tabs have a value of "false".</span>} description="This notifies users navigating via screen readers which tab is currently selected." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-3" label={<span>The tab content of any inactive tabs has the <code class="ws-code">hidden</code> attribute.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-4" label="Standard keyboard navigation can be used to navigate between each tab within a set of tabs or other focusable elements." description={<span><kbd>Tab</kbd> navigates to the next tab or focusable element, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous tab or focusable element.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="tabs-a11y-checkbox-5" label={<span>Each tab can be selected via keyboard by pressing <kbd>Space</kbd> or <kbd>Enter</kbd>.</span>} description={<span>If a tab has the <code class="ws-code">href</code> attribute, then only <kbd>Enter</kbd> should activate the tab.</span>} />
+  </ListItem>
+</List>
+
 
 **Keyboard users** should be able to use standard keyboard user navigation (**Tab** and **Shift + Tab**) to move to and between tabs.
 Keyboard users should also be able to select a tab using **Enter** and **Space**. Disabled tabs cannot receive

--- a/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
@@ -20,7 +20,7 @@ At a minimumm, tabs should meet the following criteria:
     <Checkbox id="tabs-a11y-checkbox-1" label="Each tab within a set of tabs has a unique title." />
   </ListItem>
   <ListItem>
-    <Checkbox id="tabs-a11y-checkbox-2" label={<span>The active tab has the attribute <code class="ws-code">aria-selected</code> with a value of "true", while all other tabs within a set of tabs have a value of "false".</span>} description="This notifies users navigating via screen readers which tab is currently selected." />
+    <Checkbox id="tabs-a11y-checkbox-2" label={<span>The active tab has the attribute <code class="ws-code">aria-selected</code> with a value of "true", while all other tabs within a set of tabs have a value of "false".</span>} description="This notifies users navigating via screen readers which tab is currently selected and when a new tab has been selected." />
   </ListItem>
   <ListItem>
     <Checkbox id="tabs-a11y-checkbox-3" label={<span>The tab content of any inactive tabs has the <code class="ws-code">hidden</code> attribute.</span>} />
@@ -32,7 +32,7 @@ At a minimumm, tabs should meet the following criteria:
     <Checkbox id="tabs-a11y-checkbox-5" label={<span>Each tab can be selected via keyboard by pressing <kbd>Space</kbd> or <kbd>Enter</kbd>.</span>} description={<span>If a tab has the <code class="ws-code">href</code> attribute, then only <kbd>Enter</kbd> should activate the tab.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="tabs-a11y-checkbox-6" label={<span>When a set of tabs creates an overflow and one of the tabs has focus, pressing <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> scrolls the tablist container.</span>} />
+    <Checkbox id="tabs-a11y-checkbox-6" label={<span>When a set of tabs creates an overflow and one of the tabs has focus, pressing <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> scrolls the tablist.</span>} />
   </ListItem>
 </List>
 
@@ -43,7 +43,7 @@ Various React props have been provided for more fine-tuned control over accessib
 | Prop | Applied to | Reason | 
 |---|---|---|
 | `title` | `Tab` | Sets the title of the tab. Each tab within a set of tabs should have a unique title. |
-| `isDisabled` | `Tab` | Disables the tab and prevents it from being perceivable and operable by users navigating via assistive technologies. Use this prop to disable a tab if you don't expect or intend for the tab to ever receive need to receive focus. For example, if the tab will never have a tooltip, you should pass this prop in to disable it. |
+| `isDisabled` | `Tab` | Disables the tab and prevents it from being perceivable and operable by users navigating via assistive technologies. Use this prop to disable a tab if you don't expect or intend for the tab to ever need to receive focus. For example, if the tab will never have a tooltip, you should pass this prop in to disable it. |
 | `isAriaDisabled` | `Tab` | Disables the tab, but keeps the tab perceivable to users. Use this prop instead of `isDisabled` when you want users to still be aware of the tab and that it is disabled, or when you expect or intend for the tab to receive focus despite being disabled. For example, if the disabled tab has a tooltip, you should pass this prop in to disable it. |
 | `inoperableEvents` | `Tab` | Prevents events from firing when the `isAriaDisabled` prop is also passed in. Since the `aria-disabled` attribute doesn't change the behavior of an element, any events must be manually prevented. By default the value is `["onClick", "onKeyPress"]`. |
 | `closeButtonAriaLabel` | `Tab` | Adds an accessible name to the close button of a closeable tab when the `onClose` prop is passed into the Tabs sub-component. The value passed in should indicate that the button will close a tab and which tab will be closed. For example, "Close users tab". |
@@ -66,37 +66,35 @@ Various HTML attributes and PatternFly classes can be used for more fine-tuned c
 
 | Attribute or class | Applied to | Reason | 
 |---|---|---|
-
+| `aria-label` | `.pf-c-tabs` | Adds an accessible name to the entire set of tabs. Each set of tabs should have a unique accessible name on a page. The value passed in should generally indicate the primary purpose or content of the tablist. | 
+| `aria-label` | `.pf-c-tabs__add .pf-c-button.pf-m-plain` | Adds an accessible name to the add button of the tabs component when a tab can by dynamically added. The value passed in should generally indicate that the button will add a tab to the tablist, and optionally which tablist the tab will be added to. |
+| `aria-label` | `.pf-c-tabs__item-close .pf-c-button.pf-m-plain` | Adds an accessible name to the close button of a closeable tab. The value passed in should indicate that the button will close a tab and which tab will be closed. For example, "Close users tab". |
+| `aria-controls` | `.pf-c-tabs__link` | Indicates which tab content panel is controlled by the tab by passing in the ID of the tab content panel as a value. **Required**. |
+| `aria-disabled="true"` | `.pf-c-tabs__link.pf-m-aria-disabled` | Disables the tab, but keeps the tab perceivable to users. Use this attribute instead of `disabled` when you want users to still be aware of the tab and that it is disabled, or when you expect or intend for the tab to receive focus despite being disabled. For example, if the disabled tab has a tooltip, you should pass this prop in to disable it. <br/><br/> When using this attribute, additional steps must be taken via JavaScript to prevent events from firing on the element. |
+| `aria-selected="false"` | `.pf-c-tabs__link` | Indicates to assistive technologies that a tab is not selected. **Required** on all tab components that are not currently selected. |
+| `aria-selected="true"` | `.pf-c-tabs__link` | Indicates to assistive technologies that a tab is selected. **Required** when a tab is currently selected. |
+| `disabled` | `.pf-c-tabs__link` | Disables the tab and prevents it from being perceivable and operable by users navigating via assistive technologies. Use this attribute to disable a tab if you don't expect or intend for the tab to ever need to receive focus. For example, if the tab will never have a tooltip, you should pass this prop in to disable it. |
+| `role="tab"` | `.pf-c-tabs__link` | Adds a tab role to the component. **Required**. |
+| `role="tabslist"` | `.pf-c-tabs__list` | Adds a tablist role to the component. **Required**. |
+| `aria-hidden="true"` | `.pf-c-tabs__scroll-button` | Removes the scroll button from the accessibility tree to prevent assistive technologies from being able to place focus on it. This is only added because the tabs list will automatically scroll as focus is placed on each tab. |
+| `disabled` | `.pf-c-tabs__scroll-button` | Adds styling to indicate that a scroll button is disabled. **Required** on the applicable scroll button when the tabs list is scrolled all the way to the first or last tab. |
+| `aria-expanded="false"` | `.pf-c-tabs__toggle-button .pf-c-button.pf-m-plain` | Indicates that an expandable, vertical tabs toggle is collapsed to assistive technologies. **Required** if the toggle is collapsed. |
+| `aria-expanded="true"` | `.pf-c-tabs__toggle-button .pf-c-button.pf-m-plain` | Indicates that an expandable, vertical tabs toggle is expanded to assistive technologies. **Required** if the toggle is expanded. |
+| `aria-label` | `.pf-c-tabs__toggle-button .pf-c-button.pf-m-plain` | Adds an accessible name to the expandable tabs toggle. |
+| `aria-hidden="true"` | `.pf-c-tabs__toggle-icon i` | Removes the toggle icon from the accessibility tree, preventing assistive technologies from potentially announcing duplicate or unnecessary information without visually hiding it. **Required**. |
+| `aria-label` | `.pf-c-tab-content` | Adds an accessible name to the tab content panel. The value passed in should generally indicate the title of the tab that the content is related to. For example, if a tab content panel is related to a tab with a title of "Users", you could pass in "Content for users tab" as a value to this attribute. Either this or the `aria-labelledby` attribute can be used, but do not use both. |
+| `aria-labelledby` | `.pf-c-tab-content` | Adds an accessible name to the tab content panel. The value passed in should be the ID of the related tab component. Either this or the `aria-labelledby` attribute can be used, but do not use both. |
+| `role="tabpanel"` | `.pf-c-tab-content` | Adds a tabpanel role to the component. **Required**. |
+| `tabindex="0"` | `.pf-c-tab-content` | Allows users navigating via keyboard to place focus on the tab content panel. **Required**. |
 
 ## Additional considerations
 
 Consumers must ensure they take any additional considerations when customizing tabs, using them in a way not described or recommended by PatternFly, or in various other specific use-cases not outlined elsewhere on this page.
 
-- If a tab's title consists of only an icon without any accompanying title text, the tab sub-component should have an `aria-label` to provide an accessible name and the `tooltip` prop passed in to provide visual context. Without both of these props, users will have no context as to which tab they are currently focused on or what the tab name is. 
+- If a tab's title consists of only an icon without any accompanying title text, the tab sub-component should have the `tooltip` prop passed in to provide visual context and an accessible name. For information regarding accessibility with a tooltip, read the [tooltip accessibility](/components/tooltip/accessibility) documentation.
 
 ## Further reading
 
 To read more about accessibility with tabs, refer to the following resources:
 
 - [ARIA Authoring Practices Guide - Tabs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
-
-**Keyboard users** should be able to use standard keyboard user navigation (**Tab** and **Shift + Tab**) to move to and between tabs.
-Keyboard users should also be able to select a tab using **Enter** and **Space**. Disabled tabs cannot receive
-browser focus by default. Whenever a disabled tab needs to be able to receive browser focus, such as in the case of
-disabled tabs with a tooltip, use the `isAriaDisabled` prop instead of `isDisabled`.
-
-**Screen reader users** should be made aware that the tabs are interactable screen reader cursor focus, and which 
-tab is currently active using `aria-selected="true"` on the active tab, and `aria-selected="false"` 
-on the non-active tabs. Additionally, all buttons and controls used to maneuver the tabs (i.e. the left and right
-scroll buttons and the expandable tab toggle) should be labelled.
-
-The following props/attributes have been added for you or are customizable in PatternFly:
-
-| React component | React prop           | Which HTML element it appears on in markup | Explanation                                                                                                                                                                                                                                        | 
-|-----------------|----------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Tabs            | aria-label           | .pf-c-tabs                                 | Provides an accessible label for the tabs. Labels should be unique for each set of tabs that are present on a page. When component is set to nav, this prop should be defined to differentiate the tabs from other navigation regions on the page. |
-| Tabs            | leftScrollAriaLabel  | .pf-c-tabs__scroll-button:nth-of-type(1)   | Aria-label for the left scroll button                                                                                                                                                                                                              |
-| Tabs            | rightScrollAriaLabel | .pf-c-tabs__scroll-button:nth-of-type(2)   | Aria-label for the right scroll button                                                                                                                                                                                                             |
-| Tabs            | toggleAriaLabel      | .pf-c-tabs__toggle-button > button         | Aria-label for the expandable toggle                                                                                                                                                                                                               |
-| Tab             | isAriaDisabled       | .pf-c-tabs__link > button                  | Adds disabled styling and communicates that the button is disabled using the aria-disabled html attribute. Using this property to make a tab appear disable will allow the tab to receive browser focus to trigger a tooltip.                      |
-| TabContent      | aria-label           | .pf-c-tabs                                 | Title of controlling Tab if used outside Tabs component                                                                                                                                                                                            |


### PR DESCRIPTION
Closes #3071 

[Tabs a11y tab](https://patternfly-org-pr-3074-v4.surge.sh/v4/components/tabs/accessibility)

Added in several attributes to the HTML table which will require HTML examples to be updated as a follow-up (this can be done alongside updating the Accessibility section(s) on that tab).