### PR TITLE
Create workflow for extensions

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,0 +1,17 @@
+name: Add relevant issues to extensions project board
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  add-to-extensions:
+    if: github.event.label.name == 'extensions'
+    name: Add issue to extensions board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/patternfly/projects/12
+          github-token: ${{ secrets.PF_ISSUES_PROJECT_SECRET }}


### PR DESCRIPTION
Add new github workflow to automatically add all issues with 'extensions' label to the PatternFly Extensions project.