### PR TITLE
chore(docs): added new opendrawerrighticon to docs

### DIFF
--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@patternfly/documentation-framework": "^1.2.48",
     "@patternfly/quickstarts": "^2.2.4",
-    "@patternfly/react-docs": "5.102.34",
+    "@patternfly/react-docs": "5.102.59",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },

--- a/packages/v4/patternfly-docs/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/patternfly-docs/content/design-guidelines/styles/icons/icons.js
@@ -1092,6 +1092,13 @@ export const iconsData = [
   },
   {
     "Style": "pf-icon",
+    "Name": "pf-icon-open-drawer-right",
+    "React_name": "OpenDrawerRightIcon",
+    "Type": "Action",
+    "Contextual_usage": "Open or close a drawer",
+  },
+  {
+    "Style": "pf-icon",
     "Name": "pf-icon-optimize",
     "React_name": "OptimizeIcon",
     "Type": "Action",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,10 +2366,15 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.122.2.tgz#3e774d78996c7027b8c528edb2e90990676458a5"
   integrity sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw==
 
-"@patternfly/patternfly@4.217.1":
-  version "4.217.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.217.1.tgz#3583aa7216de9255b912fcc67a5af95ff8bd9cb3"
-  integrity sha512-uN7JgfQsyR16YHkuGRCTIcBcnyKIqKjGkB2SGk9x1XXH3yYGenL83kpAavX9Xtozqp17KppOlybJuzcKvZMrgw==
+"@patternfly/patternfly@4.219.0":
+  version "4.219.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.219.0.tgz#a61e0786de905fa750e99eee9ff417aa93bdd68d"
+  integrity sha512-V47JKwmEPfQEC2NZCWm5X1ojAUIsq4kMQEbox49AO6l9+mtCT/iZtBqZVwJwoDqEE825KeWTOAfTwAkBc7MYug==
+
+"@patternfly/patternfly@4.219.1":
+  version "4.219.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.219.1.tgz#379d40113218154c40efb8a8cf361e3fb79ef3b7"
+  integrity sha512-SdTWvCgR6L79diz4YaVvrepyjS0yZL2XyF7sBpcdoqcYbVuaBsF4a7kaNCv6gaggIErnqh9qxgZpDXMkQIYz2g==
 
 "@patternfly/quickstarts@^2.2.4":
   version "2.2.4"
@@ -2391,22 +2396,22 @@
     "@patternfly/react-styles" "^4.11.4"
     classnames "^2.2.5"
 
-"@patternfly/react-catalog-view-extension@^4.92.27":
-  version "4.92.27"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.92.27.tgz#17c0d8222249bccb850f7e15234ae073f245d284"
-  integrity sha512-tDNYsioPl3NE07Y0GlDQLeUQHIGKND+me3QdNDmGKlSIGnU7nZlTZ9HxMaSMrKigFPGfY+vbHRRh2S02EEjlTQ==
+"@patternfly/react-catalog-view-extension@^4.92.51":
+  version "4.92.53"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.92.53.tgz#88351746f568e2de93f38b5c894463c99c5da23d"
+  integrity sha512-pujTRB4gYuHde2NtW6hKHqK38SWMS2NahI9YOFQkbDe0pbUdEhD0eRYmDAkMb8S6p8chhwEEjzwmmPfKWH/2cA==
   dependencies:
-    "@patternfly/patternfly" "4.217.1"
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-styles" "^4.91.6"
+    "@patternfly/patternfly" "4.219.1"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-styles" "^4.91.9"
 
-"@patternfly/react-charts@^6.94.7":
-  version "6.94.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.94.7.tgz#1c1ee94fd5256218867b4db0d000ed534e0c3e6e"
-  integrity sha512-ZiZMBGxAiTkYTf6p1Jv3GSgv6bxFbn0WtcYuerfB3gOeRi5JUDysciJai6MT/TFuLQmf3bNy3CJ0/b/x/rER2w==
+"@patternfly/react-charts@^6.94.9":
+  version "6.94.10"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.94.10.tgz#6d66038137188d8b13fed749c84478eff4d5d8c9"
+  integrity sha512-LP/w9bkEpkdkb/DKeeLHWAIvEMnqwEoBueLqumN4ibW8RadkNa0IwdEqXhsInB2KUDB8pKQjbNcA0ceHPnGL7Q==
   dependencies:
-    "@patternfly/react-styles" "^4.91.6"
-    "@patternfly/react-tokens" "^4.93.6"
+    "@patternfly/react-styles" "^4.91.9"
+    "@patternfly/react-tokens" "^4.93.9"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "^2.0.0"
@@ -2427,14 +2432,14 @@
     victory-voronoi-container "^36.6.7"
     victory-zoom-container "^36.6.7"
 
-"@patternfly/react-code-editor@^4.82.27":
-  version "4.82.27"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-4.82.27.tgz#7603a6e2b355662e818c373a161cd1e1c16606bd"
-  integrity sha512-jy7NmbkXeaph1eo2KYPqO3h1NPPOMCbv8e0+i+IW4MdcXOFHy9XINCi6ozvbnL6fgDy5Lk/x0rJSbcEu5mgGLA==
+"@patternfly/react-code-editor@^4.82.51":
+  version "4.82.53"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-4.82.53.tgz#26866b3143b3d4744ef5af13d4fdad9da39f943d"
+  integrity sha512-4xpo3oC4xxLgWC+U+KC9xfuCI+XpUA11XXp/HTG96G2UaREQsNiD4GrpvI7F4Pf8s0vqVCzh9XOSJVwQuJsFIQ==
   dependencies:
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
     react-dropzone "9.0.0"
     tslib "^2.0.0"
 
@@ -2451,66 +2456,66 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^4.250.2":
-  version "4.250.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.250.2.tgz#2b11cc4ea5cfdc8b782a82d73f104b85642f6017"
-  integrity sha512-D5e6ymu9jckAWEEZT6Tq5fVbvFhN5G+h5b5Ueh2lPMrbeK/WjmvR1fXKWb3fkwC5lHFY452xJOOl5gBUCNY9bQ==
+"@patternfly/react-core@^4.257.1", "@patternfly/react-core@^4.258.1":
+  version "4.258.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.258.1.tgz#5c2989230c7b4ed70ddb8fd7812181de206dcc9f"
+  integrity sha512-hbgSo9viyNDLJo3sPh1Phx3Fynp9WwC/dwXguB+3hawvLR4Maz/hfBG+ixgjVGs6WWePNdavseI7QPSxZN6oEg==
   dependencies:
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
-    "@patternfly/react-tokens" "^4.93.6"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
+    "@patternfly/react-tokens" "^4.93.9"
     focus-trap "6.9.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-docs@5.102.34":
-  version "5.102.34"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-5.102.34.tgz#a1a82473e77c8c318578c469cf83c17d7ee28686"
-  integrity sha512-Il97Y+aFTSlRHQ9Fvn/iZ1eyr2rHsmIJsXYGiT+n0f/d43WprG7b7tvnmkkijngk3cfkOpJCsrHj9VV99RhgcA==
+"@patternfly/react-docs@5.102.59":
+  version "5.102.59"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-5.102.59.tgz#3f7d391edd05e3757da3533ff6181d17d3683709"
+  integrity sha512-X+Uk7Ek0a9qMiGnH3Bumwwr6lm/+64LswIhWa79WB3dXtYfFGV1dfpZMc7i9OawdvzUqrNIJ4T8VLEnVQnVDfw==
   dependencies:
-    "@patternfly/patternfly" "4.217.1"
-    "@patternfly/react-catalog-view-extension" "^4.92.27"
-    "@patternfly/react-charts" "^6.94.7"
-    "@patternfly/react-code-editor" "^4.82.27"
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-inline-edit-extension" "^4.86.28"
-    "@patternfly/react-log-viewer" "^4.87.22"
-    "@patternfly/react-styles" "^4.91.6"
-    "@patternfly/react-table" "^4.111.5"
-    "@patternfly/react-tokens" "^4.93.6"
-    "@patternfly/react-topology" "^4.88.27"
-    "@patternfly/react-virtualized-extension" "^4.88.27"
+    "@patternfly/patternfly" "4.219.0"
+    "@patternfly/react-catalog-view-extension" "^4.92.51"
+    "@patternfly/react-charts" "^6.94.9"
+    "@patternfly/react-code-editor" "^4.82.51"
+    "@patternfly/react-core" "^4.257.1"
+    "@patternfly/react-icons" "^4.92.8"
+    "@patternfly/react-inline-edit-extension" "^4.86.52"
+    "@patternfly/react-log-viewer" "^4.87.46"
+    "@patternfly/react-styles" "^4.91.8"
+    "@patternfly/react-table" "^4.111.29"
+    "@patternfly/react-tokens" "^4.93.8"
+    "@patternfly/react-topology" "^4.90.6"
+    "@patternfly/react-virtualized-extension" "^4.88.51"
 
 "@patternfly/react-icons@^4.75.1":
   version "4.82.8"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.82.8.tgz#59ab1a139d3fc586fd384a58816e4608a060ee32"
   integrity sha512-cKixprTiMLZRe/+kmdZ5suvYb9ly9p1f/HjlcNiWBfsiA8ZDEPmxJnVdend/YsafelC8YC9QGcQf97ay5PNhcw==
 
-"@patternfly/react-icons@^4.92.6":
-  version "4.92.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.92.6.tgz#a1f2190edb49ab146c30ed07f8447af5d9401f13"
-  integrity sha512-UdMSDqJ7fCxi/E6vlsFHuDZ3L0+kqBZ4ujRi4mjokrsvzOR4WFdaMhC+7iRy4aPNjT0DpHVjVUUUoWwKID9VqA==
+"@patternfly/react-icons@^4.92.8", "@patternfly/react-icons@^4.92.9":
+  version "4.92.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.92.9.tgz#9ed1ef386e21a5cf655a6d1ee80547ad2bc07e49"
+  integrity sha512-q9EBYoggSXH0kNbkv2z9lGX80E4Bg4mHSlNwdQkESnwGPcD4+k9+60etFJHYq88MCKq/WXXk63F7O7WiUNW8kw==
 
-"@patternfly/react-inline-edit-extension@^4.86.28":
-  version "4.86.28"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-inline-edit-extension/-/react-inline-edit-extension-4.86.28.tgz#abd57171512f3c8d7359d70ddde3e2c64f979d3f"
-  integrity sha512-oCjnTx2hGlTkaXwYNpJ4TYb9gplDF2f7VzU+TtONa113eaqHlyePIw0qbAemoFnPYGWt4snqUl3JzHQE3rfOCw==
+"@patternfly/react-inline-edit-extension@^4.86.52":
+  version "4.86.54"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-inline-edit-extension/-/react-inline-edit-extension-4.86.54.tgz#e659be8fd4f94ace15426bfeeb52a9ad71ec4b80"
+  integrity sha512-/53LycRN2ltOFeghsu/TBdo7ujkFyNxNTCE/z4fK3jwBlkip0Zf/YevSRAkob2GB/TvS3f1BbH0MSq/bXNfpRw==
   dependencies:
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
-    "@patternfly/react-table" "^4.111.5"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
+    "@patternfly/react-table" "^4.111.31"
 
-"@patternfly/react-log-viewer@^4.87.22":
-  version "4.87.22"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-4.87.22.tgz#afcfd0fc11f5998268a9d8f4330c5dd3bbdbe476"
-  integrity sha512-iSEirouYqU0gSGwdJeALZAuDaLezL3THYremxSJchubTcApPPmEYQyA4poD3vu0T8116Ji5eGCl+tF/B0CyrKw==
+"@patternfly/react-log-viewer@^4.87.46":
+  version "4.87.48"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-4.87.48.tgz#3a222f86775034797b3be730b6972bf396b50298"
+  integrity sha512-P5K7/0EOkAhQNaB4YBbh4+Tpg+X1JW4uP63Fxiqgvsf8JC7zklhKUA9vOcewSjr/fbtAfcI1jOugH9Wv4lp8Iw==
   dependencies:
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
     memoize-one "^5.1.0"
     resize-observer-polyfill "^1.5.1"
 
@@ -2524,20 +2529,20 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.81.8.tgz#8d2f103e03a7edd997218600a54bd2cd452d3348"
   integrity sha512-Q5FiureSSCMIuz+KLMcEm1317TzbXcwmg2q5iNDRKyf/K+5CT6tJp0Wbtk3FlfRvzli4u/7YfXipahia5TL+tA==
 
-"@patternfly/react-styles@^4.91.6":
-  version "4.91.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.91.6.tgz#2cd4f0d5dca7774fe6a64505b8a3e7bd2abd66c6"
-  integrity sha512-3wCYkvGRgbx6u5JrCaUNcpDvyTOrgvXU/Mh2hs8s/njBUDpyuyRb+gkFoE3l3Ro3Lk0DnRLYpIjCSjl38Bd0iA==
+"@patternfly/react-styles@^4.91.8", "@patternfly/react-styles@^4.91.9":
+  version "4.91.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.91.9.tgz#8b5ced5bd39ac91a552c8ea524a8980909635dae"
+  integrity sha512-ZoFl+/NBUWJ0ED+IyPHZ1T8l9VuPH1N8XAeBzlTRZK8pD2dM6QAJCUrB3jzMGn635TDU+a+rIK0ry7nZb+Eytg==
 
-"@patternfly/react-table@^4.111.5":
-  version "4.111.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.111.5.tgz#5c76ad5aa382135de766c30623da0af7d57f575e"
-  integrity sha512-3xFT14s3oHwIOFQOnXymyY0rYQSQ25jQVM+lf2334X9JB073yMmbWxynyjj7Ujbyejn+0+AwVyS0UPibnlA0Hw==
+"@patternfly/react-table@^4.111.29", "@patternfly/react-table@^4.111.31":
+  version "4.111.31"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.111.31.tgz#e705d204dac15e66f96a2c140ee023465775cdb2"
+  integrity sha512-hQF/Ip+V9mb5PQ0GaeW0vOfdHej4bmKzmGwz4R/wMGYytAQ5AI8+wTT0FrfHtg/z0VSyBtd2RpF4w+8hBJlXEA==
   dependencies:
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
-    "@patternfly/react-tokens" "^4.93.6"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
+    "@patternfly/react-tokens" "^4.93.9"
     lodash "^4.17.19"
     tslib "^2.0.0"
 
@@ -2546,19 +2551,19 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.83.8.tgz#3055ea6f4c195d59840d1ce0ceaa59da76104f9a"
   integrity sha512-Z/MHXNY8PQOuBFGUar2yzPVbz3BNJuhB+Dnk5RJcc/iIn3S+VlSru7g6v5jqoV/+a5wLqZtLGEBp8uhCZ7Xkig==
 
-"@patternfly/react-tokens@^4.93.6":
-  version "4.93.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz#b09e8935783dab86f10decd05e357570b2a70aec"
-  integrity sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw==
+"@patternfly/react-tokens@^4.93.8", "@patternfly/react-tokens@^4.93.9":
+  version "4.93.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.93.9.tgz#b94f38c070136a93bafc98802bc7b2f80b106d55"
+  integrity sha512-6Q1SxVlAzhkj7E0JICoZnaZAqcgh+1/Huy4br5pj2TMGYxbi+ZEa3ad/IEIttkC18281AxoR5y1f5gpQH+RPVw==
 
-"@patternfly/react-topology@^4.88.27":
-  version "4.88.27"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.88.27.tgz#79389823bd2c0321b13f1db930484e861091df0c"
-  integrity sha512-X6SXkJoOpqC+4IY79/QAv5NhbFQltQiDgTqCrs+TdSiBlnZ7l48pYoFMKOBZRR/ZxDpC6a856/61vabbvojfhg==
+"@patternfly/react-topology@^4.90.6":
+  version "4.90.8"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-4.90.8.tgz#7e85629483a0711064b7bb401695d34886e84823"
+  integrity sha512-N9tplzagHr/tKpT5B5tEMc6XNskzsyH6ropTxIdcAYYDY6yeDW8tsi77HDLP5kDOAkQ+zC9SzmcKxMgmjTPc9g==
   dependencies:
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
     "@types/d3" "^5.7.2"
     "@types/d3-force" "^1.2.1"
     "@types/dagre" "0.7.42"
@@ -2575,14 +2580,14 @@
     tslib "^2.0.0"
     webcola "3.4.0"
 
-"@patternfly/react-virtualized-extension@^4.88.27":
-  version "4.88.27"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-virtualized-extension/-/react-virtualized-extension-4.88.27.tgz#5b0902cdad16458efa2650b2c08671fd863084d1"
-  integrity sha512-+MUC5GzEYi+xxv+IT2B4gEuq3efhVidOPddxy6CxGUk5l97O3128UQ9eQaZaqyTyuu8Yot/7YaW6LAMYtFJfTg==
+"@patternfly/react-virtualized-extension@^4.88.51":
+  version "4.88.53"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-virtualized-extension/-/react-virtualized-extension-4.88.53.tgz#d35cfefc5c189a6ef063fa25599b086b5845beee"
+  integrity sha512-vsJ1E7bXkhs14hP61qeWe/kofTirqSUJFv7CzHtil4T9PznGLu7CqSsn5pVhCHlmQOC482ab+t10IAAUCsyZcA==
   dependencies:
-    "@patternfly/react-core" "^4.250.2"
-    "@patternfly/react-icons" "^4.92.6"
-    "@patternfly/react-styles" "^4.91.6"
+    "@patternfly/react-core" "^4.258.1"
+    "@patternfly/react-icons" "^4.92.9"
+    "@patternfly/react-styles" "^4.91.9"
     linear-layout-vector "0.0.1"
     react-virtualized "^9.21.1"
     tslib "^2.0.0"


### PR DESCRIPTION
Closes #3223 

This PR adds the new `pf-icon-open-drawer-right` icon to the website, which includes pulling in a newer `react-docs` version in order to get the new icon.