### PR TITLE
chore(Badge): update a11y docs

### DIFF
--- a/packages/v4/patternfly-docs/content/accessibility/badge/badge.md
+++ b/packages/v4/patternfly-docs/content/accessibility/badge/badge.md
@@ -9,8 +9,8 @@ import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
 To implement an accessible PatternFly **badge**:
 
-- Ensure the badge itself is not interactive in anyway. 
-- Ensure that the surrounding context can convey to users via screen reader or similar assistive technologies the purpose of the badge.
+- Ensure the badge itself is not interactive in any way. 
+- Ensure that the surrounding context can convey the purpose of the badge to users via screen reader or similar assistive technologies.
 - Ensure badge information is not conveyed by only color, such as a read or unread badge.
 
 ## Testing
@@ -39,7 +39,7 @@ A badge does not have any further HTML/CSS attributes or classes for accessibili
 
 ## Additional considerations
 
-Consumers must ensure they take any additional considerations when customizing a badge, using it in a way not described or recommended by PatternFly, or in various other specific use-cases not outlined elsewhere on this page.
+Consumers must ensure they take any additional considerations when customizing a badge, using it in a way not described or recommended by PatternFly, or in various other specific use cases not outlined elsewhere on this page.
 
 ### Color
 
@@ -47,12 +47,12 @@ Generally you should avoid using only color to convey information about a badge.
 
 If a badge will always be rendered whether it's unread or read, or different badges will convey different types of information, it may be difficult for users to perceive or understand the difference between the two badges.
 
-There are two ways in which to supplement color in order to more accessibly convey badge information:
+You should do the following to supplement color to convey badge information:
 
-- Adding an icon to visually convey information
-- Adding a visually-hidden element via the `pf-screen-reader` class to convey information to users of screen readers and similar assistive technologies
+- Add an icon to visually convey information
+- Add a visually-hidden element via the `pf-screen-reader` class to convey information to users of screen readers and similar assistive technologies
 
-Note how difficult it is to determine that there are unread or actionable items associated with either of the badges in Figure 1 with its lack of visual cues. Compare Figure 1 to Figure 2 where there is an icon used to indicate that the second badge is associated with actionable or unread content.
+In Figure 1, note that the lack of visual cues make it difficult to differentiate unread or actionable items associated with the badges. Compare this to Figure 2, where an icon indicates that the second badge is associated with actionable or unread content.
 
 Figure 1.
 

--- a/packages/v4/patternfly-docs/content/accessibility/badge/badge.md
+++ b/packages/v4/patternfly-docs/content/accessibility/badge/badge.md
@@ -10,8 +10,15 @@ import { Checkbox, List, ListItem } from '@patternfly/react-core';
 To implement an accessible PatternFly **badge**:
 
 - Ensure the badge itself is not interactive in any way. 
-- Ensure that the surrounding context can convey the purpose of the badge to users via screen reader or similar assistive technologies.
 - Ensure badge information is not conveyed by only color, such as a read or unread badge.
+- Ensure that the surrounding context can convey the purpose of the badge to users via screen reader or similar assistive technologies.
+  - A heading or other text element prefacing the badge or visually hidden text content accessible only to assistive technologies are some examples of a surrounding context.
+
+  ```
+  <h2>Notificaitons <Badge>5</Badge></h2>
+
+  <Badge>5 <span class="pf-screen-reader">unread notifications</span></Badge>
+  ```
 
 ## Testing
 
@@ -22,10 +29,10 @@ To implement an accessible PatternFly **badge**:
     <Checkbox id="badge-a11y-checkbox-1" label="Users should not be able to interact with or navigate to the badge with the keyboard, as it is not an interactive element." />
   </ListItem>
   <ListItem>
-    <Checkbox id="badge-a11y-checkbox-2" label="Users navigating via screen reader or similar assistive technology should understand the purpose of the badge by its surrounding context." />
+    <Checkbox id="badge-a11y-checkbox-2" label="Information about a badge is not conveyed by only color."/>
   </ListItem>
   <ListItem>
-    <Checkbox id="badge-a11y-checkbox-3" label="Information about a badge is not conveyed by only color."/>
+    <Checkbox id="badge-a11y-checkbox-3" label="Users navigating via screen reader or similar assistive technology should understand the purpose of the badge by its surrounding context." />
   </ListItem>
 </List>
 
@@ -43,7 +50,7 @@ Consumers must ensure they take any additional considerations when customizing a
 
 ### Color
 
-Generally you should avoid using only color to convey information about a badge. One possible exception to this rule may be if a badge is only ever rendered in a specific scenario, such as only when there are unread notifications, and will otherwise not be rendered for any other purpose. Caution should still be used when using color in this way, though.
+Generally you should avoid using only color to convey information about different types of badges, such as between read and unread notifications.
 
 If a badge will always be rendered whether it's unread or read, or different badges will convey different types of information, it may be difficult for users to perceive or understand the difference between the two badges.
 

--- a/packages/v4/patternfly-docs/content/accessibility/badge/badge.md
+++ b/packages/v4/patternfly-docs/content/accessibility/badge/badge.md
@@ -3,25 +3,56 @@ id: Badge
 section: components
 ---
 
-A **badge** is used to annotate other information like a label or an object name. Badges are typically used to reflect counts, like number of unread notifications. Badges are not interactive.
+import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
-**Keyboard users** should not be able to focus on a badge.
+## Accessibility
 
