### PR TITLE
fix(example): increase code editor button tooltip size, other cleanup

### DIFF
--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -1,3 +1,7 @@
+:root {
+  --ws-code-editor--tooltip--MaxWidth: 16ch;
+}
+
 .ws-example {
   margin-top: var(--pf-global--spacer--lg);
   margin-bottom: var(--pf-global--spacer--lg);

--- a/packages/documentation-framework/components/example/exampleToolbar.js
+++ b/packages/documentation-framework/components/example/exampleToolbar.js
@@ -42,16 +42,6 @@ export const ExampleToolbar = ({
   const [isEditorOpen, setIsEditorOpen] = React.useState(false);
   const [isCopied, setCopied] = React.useState(false);
 
-  const copyCode = () => {
-    copy(code);
-
-    setCopied(true);
-    // Reset isCopied after Tooltip fades out
-    setTimeout(() => {
-      setCopied(false);
-    }, 2500);
-  };
-
   const copyLabel = 'Copy code to clipboard';
   const languageLabel = `Toggle ${lang.toUpperCase()} code`;
   const codesandboxLabel = 'Open example in CodeSandbox';
@@ -65,6 +55,22 @@ export const ExampleToolbar = ({
   const fullscreenAriaLabel = `Open ${exampleTitle} example in new window`;
   const convertAriaLabel = `Convert ${exampleTitle} example from Typescript to JavaScript`;
   const undoAllAriaLabel = `Undo all changes to ${exampleTitle}`;
+
+  const editorControlProps = {
+    maxWidth: 'var(--ws-code-editor--tooltip--MaxWidth)',
+    className: "ws-code-editor-control",
+    exitDelay: 300
+  };
+
+  const copyCode = () => {
+    copy(code);
+
+    setCopied(true);
+    // Reset isCopied after Tooltip fades out
+    setTimeout(() => {
+      setCopied(false);
+    }, 2500);
+  };
 
   const customControls = (
     <React.Fragment>
@@ -83,38 +89,37 @@ export const ExampleToolbar = ({
         aria-label={languageAriaLabel}
         toolTipText={languageLabel}
         aria-expanded={isEditorOpen}
-        className="ws-code-editor-control"
+        {...editorControlProps}
       />
       <Tooltip
         trigger="mouseenter"
         content={<div>{isCopied ? 'Code copied' : copyLabel}</div>}
-        exitDelay={isCopied ? 1600 : 300}
-        entryDelay={300}
-        maxWidth="100px"
-        position="top"
+        {...(isCopied && {exitDelay: 1600})}
+        maxWidth={editorControlProps.maxWidth}
       >
-        <Button onClick={() => {
-          copyCode();
-          trackEvent('code_editor_control_click', 'click_event', 'COPY_CODE');
-        }} variant="control" aria-label={copyAriaLabel} className="ws-code-editor-control">
+        <Button
+          onClick={() => {
+            copyCode();
+            trackEvent('code_editor_control_click', 'click_event', 'COPY_CODE');
+          }}
+          variant="control"
+          aria-label={copyAriaLabel}
+          className={editorControlProps.className}
+        >
           <CopyIcon />
         </Button>
       </Tooltip>
       {codeBoxParams &&
-        <Tooltip
-          trigger="mouseenter"
-          content={codesandboxLabel}
-          exitDelay={300}
-          entryDelay={300}
-          maxWidth="100px"
-          position="top"
+        <Form
+          aria-label={`${codesandboxAriaLabel} form` }
+          action="https://codesandbox.io/api/v1/sandboxes/define"
+          method="POST"
+          target="_blank"
+          style={{ display: "inline-block" }}
         >
-          <Form
-            aria-label={`${codesandboxAriaLabel} form` }
-            action="https://codesandbox.io/api/v1/sandboxes/define"
-            method="POST"
-            target="_blank"
-            style={{ display: "inline-block" }}
+          <Tooltip
+            content={codesandboxLabel}
+            maxWidth={editorControlProps.maxWidth}
           >
             <Button
               aria-label={codesandboxAriaLabel}
@@ -123,13 +128,13 @@ export const ExampleToolbar = ({
               onClick={() => {
                 trackEvent('code_editor_control_click', 'click_event', 'CODESANDBOX_LINK');
               }}
-              className="ws-code-editor-control"
+              className={editorControlProps.className}
             >
-              <input type="hidden" name="parameters" value={codeBoxParams} />
               <CodepenIcon />
             </Button>
-          </Form>
-        </Tooltip>
+          </Tooltip>
+          <input type="hidden" name="parameters" value={codeBoxParams} />
+        </Form>
       }
       {fullscreenLink && 
         <CodeEditorControl
@@ -143,7 +148,7 @@ export const ExampleToolbar = ({
           onClick={() => {
             trackEvent('code_editor_control_click', 'click_event', 'FULLSCREEN_LINK');
           }}
-          className="ws-code-editor-control"
+          {...editorControlProps}
         />
       }
       {isEditorOpen && lang === 'ts' &&
@@ -159,7 +164,7 @@ export const ExampleToolbar = ({
             setCode(convertToJSX(code).code);
             trackEvent('code_editor_control_click', 'click_event', 'TS_TO_JS');
           }}
-          className="ws-code-editor-control"
+          {...editorControlProps}
         />
       }
       {code !== originalCode &&
@@ -171,7 +176,7 @@ export const ExampleToolbar = ({
             setCode(originalCode);
             trackEvent('code_editor_control_click', 'click_event', 'RESET_CODE');
           }}
-          className="ws-code-editor-control"
+          {...editorControlProps}
         />
       }
     </React.Fragment>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/3137

--

I noticed a bunch of other discrepancies between the buttons, so I tried updating all of them to use [`<CodeEditorControl>`](https://github.com/patternfly/patternfly-react/blob/main/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx), and with @nicolethoen's help, we discovered that [passing `exitDelay` from a state var (`isCopied`)](https://github.com/patternfly/patternfly-org/blob/9298e0ede6347f0b1ced12de5c2c924d8859d163/packages/documentation-framework/components/example/exampleToolbar.js#L90) doesn't work if there are multiple `trigger` values passed... or something like that. Got a little tricky for me, and our fearless leader @nicolethoen is going to look at it.

This PR
* adds a new CSS var to control the tooltip `maxWidth` that widens it a bit
* adds an object of props/vals we can pass directly to `<CodeEditorControl>` and individually to `<Tooltip>` and `<Button>` to keep the examples consistent
* Cleans up a bunch of redundant props that don't need to be defined because they're the default
* Fixes the tooltip on the codesandbox link when you focus on it via keyboard. It needed `focus` as a value for `trigger` and for the tooltip to move to the button - wasn't working on the `<form>`

Some things I noticed that @nicolethoen may clean up with her work, or may need new issues for:
* [`<CodeEditor>` actions](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx#L557-L568) are built using `<Tooltip>` and `<Button>` and we have this fancy pants [`<CodeEditorControl>` component](https://github.com/patternfly/patternfly-react/blob/main/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx), so we have a lot of unnecessary duplication in the code editor, and in this example toolbar. Ideally we would use `<CodeEditorControl>` for all the things.
* `<CodeEditorControl>` has a lot of props that are redundantly redefined or different (that might not need to be?) from `<Tooltip>`'s defaults. For example
  * [`entryDelay: 300`](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx#L48) is tooltip's default
  * [`exitDelay: 0`](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx#L47) is different (tooltip's is 300) - does it need to be different?
  * [`position: top`](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx#L50) is tooltip's default
  * and so on...
  * As a side note, ideally we would just leave all of these redundant props unset if they aren't passed, so `<CodeEditorControl>` stays in sync with `<Tooltip>`
* [`<CodeEditorControl>` hardcodes the tooltip's `trigger` prop](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx#L63). That should be configurable with a `trigger` prop on `<CodeEditorControl>`.
* You should probably be able to pass `tooltipProps` or something to `<CodeEditorControl>` that gets passed along to `<Tooltip>`.
* Does `<CodeEditorControl>` need to set `maxWidth: 100px`? That's pretty narrow. Could that just use tooltip's default?
* It's probably covered with the context above, but the [example's copy code button](https://github.com/patternfly/patternfly-org/blob/9298e0ede6347f0b1ced12de5c2c924d8859d163/packages/documentation-framework/components/example/exampleToolbar.js#L89) needs a tooltip on focus at least. 
* Why don't the `exitDelay` and "reset tooltip text" times sync up? They're different - they're 1600 `exitDelay`, and text resets at 2500. If you set them to the same, the text resets before the tooltip disappears. I found this in a few spots:
  * [Example toolbar `exitDelay`](https://github.com/patternfly/patternfly-org/blob/9298e0ede6347f0b1ced12de5c2c924d8859d163/packages/documentation-framework/components/example/exampleToolbar.js#L91) and [reset text](https://github.com/patternfly/patternfly-org/blob/9298e0ede6347f0b1ced12de5c2c924d8859d163/packages/documentation-framework/components/example/exampleToolbar.js#L52)
  * Code editor's [`exitDelay`](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx#L262) and [reset text](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx#L447)
  * Copy clipboard's [`exitDelay`](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx#L114) and [reset text](https://github.com/patternfly/patternfly-react/blob/cbdc5af739f7e9d074dc0012497e85b1efa25180/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx#L116) (I think that's it anyways, and it's 2000 instead of 2500)
* We use `execCommand('copy')` in all of these places, like https://github.com/patternfly/patternfly-org/blob/main/packages/documentation-framework/helpers/copy.js
  * That's officially deprecated - https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
  * That method calls for adding a form element to the DOM, and calling `.select()` on it to copy the text. `.select()` steals the browser focus, so clicking on the copy button doesn't manage focus the same way other buttons do. IMO, unless the stuff you're copying is 1) in a form element already, and 2) visibly selected, focus should be maintained on the element that triggered the copy command. It's most visible when you click the copy button at the end of any of our examples, then hit `tab` - that uses `copy.js` linked above, which appends the form element to `<body>`, so hitting `tab` takes you to the "skip to content" button.
  * [navigator.clipboard()]() seems widely supported for regular text anyways. Could we use that instead?
    * I made this codepen to test - https://codepen.io/mcoker/pen/MWVdOPE
    