### PR TITLE
chore(avatar): reformat a11y docs, also fix a typo

### DIFF
--- a/packages/v4/patternfly-docs/content/accessibility/accordion/accordion.md
+++ b/packages/v4/patternfly-docs/content/accessibility/accordion/accordion.md
@@ -21,7 +21,7 @@ For the HTML/CSS library:
 
 ## Testing
 
-At a minimumm, an accordion should meet the following criteria:
+At a minimum, an accordion should meet the following criteria:
 
 <List isPlain>
   <ListItem>

--- a/packages/v4/patternfly-docs/content/accessibility/alert-group/alert-group.md
+++ b/packages/v4/patternfly-docs/content/accessibility/alert-group/alert-group.md
@@ -21,7 +21,7 @@ For the HTML/CSS library:
 
 ## Testing
 
-At a minimumm, an alert group should meet the following criteria:
+At a minimum, an alert group should meet the following criteria:
 
 <List isPlain>
   <ListItem>

--- a/packages/v4/patternfly-docs/content/accessibility/alert/alert.md
+++ b/packages/v4/patternfly-docs/content/accessibility/alert/alert.md
@@ -13,7 +13,7 @@ To implement an accessible PatternFly **alert**:
 
 ## Testing
 
-At a minimumm, an alert should meet the following criteria:
+At a minimum, an alert should meet the following criteria:
 
 <List isPlain>
   <ListItem>

--- a/packages/v4/patternfly-docs/content/accessibility/avatar/avatar.md
+++ b/packages/v4/patternfly-docs/content/accessibility/avatar/avatar.md
@@ -5,14 +5,12 @@ section: components
 
 import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
-An **avatar** is a visual used to represent a user. It may contain an image or a placeholder graphic. Typical usage is to represent the current user in the masthead.
-
 ## Accessibility
 
 To implement an accessible PatternFly **avatar**:
 
 - Pass in `alt` as a React prop or HTML attribute to provide alternative text for the avatar image.
-- If you are using an SVG element for the avatar, [learn how to create accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/) and reference the different SVG patterns. Screen reader accessibility for SVGs varies based on the pattern being used.
+- If you are using an SVG element for the avatar, make sure the SVG is accessible (see [How to create accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/)) and reference the different SVG patterns. Screen reader accessibility for SVGs varies based on the pattern being used.
 - If you’re combining an avatar with another component, make sure to check accessibility guidelines for that component as well.
 
 ## Testing

--- a/packages/v4/patternfly-docs/content/accessibility/avatar/avatar.md
+++ b/packages/v4/patternfly-docs/content/accessibility/avatar/avatar.md
@@ -3,21 +3,54 @@ id: Avatar
 section: components
 ---
 
+import { Checkbox, List, ListItem } from '@patternfly/react-core';
+
 An **avatar** is a visual used to represent a user. It may contain an image or a placeholder graphic. Typical usage is to represent the current user in the masthead.
 
-**Keyboard users** shouldn’t be able to interact with the avatar on its own. Thus, the user should not be able to focus on the avatar using **Tab** to move forward and **Tab + Shift** to move backwards through interactive elements.
+## Accessibility
 
-**Screen reader users** should be able to navigate to the avatar and it should have alternative text, since it’s an image element. You can use the `alt` prop to provide alternative text.
+To implement an accessible PatternFly **avatar**:
 
-If you’re combining an avatar with another component, make sure to check accessibility guidelines for that component as well.
-
-
-## To make avatar accessible:
-- You may use the `alt` React prop to provide alternative text for the avatar image.
+- Use the `alt` React prop to provide alternative text for the avatar image.
 - If you are using an SVG element for the avatar, [learn how to create accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/) and reference the different SVG patterns. Screen reader accessibility for SVGs varies based on the pattern being used.
