### PR TITLE
chore(docs): added data sink/source icons

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -83,7 +83,7 @@ const HeaderTools = ({
         )}
         <ToolbarGroup
           alignment={{ default: 'alignRight' }}
-          spacerItems={{ default: 'spacerNone', md: 'spacerMd' }}
+          spaceItems={{ default: 'spacerNone', md: 'spacerMd' }}
         >
           {hasDarkThemeSwitcher && (
             <ToolbarItem>

--- a/packages/v4/patternfly-docs/content/design-guidelines/styles/icons/icons.js
+++ b/packages/v4/patternfly-docs/content/design-guidelines/styles/icons/icons.js
@@ -958,6 +958,20 @@ export const iconsData = [
   },
   {
     "Style": "pf-icon",
+    "Name": "pf-icon-data-sink",
+    "React_name": "DataSinkIcon",
+    "Type": "Status",
+    "Contextual_usage": "Represents a data sink",
+  },
+  {
+    "Style": "pf-icon",
+    "Name": "pf-icon-data-source",
+    "React_name": "DataSourceIcon",
+    "Type": "Status",
+    "Contextual_usage": "Represents a data source",
+  },
+  {
+    "Style": "pf-icon",
     "Name": "pf-icon-degraded",
     "React_name": "DegradedIcon",
     "Type": "Status",


### PR DESCRIPTION
Closes #3305 

This PR adds the `data-sink` and `data-source` icons to the website icons page.