### PR TITLE
chore(docs): update pathPrefix to remove v4

### DIFF
--- a/packages/v4/patternfly-docs/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs/patternfly-docs.config.js
@@ -1,6 +1,6 @@
 // This module is shared between NodeJS and babelled ES5
 module.exports = {
-  pathPrefix: '/v4',
+  pathPrefix: '',
   googleAnalyticsID: 'UA-47523816-6',
   algolia: {
     apiKey: 'a8fb1726b78594ff97a3418757514404',


### PR DESCRIPTION
Testing: update `[start.js](https://github.com/patternfly/patternfly-org/blob/main/packages/documentation-framework/scripts/cli/start.js#L24)` to build local code in `production` rather than `development`.