### PR TITLE
chore(Button): updated a11y docs

### DIFF
--- a/packages/v4/patternfly-docs/content/accessibility/button/button.md
+++ b/packages/v4/patternfly-docs/content/accessibility/button/button.md
@@ -37,7 +37,7 @@ At a minimum, a button should meet the following criteria:
     <Checkbox id="button-a11y-checkbox-3" label="Users are able to tell whether a button as a link will open in a new tab or window." description={<span>This can be best achieved by rendering an icon for visual context, and passing in visually-hidden text via the <code className="ws-code">pf-screen-reader</code> class.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="button-a11y-checkbox-3" label={<span>If a button should be disabled, but remain focusable, it has the <code className="ws-code">aria-disabled="true"</code> attribute instead of the standard <code className="ws-code">disabled</code> attribute.</span>} description="One example for when you should do this is if the button has a tooltip that should be triggered when the button receives focus." />
+    <Checkbox id="button-a11y-checkbox-4" label={<span>If a button should be disabled, but remain focusable, it has the <code className="ws-code">aria-disabled="true"</code> attribute instead of the standard <code className="ws-code">disabled</code> attribute.</span>} description="One example for when you should do this is if the button has a tooltip that should be triggered when the button receives focus." />
   </ListItem>
 </List>
 

--- a/packages/v4/patternfly-docs/content/accessibility/button/button.md
+++ b/packages/v4/patternfly-docs/content/accessibility/button/button.md
@@ -31,13 +31,16 @@ At a minimum, a button should meet the following criteria:
     <Checkbox id="button-a11y-checkbox-1" label="Standard keyboard navigation can be used to navigate between buttons or other focusable elements." description={<span><kbd>Tab</kbd> navigates to the next button or focusable element, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous button or focusable element.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="button-a11y-checkbox-2" label={<span>Each button on a page includes unique and descriptive text, or an <code className="ws-code">aria-label</code> if the button contains no visible text.</span>} description="This ensures that users can more quickly scan through and differentiate buttons on a page, such as when using VoiceOver's rotor menu." />
+    <Checkbox id="button-a11y-checkbox-2" label="Standard keyboard interaction can be used to interact with the button." description={<span><kbd>Enter</kbd> and <kbd>Space</kbd> should be able to activate the button. This can usually be achieved by using "click" events.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="button-a11y-checkbox-3" label="Users are able to tell whether a button as a link will open in a new tab or window." description={<span>This can be best achieved by rendering an icon for visual context, and passing in visually-hidden text via the <code className="ws-code">pf-screen-reader</code> class.</span>} />
+    <Checkbox id="button-a11y-checkbox-3" label={<span>Each button on a page includes unique and descriptive text, or an <code className="ws-code">aria-label</code> if the button contains no visible text.</span>} description="This ensures that users can more quickly scan through and differentiate buttons on a page, such as when using VoiceOver's rotor menu." />
   </ListItem>
   <ListItem>
-    <Checkbox id="button-a11y-checkbox-4" label={<span>If a button should be disabled, but remain focusable, it has the <code className="ws-code">aria-disabled="true"</code> attribute instead of the standard <code className="ws-code">disabled</code> attribute.</span>} description="One example for when you should do this is if the button has a tooltip that should be triggered when the button receives focus." />
+    <Checkbox id="button-a11y-checkbox-4" label="Users are able to tell whether a button as a link will open in a new tab or window." description={<span>This can be best achieved by rendering an icon for visual context, and passing in visually-hidden text via the <code className="ws-code">pf-screen-reader</code> class.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="button-a11y-checkbox-5" label={<span>If a button should be disabled, but remain focusable, it has the <code className="ws-code">aria-disabled="true"</code> attribute instead of the standard <code className="ws-code">disabled</code> attribute.</span>} description="One example for when you should do this is if the button has a tooltip that should be triggered when the button receives focus." />
   </ListItem>
 </List>
 

--- a/packages/v4/patternfly-docs/content/accessibility/button/button.md
+++ b/packages/v4/patternfly-docs/content/accessibility/button/button.md
@@ -3,22 +3,66 @@ id: Button
 section: components
 ---
 
-A **button** is a box area or text that communicates and triggers user actions when clicked or selected. Buttons are interactive elements.
+import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
-**Keyboard users** should be able to focus on the button using **Tab** to move forward and **Tab + Shift** to move backwards through interactive elements. They should be able to select a focused button using **Space** or **Enter**.
+## Accessibility
 
-**Screen reader users** should be able to navigate to the button and it should have text that can be read by a screen reader, or alternative text if it only contains an icon. For alternative text, `aria-label` is the most common choice.
+To implement an accessible PatternFly **button** component:
+
+- Ensure the button can be navigated to and interacted with via keyboard and other assistive technologies such as a screen reader
+- Provide unique, descriptive text content to the button, or an `aria-label` if the button does not contain any visible text
+- Provide context that a link will open in a new tab/window when using a button as a link
+
+For the PatternFly React library:
+
+- Include the `isAriaDisabled` prop if the button is disabled, but should still be focusable
+
+For the HTML/CSS library:
+
+- Include the `aria-disabled="true"` attribute if the button is disabled, but should still be focusable
 
 
-## Accessibility application:
+## Testing
 
-- A button containing only an icon without supporting text should be labeled with the `aria-label` prop.
-- A regular disabled button is not focusable, but an aria-disabled button is. `isAriaDisabled` should be used when a disabled button provides interactive elements (like a tooltip).
-- Screen readers may read buttons to users out of context. For example, screen reader users can navigate a page specifically by form controls. So button text should be unique and easily understood on its own. Refer to PatternFly's accessibility guide for more information.
+At a minimum, a button should meet the following criteria:
 
-The following props can be added or are customizable in PatternFly:
+<List isPlain>
+  <ListItem>
+    <Checkbox id="button-a11y-checkbox-1" label="Standard keyboard navigation can be used to navigate between buttons or other focusable elements." description={<span><kbd>Tab</kbd> navigates to the next button or focusable element, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous button or focusable element.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="button-a11y-checkbox-2" label={<span>Each button on a page includes unique and descriptive text, or an <code className="ws-code">aria-label</code> if the button contains no visible text.</span>} description="This ensures that users can more quickly scan through and differentiate buttons on a page, such as when using VoiceOver's rotor menu." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="button-a11y-checkbox-3" label="Users are able to tell whether a button as a link will open in a new tab or window." description={<span>This can be best achieved by rendering an icon for visual context, and passing in visually-hidden text via the <code className="ws-code">pf-screen-reader</code> class.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="button-a11y-checkbox-3" label={<span>If a button should be disabled, but remain focusable, it has the <code className="ws-code">aria-disabled="true"</code> attribute instead of the standard <code className="ws-code">disabled</code> attribute.</span>} description="One example for when you should do this is if the button has a tooltip that should be triggered when the button receives focus." />
+  </ListItem>
+</List>
 
-| React prop | React component that it should be applied to | Which HTML element it appears on in markup | Reason used |
-| -- | -- | -- | -- |
-| `aria-label` | Button | .pf-c-button.pf-m-plain | Adds accessible text to the button if the button doesn’t contain descriptive text on its own. |
-| `isAriaDisabled` | Button | button.pf-c-button | Adds disabled styling and communicates that the button is disabled using the aria-disabled html attribute |
+## React customization
+
+The following React props have been provided for more fine-tuned control over accessibility.
+
+| Prop | Applied to | Reason | 
+|---|---|---|
+| `aria-label="[text describing the button]` | `Button` | Adds an accessible name to the button. **Required** if the button does not contain visible text, such as the `plain` button variant. |
+| `isAriaDisabled` | `Button` | Disables the button, but keeps it perceivable to users. Use this prop instead of `isDisabled` when you want users to still be aware of the button and that it is disabled, or when you expect or intend for the button to receive focus despite being disabled. For example, if the disabled button has a tooltip, you should pass this prop in to disable it. |
+
+## HTML/CSS customization
+
+The following HTML attributes and PatternFly classes can be used for more fine-tuned control over accessibility.
+
+| Attribute or class | Applied to | Reason | 
+|---|---|---|
+| `aria-label="[text describing the button]"` | `.pf-c-button` | Adds an accessible name to the button. **Required** if the button does not contain visible text, such as the `plain` button variant. |
+| `aria-disabled="true"` | `.pf-c-button` | Disables the button, but keeps it perceivable to users. Use this prop instead of `isDisabled` when you want users to still be aware of the button and that it is disabled, or when you expect or intend for the button to receive focus despite being disabled. For example, if the disabled button has a tooltip, you should pass this prop in to disable it. |
+| `tabindex="-1"` | `a.pf-c-button.pf-m-disabled`, `span.pf-c-button.pf-m-link.pf-m-inline.pf-m-disabled` | When a non-button element is used, prevents it from being focusable via keyboard. **Required** when the element is disabled. |
+| `tabindex="0"` | `span.pf-c-button.pf-m-link.pf-m-inline` | Inserts the `span` into the tab order so that is is focusable via keyboard. **Required** when the element is a `span`. |
+
+## Further reading
+
+To read more about accessibility with a button, refer to the following resources:
+
+- [ARIA Authoring Practices Guide - Button](https://www.w3.org/WAI/ARIA/apg/patterns/button/)


### PR DESCRIPTION
Closes #3286 

The HTML a11y section mentions `aria-pressed`. Would it be worth keeping this verbiage and adding a prop to React? Currently the attribute isn't used anywhere for the component, but React does have examples of native button elements being used with `aria-pressed` passed in, so if we ever plan to update those examples to use our component instead it'd make sense.