-**Screen reader users** should be able to have a screen reader describe the contents of and purpose of a badge when it pops up, but not focus on it otherwise.
+To implement an accessible PatternFly **badge**:
 
-No props need to be added or modified for badge accessibility.
+- Ensure the badge itself is not interactive in anyway. 
+- Ensure that the surrounding context can convey to users via screen reader or similar assistive technologies the purpose of the badge.
+- Ensure badge information is not conveyed by only color, such as a read or unread badge.
 
-**As a caution**, badges can be styled using a variety of colors. Do not rely on color alone to communicate information 
-because it causes barriers to access for many readers. For example, colorblind and low vision users may not be able 
-to perceive the color differences, and screen readers do not announce colors to non-sighted readers.
+## Testing
 
-Since the badge doesn't get an accessible name and isn't focusable, each badge must have adequate contextual information 
-provided in the surrounding UI to convey the same information the color alone is conveying. A developer could consider
-using a label with an icon in it to supplement the color.
+ At a minimum, a badge should meet the following criteria:
 
-Note how difficult it is to determine that there are unread or actionable items associated with either of the badges
-in Figure 1 with its lack of visual cues. Compare Figure 1 to Figure 2 where there is an icon
-used to indicate that the second badge is associated with actionable or unread content.
+<List isPlain>
+  <ListItem>
+    <Checkbox id="badge-a11y-checkbox-1" label="Users should not be able to interact with or navigate to the badge with the keyboard, as it is not an interactive element." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="badge-a11y-checkbox-2" label="Users navigating via screen reader or similar assistive technology should understand the purpose of the badge by its surrounding context." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="badge-a11y-checkbox-3" label="Information about a badge is not conveyed by only color."/>
+  </ListItem>
+</List>
+
+## React customization
+
+A badge does not have any further React props for accessibility.
+
+## HTML/CSS customization
+
+A badge does not have any further HTML/CSS attributes or classes for accessibility.
+
+## Additional considerations
+
+Consumers must ensure they take any additional considerations when customizing a badge, using it in a way not described or recommended by PatternFly, or in various other specific use-cases not outlined elsewhere on this page.
+
+### Color
+
+Generally you should avoid using only color to convey information about a badge. One possible exception to this rule may be if a badge is only ever rendered in a specific scenario, such as only when there are unread notifications, and will otherwise not be rendered for any other purpose. Caution should still be used when using color in this way, though.
+
+If a badge will always be rendered whether it's unread or read, or different badges will convey different types of information, it may be difficult for users to perceive or understand the difference between the two badges.
+
+There are two ways in which to supplement color in order to more accessibly convey badge information:
+
+- Adding an icon to visually convey information
+- Adding a visually-hidden element via the `pf-screen-reader` class to convey information to users of screen readers and similar assistive technologies
+
+Note how difficult it is to determine that there are unread or actionable items associated with either of the badges in Figure 1 with its lack of visual cues. Compare Figure 1 to Figure 2 where there is an icon used to indicate that the second badge is associated with actionable or unread content.
 
 Figure 1.
 
@@ -29,4 +60,4 @@ Figure 1.
 
 Figure 2.
 
-![badges with no color with icons](./badge-no-color-with-icons.png)
+![badges with no color and with icons](./badge-no-color-with-icons.png)

--- a/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
+++ b/packages/v4/patternfly-docs/content/accessibility/tooltip/tooltip.md
@@ -63,7 +63,7 @@ At a minimum, a tooltip should meet the following criteria:
     <Checkbox id="tooltip-a11y-checkbox-2" label={<span>The tooltip component has the <code className="ws-code">role="tooltip"</code> attribute.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="tooltip-a11y-checkbox-3" label={<span>If the tooltip is meant to act as a primary label, the trigger has the <code className="ws-code">aria-labelledby</code> attribute linked to the tooltip contents.</span>} description="One use-case for this is when a button contains only an icon and no visible text label." />
+    <Checkbox id="tooltip-a11y-checkbox-3" label={<span>If the tooltip is meant to act as a primary label, the trigger has the <code className="ws-code">aria-labelledby</code> attribute linked to the tooltip contents.</span>} description="One use case for this is when a button contains only an icon and no visible text label." />
   </ListItem>
   <ListItem>
     <Checkbox id="tooltip-a11y-checkbox-4" label={<span>If the tooltip is meant to act as supplementary information, the trigger has the <code className="ws-code">aria-describedby</code> attribute linked to the tooltip contents.</span>} />

--- a/packages/v4/patternfly-docs/content/design-guidelines/components/tree-view/tree-view.md
+++ b/packages/v4/patternfly-docs/content/design-guidelines/components/tree-view/tree-view.md
@@ -26,7 +26,7 @@ A tree view can be used for:
 <img src="./img/treeview-usage.png" alt="Default tree view usage"  width="1004" />
 
 ### When to use
-* Selecting is the main use-case. 
+* Selecting is the main use case. 
 * You apply filters that need to be structured in a clear hierarchy. 
 * The data is structured into levels.
 * You need to display hierarchies that have more than 2 levels.


### PR DESCRIPTION
Closes #3276

The a11y docs already had some verbiage about not using only color which I mostly kept in tact, but I also added some verbiage about adding a `pf-screen-reader` class to add additional context for users navigating via AT. Depending on whether we'd want to keep that, it might be worth either updating the Badge examples and/or maybe adding a prop in React for adding in `screenReaderText`.