### PR TITLE
Clean up after removing v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "build": "yarn build:v4",
     "build:analyze": "yarn workspace patternfly-org-4 build:analyze && yarn copy:v4",
     "build:v4": "yarn workspace patternfly-org-4 build && yarn copy:v4",
-    "build:v3": "yarn copy:v3",
-    "copy:v3": "rm -rf build/patternfly-org/v3 && mkdir -p build/patternfly-org && cp -r packages/v3/readme.md build/patternfly-org/v3",
     "copy:v4": "rm -rf build/patternfly-org/v4 && mkdir -p build/patternfly-org && cp -r packages/v4/public build/patternfly-org/v4 && cp -r build/patternfly-org/v4/assets build/patternfly-org/assets",
     "clean": "lerna run clean && rm -rf build",
     "serve": "pf-docs-framework serve build/patternfly-org",

--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -140,7 +140,7 @@ const HeaderTools = ({
                 key="PatternFly 3"
                 className="ws-patternfly-3"
                 target="_blank"
-                href="https://www.patternfly.org/v3"
+                href="https://pf3.patternfly.org/"
               >
                 PatternFly 3
                 <ExternalLinkAltIcon />

--- a/packages/v3/Gemfile
+++ b/packages/v3/Gemfile
@@ -1,8 +1,0 @@
-# If you do not have OpenSSL installed, update
-# the following line to use "http://" instead
-source 'https://rubygems.org'
-
-gem 'rack'
-gem 'json'
-gem 'jekyll'
-gem 'jekyll-sitemap'

--- a/packages/v3/readme.md
+++ b/packages/v3/readme.md
@@ -1,1 +1,0 @@
-Temporary placeholder for v3 - remove later

--- a/packages/v4/patternfly-docs/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs/patternfly-docs.config.js
@@ -11,7 +11,7 @@ module.exports = {
   hasFooter: true,
   hasVersionSwitcher: true,
   hasDesignGuidelines: true,
-  hasDarkThemeSwitcher: true, // change back before committing. DONT LET ME COMMIT THIS!
+  hasDarkThemeSwitcher: false,
   sideNavItems: [
     { section: 'get-started' },
     { section: 'developer-resources' },

--- a/scripts/writeV3Redirects.js
+++ b/scripts/writeV3Redirects.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const path = require('path');
 
 const outDir = 'build/patternfly-org';
-const v3_to = `${outDir}/v3`;
 const writeRedirect = (file, to) => {
   const parentFolder = path.dirname(file);
   if (!fs.existsSync(parentFolder)) {
@@ -33,23 +32,8 @@ fs.writeFileSync(`${outDir}/sitemap.xml`,
 `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://www.patternfly.org/v3/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://www.patternfly.org/v4/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>`);
 console.log('Wrote 4 static files');
 
-// Write PF3 redirects
-if (!process.argv.includes('--skip-v3')) {
-  const redirectPaths = require('glob').sync(
-    `${v3_to}/**/*.html`,
-    { ignore: [`${v3_to}/components/**`, `${v3_to}/*.html`] }
-  );
-
-  redirectPaths.forEach(file => {
-    writeRedirect(file.replace(v3_to, outDir), file.replace(outDir, ''))
-  });
-  console.log(`Wrote ${redirectPaths.length} redirects`);
-}


### PR DESCRIPTION
Closes #3048 

Remove references to v3 in package.json, the side nav, and the redirects file.

Also turned off the dark theme switcher - which is only supposed on be on in the workspaces.

There was talk of no longer needing the 'v4' in the URL, I imagine we could update `scripts/writeV3Redirects.js` again to redirect a url with a v4 in it to the url without it if we update the config to no long append 'v4' in the urls. what do you think @evwilkin @dgutride ?