### PR TITLE
fix: remove lookbacks in regex to support safari 16

### DIFF
--- a/packages/documentation-framework/helpers/codesandbox.js
+++ b/packages/documentation-framework/helpers/codesandbox.js
@@ -138,7 +138,7 @@ function getReactParams(title, code, scope, lang, relativeImports) {
     code = code.replace(imgImportMatch[0], `const ${imgName} = "https://www.patternfly.org/v4${scope[imgName]}"`);
   }
 
-  const relImportRegex = /(?<=import[\s*{])([\w*{}\n\r\t, ]+)(?=[\s*]from\s["']([\.\/]+.*)["'])/gm;
+  const relImportRegex = /(import[\s*{])([\w*{}\n\r\t, ]+)([\s*]from\s["']([\.\/]+.*)["'])/gm;
   let relImportMatch;
   while (relImportMatch = relImportRegex.exec(code)) {
     const [ relImportName, _name, relImportPath ] = relImportMatch;

--- a/packages/documentation-framework/scripts/md/mdx-hast-to-jsx.js
+++ b/packages/documentation-framework/scripts/md/mdx-hast-to-jsx.js
@@ -79,7 +79,7 @@ function serializeRoot(node, options) {
     const [_match, absoluteImportPath] = relativeImportMatch;
     if (absoluteImportPath && !absoluteImportPath.includes('srcImport')) {
       // `@patternfly/react-core/src/demos/./examples/DashboardWrapper` to `DashboardWrapper`
-      let relativeFileImport = /(?<=\/)(\.+\/.*)/gm.exec(absoluteImportPath);
+      let relativeFileImport = /(\.+\/.*)/gm.exec(absoluteImportPath);
       if (relativeFileImport) {
         // Build map of relative imports (from example.js code) to npm package import path (used in codesandbox.js)
         const relativeFilePath = relativeFileImport[0];


### PR DESCRIPTION
I spent some time parsing these regexp trying to figure out if the lookbacks were necessary. Everything seems to work without them and they are [not supported in Safari](https://caniuse.com/js-regexp-lookbehind).