### PR TITLE
docs(Modal): move aria-label from <i> to <span>

### DIFF
--- a/packages/v4/patternfly-docs/content/design-guidelines/components/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/design-guidelines/components/modal/modal.md
@@ -158,6 +158,6 @@ Icons are optional in modal dialogs. Use or omit them as your use case requires.
 
 | Icon | Use case(s) | Usage |
 | ------------- |-------------|-------------|
-| <span style="color: rgb(240, 171, 0)"> <i class="fas fa-exclamation-triangle" aria-label="warning" /> </span> | **Warning:** Cautions or warns the user of a permanent action, or that information will be deleted upon action completion | Add to confirmation dialogs or passive dialogs to indicate a higher level of urgency and importance.|
-| <span style="color: rgb(201, 25, 11)"> <i class="fas fa-exclamation-circle" aria-label="critical warning" /> </span> | **Critical Warning:** Indicates that an error has occured  | Add to error dialogs. |
-| <span style="color: rgb(43, 154, 243)"> <i class="fas fa-info-circle" aria-label="acknowledgement" /> </span> | **Acknowledgement:** Informs the user of an action or result  | Add to confirmation or passive dialogs to indicate a lower level of urgency. |
+| <span style="color: rgb(240, 171, 0)" aria-label="warning" role="img"> <i class="fas fa-exclamation-triangle" /> </span> | **Warning:** Cautions or warns the user of a permanent action, or that information will be deleted upon action completion | Add to confirmation dialogs or passive dialogs to indicate a higher level of urgency and importance.|
+| <span style="color: rgb(201, 25, 11)" aria-label="critical warning" role="img"> <i class="fas fa-exclamation-circle" /> </span> | **Critical Warning:** Indicates that an error has occured  | Add to error dialogs. |
+| <span style="color: rgb(43, 154, 243)" aria-label="acknowledgement" role="img"> <i class="fas fa-info-circle" /> </span> | **Acknowledgement:** Informs the user of an action or result  | Add to confirmation or passive dialogs to indicate a lower level of urgency. |


### PR DESCRIPTION
Closes #3198

Moved the `aria-label` properties from child `<i>` elements to parent `<span>` elements.

However, this then brings up the issue where the `role` property must be assigned a value. I've assigned `role="img"` to the <span> elements for the time being, let me know if these should be some other value or if there is another solution.