### PR TITLE
Update v4 docs source to allow for 'react-next' source names

### DIFF
--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@patternfly/documentation-framework": "^1.2.8",
-    "@patternfly/react-docs": "5.92.9",
+    "@patternfly/react-docs": "5.96.3",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },

--- a/packages/v4/patternfly-a11y.config.js
+++ b/packages/v4/patternfly-a11y.config.js
@@ -67,5 +67,5 @@ module.exports = {
     }
   ],
   ignoreIncomplete: true,
-  skip: '(mailto)|(/(react|react-demos|react-legacy|react-composable|html|html-demos)/.+)|(/react$)'
+  skip: '(mailto)|(/(react|react-next|react-demos|react-legacy|react-composable|html|html-demos)/.+)|(/react$)'
 };

--- a/packages/v4/patternfly-docs/patternfly-docs.source.js
+++ b/packages/v4/patternfly-docs/patternfly-docs.source.js
@@ -50,14 +50,15 @@ module.exports = (sourceMD, sourceProps) => {
   sourceProps(path.join(reactLogViewerPath, '/**/*.tsx'), reactPropsIgnore);
 
   // React MD
-  sourceMD(path.join(reactCorePath, '/**/examples/*.md'), 'react');
+  sourceMD(path.join(reactCorePath, '/components/**/examples/*.md'), 'react');
+  sourceMD(path.join(reactCorePath, '/next/components/**/examples/*.md'), 'react-next');
   sourceMD(path.join(reactCorePath, '/**/demos/**/*.md'), 'react-demos');
 
   // React-table MD
   sourceMD(path.join(reactTablePath, '/**/TableComposable/examples/*.md'), 'react-composable');
   sourceMD(path.join(reactTablePath, '/**/demos/*.md'), 'react-demos');
   sourceMD(path.join(reactTablePath, '/**/Table/examples/*.md'), 'react-legacy');
-  
+
   // Charts MD (no demos yet)
   sourceMD(path.join(reactChartsPath, '/**/examples/*.md'), 'react');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,27 +2326,27 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.206.3":
-  version "4.206.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.206.3.tgz#cdf3f42df06cd84f2a25bd5bf07e6e69d5d7af84"
-  integrity sha512-2Ar6qaZAozyx/KBzlqqskoEf45HUZIbk668qFwYHWaTkuucYw/usoxw03OwnGCS4GgBlMf06X2uonHgQLhVT8A==
+"@patternfly/patternfly@4.210.2":
+  version "4.210.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.210.2.tgz#3c0ba9a40897e209cf59b465baa985b7b2d739e4"
+  integrity sha512-aZiW24Bxi6uVmk5RyNTp+6q6ThtlJZotNRJfWVeGuwu1UlbBuV4DFa1bpjA6jfTZpfEpX2YL5+R+4ZVSCFAVdw==
 
-"@patternfly/react-catalog-view-extension@^4.82.9":
-  version "4.82.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.82.9.tgz#66d7fc1de9eb24f00d76e579a26fe643dd7f6249"
-  integrity sha512-bpCZrDPppOgv3EJlout2qKJ0X0HdhsgcREoFhZGsi3N6NtqtXMQMWLibOa1UR1fIBtHO94mopBcyjj0cNxUgBA==
+"@patternfly/react-catalog-view-extension@^4.86.3":
+  version "4.86.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.86.3.tgz#98e22355ac3adbc1950f776c498c863ae4eb6e54"
+  integrity sha512-p3Dcpl8tXJdya01rG77qEPQ59aXUZ+7rjQG3u2LUiaHaJzsmcL1DjDB3SOj8x8J720igTRdadjf6RZF0e/THjw==
   dependencies:
-    "@patternfly/patternfly" "4.206.3"
-    "@patternfly/react-core" "^4.231.9"
-    "@patternfly/react-styles" "^4.81.9"
+    "@patternfly/patternfly" "4.210.2"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-styles" "^4.85.3"
 
-"@patternfly/react-charts@^6.84.9":
-  version "6.84.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.84.9.tgz#e75c182d6a00eed463e387ed75b442e2e82e96b1"
-  integrity sha512-0SauXW3mpFIh+c5KmEivzmbtFrx7aN53AXpHRxQhMRis6TOsCwWF/RGwKNf6oqHWZKdJSAdRPNz08CqKjrYbIQ==
+"@patternfly/react-charts@^6.88.3":
+  version "6.88.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.88.3.tgz#8a6a10824cd1623c58c665f4ddae86ab7ce31b96"
+  integrity sha512-Ol9jZeusqzyX3X7S74mWHN/FFvgsVj19i24qPG9NpakufLbWagBsah82QqLsdk4+gvf6ZoqrJd3B3nzTj4/u7w==
   dependencies:
-    "@patternfly/react-styles" "^4.81.9"
-    "@patternfly/react-tokens" "^4.83.9"
+    "@patternfly/react-styles" "^4.85.3"
+    "@patternfly/react-tokens" "^4.87.3"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "^2.0.0"
@@ -2356,6 +2356,7 @@
     victory-chart "^36.2.1"
     victory-core "^36.2.1"
     victory-create-container "^36.2.1"
+    victory-cursor-container "^36.2.1"
     victory-group "^36.2.1"
     victory-legend "^36.2.1"
     victory-line "^36.2.1"
@@ -2366,105 +2367,105 @@
     victory-voronoi-container "^36.2.1"
     victory-zoom-container "^36.2.1"
 
-"@patternfly/react-code-editor@^4.72.9":
-  version "4.72.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-4.72.9.tgz#9cd2fae69e5e552ae373a6382db256f89bb33577"
-  integrity sha512-2jxz6i3Zqubh2+2+7e6s5jg/FUhu+4wg0jUrz0QpmMJtI/LvnyKLtf+AeFiNZRI5sZo1v2H2ltLNBVLwD7b84A==
+"@patternfly/react-code-editor@^4.76.3":
+  version "4.76.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-4.76.3.tgz#6d36b68e8f4c9a876cdb9db021e922b68ff923bb"
+  integrity sha512-XNtOOxW7DJqo60cbgSt/X9spIAp8bmkId/cnXNPG6ht2rFhOeQB3m+e79jM0PioMc4b8o2ufwAeFLZBB/dNg0A==
   dependencies:
-    "@patternfly/react-core" "^4.231.9"
-    "@patternfly/react-icons" "^4.82.9"
-    "@patternfly/react-styles" "^4.81.9"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
     react-dropzone "9.0.0"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^4.231.9", "@patternfly/react-core@^4.232.5":
-  version "4.232.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.232.5.tgz#fd80e8cf98865d7520ccac0fc06f92e045318947"
-  integrity sha512-NxME6Pyepsx+Qa0vn3qq73cOJOuFOj5qxjCnJE3mwZQeD6YfNg2dut0/OMzk2BBnbnpeb8IG6hoNMdFARMBQgA==
+"@patternfly/react-core@^4.235.3":
+  version "4.235.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.235.3.tgz#5fdd6747f1da9ba4204302a1d3c6e467ed08575d"
+  integrity sha512-q1Wcscz16yk7++0Gvmv91VqOozYoQn2zrd4iEHdaKO85aX7oP4mjHwDObT2/GUuoXbhKjZ6O4hF8vrYbMGPy1A==
   dependencies:
-    "@patternfly/react-icons" "^4.83.5"
-    "@patternfly/react-styles" "^4.82.5"
-    "@patternfly/react-tokens" "^4.84.5"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
+    "@patternfly/react-tokens" "^4.87.3"
     focus-trap "6.9.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-docs@5.92.9":
-  version "5.92.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-5.92.9.tgz#7d0d25d629291cad01e58498ee259c0a32d74bb5"
-  integrity sha512-SnWGEwYhqf4j5AVsmh9XlvHG4BC0TXd/B4br8Y1NGhP6qtgPt59NAbqjXRTGJIzRKaWb9q9x9hzM8KLChMjtMA==
+"@patternfly/react-docs@5.96.3":
+  version "5.96.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-5.96.3.tgz#d0a9cdcf0d721013a7c6254f467ff91bb77609ed"
+  integrity sha512-6uRQWZkHsc+CXFz5eElTBMU0KfVxcOBBzFFosOV6kD9NnHnXW44ouwWFB2+VY0llOASuVTxxZ7jv0NG5B0SofQ==
   dependencies:
-    "@patternfly/patternfly" "4.206.3"
-    "@patternfly/react-catalog-view-extension" "^4.82.9"
-    "@patternfly/react-charts" "^6.84.9"
-    "@patternfly/react-code-editor" "^4.72.9"
-    "@patternfly/react-core" "^4.231.9"
-    "@patternfly/react-icons" "^4.82.9"
-    "@patternfly/react-inline-edit-extension" "^4.76.9"
-    "@patternfly/react-log-viewer" "^4.76.9"
-    "@patternfly/react-styles" "^4.81.9"
-    "@patternfly/react-table" "^4.100.9"
-    "@patternfly/react-tokens" "^4.83.9"
-    "@patternfly/react-topology" "^4.78.9"
-    "@patternfly/react-virtualized-extension" "^4.78.9"
+    "@patternfly/patternfly" "4.210.2"
+    "@patternfly/react-catalog-view-extension" "^4.86.3"
+    "@patternfly/react-charts" "^6.88.3"
+    "@patternfly/react-code-editor" "^4.76.3"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-inline-edit-extension" "^4.80.3"
+    "@patternfly/react-log-viewer" "^4.80.3"
+    "@patternfly/react-styles" "^4.85.3"
+    "@patternfly/react-table" "^4.104.3"
+    "@patternfly/react-tokens" "^4.87.3"
+    "@patternfly/react-topology" "^4.82.3"
+    "@patternfly/react-virtualized-extension" "^4.82.3"
 
-"@patternfly/react-icons@^4.82.9", "@patternfly/react-icons@^4.83.5":
-  version "4.83.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.83.5.tgz#3fcbb6107d893b3221b91f754e9a7686d36fb100"
-  integrity sha512-SGSmSVhUKrUbSAZr9TCqcPh6ujIdSjmYREqSyGu2W5tICH1DtDk0BBedmTjLbLb2tMNF0jWcYzLjVrKhX72eOA==
+"@patternfly/react-icons@^4.86.3":
+  version "4.86.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.86.3.tgz#58f364c48833b162a670117280d54b9a04cd3742"
+  integrity sha512-V5dUC9W+OQ8fMYC/uY1nYsI1ixgQzoPIAEXJvuk15vB6UTZgq6Fzqz38RZIgzZzLWLndPeM3+66ndWTOVEOpMw==
 
-"@patternfly/react-inline-edit-extension@^4.76.9":
-  version "4.77.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-inline-edit-extension/-/react-inline-edit-extension-4.77.5.tgz#a4ff5ce980716aab02f78415c819f552d2b7d4dd"
-  integrity sha512-uCjP2G8OGKMy6Oi2Nqk4J376jodIf8Q/4NlfTtzj2u6KaCRw/5iRQd0f7XSHgmcsScdQA4OFZFJvura4v4HCOw==
+"@patternfly/react-inline-edit-extension@^4.80.3":
+  version "4.80.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-inline-edit-extension/-/react-inline-edit-extension-4.80.3.tgz#dcba399c06baa02adeffd88095dea01e2f996357"
+  integrity sha512-vdSFxBNyjT8DJGZP85KvPT43BVXynlaGoKncu8jyBIqRECO/gP4acoDYJ+qXaKJQG8KBBvmiQAXl1cpftz33uQ==
   dependencies:
-    "@patternfly/react-core" "^4.232.5"
-    "@patternfly/react-icons" "^4.83.5"
-    "@patternfly/react-styles" "^4.82.5"
-    "@patternfly/react-table" "^4.101.5"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
+    "@patternfly/react-table" "^4.104.3"
 
-"@patternfly/react-log-viewer@^4.76.9":
-  version "4.77.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-4.77.5.tgz#926cf5344f1b776aa23b11276de9adc3f5e2fb3a"
-  integrity sha512-nFXmNcfDxZ23qL40Z36/117C8w9zK+NQDbBeZ/qSh2o1Nv8D3uedLMvi5G46nX8I3goQRYzgYsoyq8eG5EhYNA==
+"@patternfly/react-log-viewer@^4.80.3":
+  version "4.80.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-4.80.3.tgz#1240996848db958ba3c994d6fcf872129d44ba76"
+  integrity sha512-YnOP7s466G5V8f8WiAxOFhnR+xzMnNKRH7+tK39y0+iTu2X0jCluFip1k6tSZ2mvuxpKqzWJ4/JaoOA07XmCmA==
   dependencies:
-    "@patternfly/react-core" "^4.232.5"
-    "@patternfly/react-icons" "^4.83.5"
-    "@patternfly/react-styles" "^4.82.5"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
     memoize-one "^5.1.0"
     resize-observer-polyfill "^1.5.1"
 
-"@patternfly/react-styles@^4.81.9", "@patternfly/react-styles@^4.82.5":
-  version "4.82.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.82.5.tgz#d932ff04cd768623f0579d0ca0300158feeedf64"
-  integrity sha512-pwQf+rOith61iJcr7Un4NeS0NH5FCGnghPEOk0Kllh7gMx8hh3MRYES7nSrMMnbVr4xaO2F/AmDc3q3Ao0Tn4g==
+"@patternfly/react-styles@^4.85.3":
+  version "4.85.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.85.3.tgz#a89f090fbb81cd5768bbccb32a7ed79125cf0910"
+  integrity sha512-PSSmyYb/75cnv0tU5BPd6c8f+3w35fOrDZaGKgCHKdCLzVgNIUv8+BmAln6czXx14oVlZkw+aFYpIia0ALzbLg==
 
-"@patternfly/react-table@^4.100.9", "@patternfly/react-table@^4.101.5":
-  version "4.101.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.101.5.tgz#8e3ddde815ecdf2db5f974fdb4cc89ed2a4dade2"
-  integrity sha512-d/6skiRkK3GcMzTVJReX0KP0z+iNkjM2PeZDM25jz3JehQXIt9ZJZYN9qN0t9KYgwaRczsYq9D3TYbHAZQ+k/g==
+"@patternfly/react-table@^4.104.3":
+  version "4.104.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.104.3.tgz#38edb797abdf821120573bee60e2136daf8cd244"
+  integrity sha512-MpTZ4JcOZgypi1OPfm8VivJ2uLzk3kZrv+0WGg+rp0bD4GBRrbP4td/GMvHVWKJa92PvXwvojsVXvOcAkdrhow==
   dependencies:
-    "@patternfly/react-core" "^4.232.5"
-    "@patternfly/react-icons" "^4.83.5"
-    "@patternfly/react-styles" "^4.82.5"
-    "@patternfly/react-tokens" "^4.84.5"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
+    "@patternfly/react-tokens" "^4.87.3"
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-tokens@^4.83.9", "@patternfly/react-tokens@^4.84.5":
-  version "4.84.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.84.5.tgz#a8a14ba3ed9b21e6eb072a12ca3ccc8b72062455"
-  integrity sha512-nSfkAEp+VtpDIL7dfoPcq7AqlVPYOtpxkPHnABbZ8ts82FpASPe6yI73msRwnwobyOzIJL0vxT83goqUUycChA==
+"@patternfly/react-tokens@^4.87.3":
+  version "4.87.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.87.3.tgz#511311dd1edca4481c4c5da313fe6bd156b1aab4"
+  integrity sha512-sP74GLk5Rjr7eSjrB0IZGA9x0in/Miiz5Fpw8o6T3M6k53L2DWOxRbCOMOR7v0Xt4IIVvReGvvk6kIqPmw5hdw==
 
-"@patternfly/react-topology@^4.78.9":
-  version "4.79.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.79.5.tgz#52636046e577e8cdab7109369fb2a0a29cded5ef"
-  integrity sha512-XvYJZhU5aKQ6j3Gx9xlm7gC9iM/7yl0U5dNQcCBIahb8w03kBj2Xpat1OZ/i3UbDtSNozK3HX4QmDW5johPAfA==
+"@patternfly/react-topology@^4.82.3":
+  version "4.82.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.82.3.tgz#b271cabc8fdbbe755414d89a5ee49fb52c1512d0"
+  integrity sha512-PEv4SPw9u+APKxGexqKiV+cUAeXac7cvpS0pqEjipxTEvFL2BsqCoq4LnvJKzwaDiQtfw/DqdwWqoiG9EnTCUw==
   dependencies:
-    "@patternfly/react-core" "^4.232.5"
-    "@patternfly/react-icons" "^4.83.5"
-    "@patternfly/react-styles" "^4.82.5"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
     "@types/d3" "^5.7.2"
     "@types/d3-force" "^1.2.1"
     "@types/dagre" "0.7.42"
@@ -2481,14 +2482,14 @@
     tslib "^2.0.0"
     webcola "3.4.0"
 
-"@patternfly/react-virtualized-extension@^4.78.9":
-  version "4.78.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-virtualized-extension/-/react-virtualized-extension-4.78.9.tgz#1cfdf893b572cb4a745bf32aa581a96b23c3fbf5"
-  integrity sha512-mzQzRoBsVGb8aJcxtqZinqi1fSd6WoyyBK83JwwXHWpxlJxjIaGo2KBVyVKejCttSwWtB22bIKIyKQKBFfqT0Q==
+"@patternfly/react-virtualized-extension@^4.82.3":
+  version "4.82.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-virtualized-extension/-/react-virtualized-extension-4.82.3.tgz#b7379740260f73cb6fec3117877dadd2d4ab2924"
+  integrity sha512-zkPTxWKfBB/kSfR65Ifbr2Ru9aMt34eGJmeu8ddpE+ByEa/hjXNn3DNn2ksPNrDwagkbjnrhnfEg5ZR7eCPveA==
   dependencies:
-    "@patternfly/react-core" "^4.231.9"
-    "@patternfly/react-icons" "^4.82.9"
-    "@patternfly/react-styles" "^4.81.9"
+    "@patternfly/react-core" "^4.235.3"
+    "@patternfly/react-icons" "^4.86.3"
+    "@patternfly/react-styles" "^4.85.3"
     linear-layout-vector "0.0.1"
     react-virtualized "^9.21.1"
     tslib "^2.0.0"
@@ -2527,6 +2528,11 @@
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-1.2.7.tgz#34dc654d34fc058c41c31dbca1ed68071a8fcc17"
   integrity sha512-51vHWuUyDOi+8XuwPrTw3cFqyh2Slg9y8COYkRfjCPG9TfYqY0hoNPzv/8BrcAy0FeQBzqEo/D/8Nk2caOQJnA==
+
+"@types/d3-array@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.3.tgz#87d990bf504d14ad6b16766979d04e943c046dac"
+  integrity sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==
 
 "@types/d3-axis@*":
   version "1.0.12"
@@ -2587,6 +2593,11 @@
   resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-1.0.9.tgz#1dd849bd7edef6426e915e220ed9970db5ea4e04"
   integrity sha512-U5ADevQ+W6fy32FVZZC9EXallcV/Mi12A5Tkd0My5MrC7T8soMQEhlDAg88XUWm0zoCQlB4XV0en/24LvuDB4Q==
 
+"@types/d3-ease@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.0.tgz#c29926f8b596f9dadaeca062a32a45365681eae0"
+  integrity sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==
+
 "@types/d3-fetch@*":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-1.1.5.tgz#51601f79dd4653b5d84e6a3176d78145e065db5e"
@@ -2623,6 +2634,13 @@
   dependencies:
     "@types/d3-color" "*"
 
+"@types/d3-interpolate@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz#e7d17fa4a5830ad56fe22ce3b4fac8541a9572dc"
+  integrity sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==
+  dependencies:
+    "@types/d3-color" "*"
+
 "@types/d3-path@*":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.8.tgz#48e6945a8ff43ee0a1ce85c8cfa2337de85c7c79"
@@ -2655,6 +2673,13 @@
   dependencies:
     "@types/d3-time" "*"
 
+"@types/d3-scale@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.2.tgz#41be241126af4630524ead9cb1008ab2f0f26e69"
+  integrity sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==
+  dependencies:
+    "@types/d3-time" "*"
+
 "@types/d3-selection@*":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-1.4.2.tgz#72dcd61a3aeb9ce3e8d443e3bef7685ffea3413f"
@@ -2664,6 +2689,13 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.3.2.tgz#a41d9d6b10d02e221696b240caf0b5d0f5a588ec"
   integrity sha512-LtD8EaNYCaBRzHzaAiIPrfcL3DdIysc81dkGlQvv7WQP3+YXV7b0JJTtR1U3bzeRieS603KF4wUo+ZkJVenh8w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-shape@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.0.tgz#1d87a6ddcf28285ef1e5c278ca4bdbc0658f3505"
+  integrity sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==
   dependencies:
     "@types/d3-path" "*"
 
@@ -2677,10 +2709,20 @@
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.0.10.tgz#d338c7feac93a98a32aac875d1100f92c7b61f4f"
   integrity sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==
 
+"@types/d3-time@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
+  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
+
 "@types/d3-timer@*":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-1.0.9.tgz#aed1bde0cf18920d33f5d44839d73de393633fd3"
   integrity sha512-WvfJ3LFxBbWjqRGz9n7GJt08RrTHPJDVsIwwoCMROlqF+iDacYiAFjf9oqnq0mXpb2juA2N/qjKP+MKdal3YNQ==
+
+"@types/d3-timer@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.0.tgz#e2505f1c21ec08bda8915238e397fb71d2fc54ce"
+  integrity sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==
 
 "@types/d3-transition@*":
   version "1.1.6"
@@ -5113,6 +5155,13 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.0.tgz#15bf96cd9b7333e02eb8de8053d78962eafcff14"
+  integrity sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==
+  dependencies:
+    internmap "1 - 2"
+
 d3-axis@1:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
@@ -5146,6 +5195,11 @@ d3-color@1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d3-contour@1:
   version "1.3.2"
@@ -5181,6 +5235,11 @@ d3-ease@1, d3-ease@^1.0.0:
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
   integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
 
+d3-ease@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
 d3-fetch@1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.2.0.tgz#15ce2ecfc41b092b1db50abd2c552c2316cf7fc7"
@@ -5203,6 +5262,11 @@ d3-format@1:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
   integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
 
+"d3-format@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
 d3-geo@1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.1.tgz#7fc2ab7414b72e59fbcbd603e80d9adc029b035f"
@@ -5222,10 +5286,22 @@ d3-interpolate@1, d3-interpolate@^1.1.1:
   dependencies:
     d3-color "1"
 
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
 d3-path@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
   integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.0.1.tgz#f09dec0aaffd770b7995f1a399152bf93052321e"
+  integrity sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==
 
 d3-polygon@1:
   version "1.0.6"
@@ -5275,6 +5351,17 @@ d3-scale@^1.0.0:
     d3-time "1"
     d3-time-format "2"
 
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
 d3-selection@1, d3-selection@^1.1.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
@@ -5287,6 +5374,13 @@ d3-shape@1, d3-shape@^1.0.0, d3-shape@^1.2.0, d3-shape@^1.3.5:
   dependencies:
     d3-path "1"
 
+d3-shape@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.1.0.tgz#c8a495652d83ea6f524e482fca57aa3f8bc32556"
+  integrity sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==
+  dependencies:
+    d3-path "1 - 3"
+
 d3-time-format@2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
@@ -5294,15 +5388,34 @@ d3-time-format@2:
   dependencies:
     d3-time "1"
 
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
 d3-time@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.0.0.tgz#65972cb98ae2d4954ef5c932e8704061335d4975"
+  integrity sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==
+  dependencies:
+    d3-array "2 - 3"
+
 d3-timer@1, d3-timer@^1.0.0, d3-timer@^1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+d3-timer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 d3-transition@1:
   version "1.3.2"
@@ -7797,6 +7910,11 @@ internal-ip@^4.3.0:
   dependencies:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 interpret@^1.4.0:
   version "1.4.0"
@@ -10996,6 +11114,11 @@ react-fast-compare@^2.0.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -13637,6 +13760,16 @@ victory-core@^36.2.1, victory-core@^36.3.0:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
+victory-core@^36.6.5:
+  version "36.6.5"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-36.6.5.tgz#7a443f8146646f3711a60988a6751d4fb2b2feae"
+  integrity sha512-FuuQfYTx1eU/OVvMSihT8hRZ7Enc+FT6KCbWSle44MQIt10dWMtiLyAIbHnGkMoXnNy1ffhdVzHvRnFZikEOQg==
+  dependencies:
+    lodash "^4.17.21"
+    prop-types "^15.8.1"
+    react-fast-compare "^3.2.0"
+    victory-vendor "^36.6.5"
+
 victory-create-container@^36.2.1:
   version "36.3.0"
   resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-36.3.0.tgz#31095eed7e78bcf03bd58f0872bd6164c8ed55e2"
@@ -13649,6 +13782,15 @@ victory-create-container@^36.2.1:
     victory-selection-container "^36.3.0"
     victory-voronoi-container "^36.3.0"
     victory-zoom-container "^36.3.0"
+
+victory-cursor-container@^36.2.1:
+  version "36.6.5"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-36.6.5.tgz#5eb826a77aab6f21c080ef1c01e061aa3f76d961"
+  integrity sha512-f8nAPSkecHVnFPyY4ZeOf0xqTMW2UQrKSsvSIuP711TGJ/QKizulBjEJ5nkuu/RQMV8ZuVY2ZvMV1KLkLOrAvw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.8.1"
+    victory-core "^36.6.5"
 
 victory-cursor-container@^36.3.0:
   version "36.3.0"
@@ -13756,6 +13898,26 @@ victory-tooltip@^36.2.1, victory-tooltip@^36.3.0:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     victory-core "^36.3.0"
+
+victory-vendor@^36.6.5:
+  version "36.6.5"
+  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-36.6.5.tgz#cd09672407f8a68907a457fccbcf64ec1749ee13"
+  integrity sha512-5KXhZxKZYMGXBgQ5LCXRcIDU6M8OJdheW3c99vLRW4gUOi40+onksx/NFA2tGUE/Z8j+pc1zW7ZZqvG6Rs0Ekw==
+  dependencies:
+    "@types/d3-array" "^3.0.3"
+    "@types/d3-ease" "^3.0.0"
+    "@types/d3-interpolate" "^3.0.1"
+    "@types/d3-scale" "^4.0.2"
+    "@types/d3-shape" "^3.1.0"
+    "@types/d3-time" "^3.0.0"
+    "@types/d3-timer" "^3.0.0"
+    d3-array "^3.1.6"
+    d3-ease "^3.0.1"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-shape "^3.1.0"
+    d3-time "^3.0.0"
+    d3-timer "^3.0.1"
 
 victory-voronoi-container@^36.2.1, victory-voronoi-container@^36.3.0:
   version "36.3.0"


### PR DESCRIPTION
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/96431149/187009642-efaa1ade-75b1-4994-b7ea-75a792f5dad2.png">

Also omitting react-next doc pages from a11y builds.