### PR TITLE
fix(components): width limit the description section

### DIFF
--- a/packages/documentation-framework/components/footer/footer.css
+++ b/packages/documentation-framework/components/footer/footer.css
@@ -2,8 +2,10 @@
   font-family: "RedHatText";
   font-weight: 300;
   background-color: #1a1a1a !important;
-  padding: 48px;
-  padding-top: 32px;
+  --pf-c-page__main-section--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-page__main-section--PaddingRight: var(--pf-global--spacer--2xl);
+  --pf-c-page__main-section--PaddingBottom: var(--pf-global--spacer--2xl);
+  --pf-c-page__main-section--PaddingLeft: var(--pf-global--spacer--2xl);
   /* Hide long overflowing tocs */
   z-index: 1;
 }

--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -13,7 +13,7 @@ import logo from '../../layouts/logo.svg';
 
 export const Footer = () => (
   <React.Fragment>
-    <PageSection isWidthLimited key="footer-1" className="ws-org-pfsite-l-footer">
+    <PageSection key="footer-1" className="ws-org-pfsite-l-footer">
       <Grid>
         <GridItem
           sm={12}
@@ -212,7 +212,7 @@ export const Footer = () => (
         </GridItem>
       </Grid>
     </PageSection>
-    <PageSection isWidthLimited key="footer-2" className="ws-org-pfsite-l-footer-dark pf-m-no-fill">
+    <PageSection key="footer-2" className="ws-org-pfsite-l-footer-dark pf-m-no-fill">
       <Grid className="pf-u-py-xl-on-sm pf-u-py-0-on-md pf-u-align-items-center">
         <GridItem md={2} mdOffset={1}>
           <Link

--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -13,7 +13,7 @@ import logo from '../../layouts/logo.svg';
 
 export const Footer = () => (
   <React.Fragment>
-    <PageSection key="footer-1" className="ws-org-pfsite-l-footer">
+    <PageSection isWidthLimited key="footer-1" className="ws-org-pfsite-l-footer">
       <Grid>
         <GridItem
           sm={12}
@@ -212,7 +212,7 @@ export const Footer = () => (
         </GridItem>
       </Grid>
     </PageSection>
-    <PageSection key="footer-2" className="ws-org-pfsite-l-footer-dark pf-m-no-fill">
+    <PageSection isWidthLimited key="footer-2" className="ws-org-pfsite-l-footer-dark pf-m-no-fill">
       <Grid className="pf-u-py-xl-on-sm pf-u-py-0-on-md pf-u-align-items-center">
         <GridItem md={2} mdOffset={1}>
           <Link

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -157,7 +157,7 @@ export const MDXTemplate = ({
           </Title>}
         </PageSection>
         {isComponent && summary && (
-          <PageSection variant={PageSectionVariants.light} className="pf-u-pt-0">
+          <PageSection variant={PageSectionVariants.light} isWidthLimited style={{'--pf-c-page__main-section--PaddingTop':0}}>
             <SummaryComponent />
           </PageSection>
         )}

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PageSection, Title, PageSectionVariants, BackToTop, PageGroup, Page } from '@patternfly/react-core';
+import { PageSection, Title, PageSectionVariants, BackToTop, PageGroup, Page, Text, TextContent } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Router, useLocation } from '@reach/router';
@@ -151,16 +151,13 @@ export const MDXTemplate = ({
         <PageSection
           className={isSinglePage ? "pf-m-light-100" : ""}
           variant={!isSinglePage ? PageSectionVariants.light : ""}
+          isWidthLimited
         >
-          {!katacodaLayout && <Title size="4xl" headingLevel="h1" id="ws-page-title">
-            {title}
-          </Title>}
+          <TextContent>
+          {!katacodaLayout && <Title headingLevel='h1' size='4xl' id="ws-page-title">{title}</Title>}
+          {isComponent && summary && (<SummaryComponent />)}
+          </TextContent>
         </PageSection>
-        {isComponent && summary && (
-          <PageSection variant={PageSectionVariants.light} isWidthLimited style={{'--pf-c-page__main-section--PaddingTop':0}}>
-            <SummaryComponent />
-          </PageSection>
-        )}
         {(!isSinglePage || isComponent) && (
             <PageSection id="ws-sticky-nav-tabs" stickyOnBreakpoint={{'default':'top'}} type="tabs">
               <div className="pf-c-tabs pf-m-page-insets pf-m-no-border-bottom">

--- a/packages/v4/patternfly-docs/pages/community.js
+++ b/packages/v4/patternfly-docs/pages/community.js
@@ -20,7 +20,7 @@ const CommunityPage = () => {
   }
 
   return (
-    <PageSection className="ws-community-page pf-m-light-100">
+    <PageSection isWidthLimited className="ws-community-page pf-m-light-100">
       <Title size="4xl" className="pf-u-mb-lg ws-page-title" headingLevel="h1">Community</Title>
       <p>At the core of PatternFly is our community of people—in other words, our Flyers. Together, we celebrate creativity and foster a sense of teamwork and unity.</p>
 


### PR DESCRIPTION
Fixes #3184 
Adds IsWidthLimited to the description section, but since that adds a `pf-c-page__main-body` with its own padding, I had to remove the utility class on the page section and instead directly modify the variable to remove top padding on `pf-c-page__main-body`.