+- If you’re combining an avatar with another component, make sure to check accessibility guidelines for that component as well.
+
+## Testing
+
+At a minimum, tabs should meet the following criteria:
+
+<List isPlain>
+  <ListItem>
+    <Checkbox id="avatar-a11y-checkbox-4" label="Screen reader users can navigate to the avatar." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="avatar-a11y-checkbox-1" label="The avatar image has alternative text." description={<span>Use the <code class="ws-code">alt</code> prop to provide alternative text.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="avatar-a11y-checkbox-2" label="Any SVGs used are accessible." description={<span><a href="https://www.deque.com/blog/creating-accessible-svgs/">How to create accessible SVGs</a></span>}/>
+  </ListItem>
+  <ListItem>
+    <Checkbox id="avatar-a11y-checkbox-3" label={<span>Keyboard users should not be able to interact with the avatar on its own (via <kbd>Tab</kbd> and <kbd>Tab + Shift</kbd>).</span>} />
+  </ListItem>
+</List>
+
+## React customization
 
 The following props/attributes have been added for you or are customizable in PatternFly:
 
-| React prop | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
-| -- | -- | -- | -- |
-| `alt` | Avatar | .pf-c-avatar | Provides an accessible description of the avatar as it uses an image instead of text. |
+| Prop | Applied to | Which HTML element it appears on in markup | Reason  |
+| -- | -- | -- |
+| `alt` | `Avatar` |  Provides an accessible description of the avatar. |
+
+## HTML/CSS customization
+
+Various HTML attributes and PatternFly classes can be used for more fine-tuned control over accessibility.
+
+| Attribute or class | Applied to | Reason | 
+|---|---|---|
+| `alt` | `.pf-c-avatar` | The alt attribute describes the appearance and function of the avatar image. **Required** |
+
+## Further reading
+
+To read more about how to create accessible SVGs, refer to the following resource:
+- [Creating Accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/)

--- a/packages/v4/patternfly-docs/content/accessibility/avatar/avatar.md
+++ b/packages/v4/patternfly-docs/content/accessibility/avatar/avatar.md
@@ -11,20 +11,20 @@ An **avatar** is a visual used to represent a user. It may contain an image or a
 
 To implement an accessible PatternFly **avatar**:
 
-- Use the `alt` React prop to provide alternative text for the avatar image.
+- Pass in `alt` as a React prop or HTML attribute to provide alternative text for the avatar image.
 - If you are using an SVG element for the avatar, [learn how to create accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/) and reference the different SVG patterns. Screen reader accessibility for SVGs varies based on the pattern being used.
 - If you’re combining an avatar with another component, make sure to check accessibility guidelines for that component as well.
 
 ## Testing
 
-At a minimum, tabs should meet the following criteria:
+At a minimum, an avatar should meet the following criteria:
 
 <List isPlain>
   <ListItem>
-    <Checkbox id="avatar-a11y-checkbox-4" label="Screen reader users can navigate to the avatar." />
+    <Checkbox id="avatar-a11y-checkbox-4" label="Users can navigate to the avatar via the screen reader." />
   </ListItem>
   <ListItem>
-    <Checkbox id="avatar-a11y-checkbox-1" label="The avatar image has alternative text." description={<span>Use the <code class="ws-code">alt</code> prop to provide alternative text.</span>} />
+    <Checkbox id="avatar-a11y-checkbox-1" label="The avatar image has alternative text." />
   </ListItem>
   <ListItem>
     <Checkbox id="avatar-a11y-checkbox-2" label="Any SVGs used are accessible." description={<span><a href="https://www.deque.com/blog/creating-accessible-svgs/">How to create accessible SVGs</a></span>}/>
@@ -36,11 +36,11 @@ At a minimum, tabs should meet the following criteria:
 
 ## React customization
 
-The following props/attributes have been added for you or are customizable in PatternFly:
+Various React props have been provided for more fine-tuned control over accessibility.
 
-| Prop | Applied to | Which HTML element it appears on in markup | Reason  |
+| Prop | Applied to | Reason  |
 | -- | -- | -- |
-| `alt` | `Avatar` |  Provides an accessible description of the avatar. |
+| `alt` | `Avatar` |  Provides an accessible description of the avatar. **Required**|
 
 ## HTML/CSS customization
 
@@ -48,9 +48,4 @@ Various HTML attributes and PatternFly classes can be used for more fine-tuned c
 
 | Attribute or class | Applied to | Reason | 
 |---|---|---|
-| `alt` | `.pf-c-avatar` | The alt attribute describes the appearance and function of the avatar image. **Required** |
-
-## Further reading
-
-To read more about how to create accessible SVGs, refer to the following resource:
-- [Creating Accessible SVGs](https://www.deque.com/blog/creating-accessible-svgs/)
+| `alt` | `.pf-c-avatar` | Provides an accessible description of the avatar. **Required** |

--- a/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tabs/tabs.md
@@ -13,7 +13,7 @@ To implement accessible PatternFly **tabs**:
 
 ## Testing
 
-At a minimumm, tabs should meet the following criteria:
+At a minimum, tabs should meet the following criteria:
 
 <List isPlain>
   <ListItem>

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -53,7 +53,7 @@ For the HTML/CSS library:
 
 ## Testing
 
-At a minimumm, a tooltip should meet the following criteria:
+At a minimum, a tooltip should meet the following criteria:
 
 <List isPlain>
   <ListItem>


### PR DESCRIPTION
This reformats the avatar a11y documentation, and also fixes a typo that's gotten copied to a few sections.

Fixes #3242 