### PR TITLE
fix(lodash): add lodash.constant to global._

### DIFF
--- a/packages/documentation-framework/app.js
+++ b/packages/documentation-framework/app.js
@@ -17,7 +17,7 @@ import './components/sideNav/sideNav.css';
 import './components/topNav/topNav.css';
 import './layouts/sideNavLayout/sideNavLayout.css';
 
-global._ = { ...global?._, constant }
+global._ = { ...global?._, constant } // temporary fix for '_.constant is not a function' bug in a topology dependency
 
 const AppRoute = ({ child, katacodaLayout, title, path }) => {
   const pathname = useLocation().pathname;

--- a/packages/documentation-framework/app.js
+++ b/packages/documentation-framework/app.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useLocation } from '@reach/router';
 import 'client-styles'; // Webpack replaces this import: patternfly-docs.css.js
+import { constant } from 'lodash';
 import { SideNavLayout } from '@patternfly/documentation-framework/layouts';
 import { Footer } from '@patternfly/documentation-framework/components';
 import { MDXTemplate } from '@patternfly/documentation-framework/templates/mdx';
@@ -15,6 +16,8 @@ import './components/footer/footer.css';
 import './components/sideNav/sideNav.css';
 import './components/topNav/topNav.css';
 import './layouts/sideNavLayout/sideNavLayout.css';
+
+global._ = { ...global?._, constant }
 
 const AppRoute = ({ child, katacodaLayout, title, path }) => {
   const pathname = useLocation().pathname;


### PR DESCRIPTION
Resolves bug causing issues in graphlib dependency of the topology extension when attempting to add topology documentation.

Bug reported here: https://patternfly.slack.com/archives/C4FM977N0/p1671037144183429

Bug TLDR: the graphlib dependency of the dagre package which topology relies on throws a runtime error of `_.constant is not a function` when attempting to run topology components using the pf docs framework.

I think the issue is rooted in [this webpack alias](https://github.com/patternfly/patternfly-org/blob/31f12aca3284b6eadb1d458990023a512ede352a/packages/documentation-framework/scripts/webpack/webpack.base.config.js#L123) as removing that also fixes the issue. Not sure what the exact mechanism of the issue is though as constant seems like it also exists on lodash-es. Either way the change here seems to fix the issue in topology based on my testing.