### PR TITLE
Change section to 'demos'

### DIFF
--- a/packages/v4/patternfly-docs/content/design-guidelines/usage-and-behavior/filters/filters.md
+++ b/packages/v4/patternfly-docs/content/design-guidelines/usage-and-behavior/filters/filters.md
@@ -1,6 +1,6 @@
 ---
 id: Filters
-section: guidelines
+section: demos
 related: [
   'Badge',
   'Chip',


### PR DESCRIPTION
Moves the Filters design guidelines from the Guidelines to Demos to appear with the Filters demo page on the website