### PR TITLE
fix(docs): added support for optional chaining in docs-framework

### DIFF
--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@babel/core": "7.18.2",
     "@babel/plugin-proposal-class-properties": "7.17.12",
+    "@babel/plugin-proposal-optional-chaining": "^7.18.9",
     "@babel/plugin-proposal-private-methods": "7.17.12",
     "@babel/plugin-proposal-private-property-in-object": "7.17.12",
     "@babel/plugin-transform-react-jsx": "7.17.12",

--- a/packages/documentation-framework/scripts/webpack/webpack.base.config.js
+++ b/packages/documentation-framework/scripts/webpack/webpack.base.config.js
@@ -62,6 +62,7 @@ module.exports = (_env, argv) => {
               plugins: [
                 '@babel/plugin-transform-react-jsx',
                 '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-proposal-optional-chaining',
                 ["@babel/plugin-proposal-private-methods", { "loose": false }],
                 ["@babel/plugin-proposal-private-property-in-object", { "loose": false }]
               ],


### PR DESCRIPTION
Closes #3175 

This PR adds `@babel/plugin-proposal-optional-chaining` to the `documenation-framework` package in order to properly handle files contained within this package that include optional chaining.