### PR TITLE
chore(Modal): updated a11y docs

### DIFF
--- a/packages/v4/patternfly-docs/content/accessibility/alert/alert.md
+++ b/packages/v4/patternfly-docs/content/accessibility/alert/alert.md
@@ -50,12 +50,12 @@ The following HTML attributes and PatternFly classes can be used for more fine-t
 | Attribute or class | Applied to | Reason | 
 |---|---|---|
 | `aria-label="[variant] alert"` | `.pf-c-alert` | Adds an accessible name to the alert for assistive technologies. The value passed in place of `[variant]` should generally be one of either "default", "success", "danger", "warning", or "information". |
-| `.pf-screen-reader` | `.pf-c-alert__title <span>` | Should be used to add text to the alert title that is accessible only to assistive technologies and is not visually rendered. The text content of this element should state the type of alert and should preface the alert title. |
+| `.pf-screen-reader` | `.pf-c-alert__title span` | Should be used to add text to the alert title that is accessible only to assistive technologies and is not visually rendered. The text content of this element should state the type of alert and should preface the alert title. |
 | `aria-label="Close [variant] alert: [alert title]"` | `.pf-c-button.pf-m-plain` | Should be used to add an accessible name to the alert close button. |
 | `hidden` | `.pf-c-alert__description` | Hides the expandable alert description content. **Required** when `aria-expanded="false"` is passed into `.pf-c-alert__toggle`. |
 | `aria-expanded="[true or false]"` | `.pf-c-alert__toggle` | Indicates whether the alert toggle is expanded (true) or collapsed (false) to assistive technologies and that the expandable alert description is hidden. **Required**. |
 | `aria-label="[variant] alert details"` | `.pf-c-button.pf-m-plain` | Should be used to add an accessible name to the alert toggle when an alert has the `aria-expanded` attribute passed in. |
-| `aria-hidden="true"` | `.pf-c-alert__icon <i>` | Removes the expandable alert toggle icon from the accessibility tree, preventing assistive technologies from potentially announcing duplicate or unnecessary information without visually hiding it. **Required**. |
+| `aria-hidden="true"` | `.pf-c-alert__icon i` | Removes the expandable alert toggle icon from the accessibility tree, preventing assistive technologies from potentially announcing duplicate or unnecessary information without visually hiding it. **Required**. |
 
 When using JavaScript to automatically dismiss alerts, read the `timeout` prop row in the [React customization](#react-customization) section for details on an accessible implementation.
 

--- a/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
@@ -3,28 +3,66 @@ id: Modal
 section: components
 ---
 
-A **modal** displays important information to a user without requiring them to navigate to a new page.
+import { Checkbox, List, ListItem } from '@patternfly/react-core';
 
-**Keyboard and mouse users** shouldn’t be able to interact with the rest of the page outside of an open modal. Set initial focus on the first focusable element in the modal. The user should be able to Tab to any interactive elements within the modal and use Tab + Shift to move backward through interactive elements. Keyboard users should be able to leave the modal by pressing Esc and focus should return to the element that invoked the modal. 
+## Accessibility
 
-**Screen reader users** shouldn’t be able to interact with the rest of the page outside an open modal. Add alternative text for any images or non-textual buttons (like icon buttons). Images should use the alt attribute: `aria-label` is most common to label icon buttons. Write a clear headline that describes the modal, and be sure to follow our modal content guidelines to clearly communicate information contained within it. 
+To implement an accessible PatternFly **modal** component:
 
-Bear in mind that any components placed inside the modal should also follow that component’s accessibility requirements.
-<br/>
-<br/>
+- Add an `aria-label` to the modal if it doesn't have a visible text title
+- Ensure any other PatternFly components follow their respective accessibility documentation
 
-**To make modal accessible:**
+## Testing
 
-- **If you don’t use a title in your modal**, add an `aria-label` to give the modal an accessible name. It will look like `aria-label=”[title of modal]” on the AboutModal and will appear directly on the class .pf-c-about-modal-box. 
-- Use `aria-describedby` for any description you add to the modal.
+At a minimum, a modal should meet the following criteria:
 
-<br/>
-The following props can be added or are customizable in PatternFly:
+<List isPlain>
+  <ListItem>
+    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page but outside of the modal cannot be interacted with or navigated to while the modal is open." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="modal-a11y-checkbox-2" label="Standard keyboard navigation can be used to navigate between the contents of a modal." description={<span><kbd>Tab</kbd> navigates to the next focusable element inside a modal, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous focusable element.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="modal-a11y-checkbox-3" label={<span>The <kbd>Escape</kbd> key should close the modal, if no components within the modal are open.</span>} description={<span>If a dropdown is open within an open modal, pressing <kbd>Escape</kbd> once should close the dropdown only, and pressing <kbd>Escape</kbd> again should close the modal.</span>} />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="modal-a11y-checkbox-4" label="When a modal closes, focus should return to the last focused item before the modal was opened." description="Exceptions to this include if the last focused item no longer exists, or if focusing another element makes more sense from a work flow perspective." />
+  </ListItem>
+</List>
 
-| React component | React prop | Which HTML element it appears on in markup | Explanation | 
-|---|---|---|---|
-| Modal | aria-describedby | .pf-c-modal-box | Id to use for Modal Box descriptor |
-| Modal | aria-label | .pf-c-modal-box | Accessible descriptor of modal (use if no title) |
-| Modal | aria-labelledby | .pf-c-modal-box | Id to use for Modal Box label (use if no title) |
-| Modal | title | .pf-c-modal-box | Simple text content of the Modal Header, also used for aria-label on the body |
-| Modal | titleLabel | .pf-c-modal-box__title | Optional title label text for screen readers |
+## React customization
+
+The following React props have been provided for more fine-tuned control over accessibility.
+
+| Prop | Applied to | Reason | 
+|---|---|---|
+
+
+## HTML/CSS customization
+
+The following HTML attributes and PatternFly classes can be used for more fine-tuned control over accessibility.
+
+| Attribute or class | Applied to | Reason | 
+|---|---|---|
+| `aria-describedby="[id of the element that describes the modal"` | `.pf-c-modal-box` | Adds an accessible description to the modal. Typically this will be the id of the primary modal content. |
+| `aria-label="[text describing the modal]"` | `.pf-c-modal-box` | Adds an accessible name to the modal. **Required** if there is no visible text that acts as the modal title. |
+| `aria-labelledby="[id of the .pf-c-modal-box__title element or another title element]"` | `.pf-c-modal-box` | Adds an accessible name to the modal. **Required** if `.pf-c-modal-box__title` or another title element is present. |
+| `aria-modal="true"` | `.pf-c-modal-box` | Notifies users of assistive technologies that the contents underneath the modal are not available for interaction. This does not prevent other content from being interacted with, nor does it make the element a modal itself. **Required**. |
+| `role="dialog"` | `.pf-c-modal-box` | Identifies the element that serves as the modal container. **Required**. |
+| `tab-index="0"` | `.pf-c-modal-box__body` | Makes the modal body focusable via keyboard and other assistive technologies. **Required** if the modal body content renders a scrollbar due to overflow and if there is no other focusable element within the scrollable region. |
+| `aria-label="Close"` | `.pf-c-modal-box__close .pf-c-button` | Adds an accessible name to the close button of a modal. **Required**. |
+| `form="[id of the form element in the modal body]"` | `.pf-c-modal-box__footer .pf-c-button` | Links a "submit" button in the modal footer with a form in the modal body. **Required** when the submit button is outside of a `<form>` element. |
+| `aria-hidden="true"` | Parent element that contains the page contents | Removes the specified content from the accessibility tree, preventing assistive technologies from interacting with it. The `.pf-c-modal-box` element must not be a descendent of the element that has this attribute. **Required** when the modal is open. |
+
+## Additional considerations
+
+Consumers must ensure they take any additional considerations when customizing a modal, using it in a way not described or recommended by PatternFly, or in various other specific use cases not outlined elsewhere on this page.
+
+### Focus
+
+## Further reading
+
+To read more about accessibility with a modal, refer to the following resources:
+
+- [ARIA Authoring Practices Guide - Dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/)

--- a/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
@@ -28,10 +28,13 @@ At a minimum, a modal should meet the following criteria:
     <Checkbox id="modal-a11y-checkbox-3" label={<span>The <kbd>Escape</kbd> key should close the modal only if no other components within the modal are open.</span>} description={<span>If a dropdown is open within an open modal, pressing <kbd>Escape</kbd> once should close the dropdown only, and pressing <kbd>Escape</kbd> again should close the modal itself.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-4" label="There is at least one clickable button that will close the modal, such as the close icon in the modal header or a 'cancel' button in the footer." />
+    <Checkbox id="modal-a11y-checkbox-4" label="There is at least one clickable button that will close the modal." description="For example, the close icon in the modal header or a 'cancel' button in the footer." />
   </ListItem>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-5" label="When a modal closes, focus should return to the last focused item before the modal was opened." description="Exceptions to this include if the last focused item no longer exists, or if focusing another element makes more sense from a work flow perspective." />
+    <Checkbox id="modal-a11y-checkbox-5" label="The modal content can receive focus via keyboard if it overflows and renders a scrollbar." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="modal-a11y-checkbox-6" label="When a modal closes, focus should return to the last focused item before the modal was opened." description="Exceptions to this include if the last focused item no longer exists, or if focusing another element makes more sense from a work flow perspective." />
   </ListItem>
 </List>
 
@@ -58,13 +61,17 @@ The following HTML attributes and PatternFly classes can be used for more fine-t
 | Attribute or class | Applied to | Reason | 
 |---|---|---|
 | `aria-describedby="[id of the element that describes the modal"` | `.pf-c-modal-box` | Adds an accessible description to the modal. Typically this will be the id of the primary modal content. |
-| `aria-label="[text describing the modal]"` | `.pf-c-modal-box` | Adds an accessible name to the modal. **Required** if there is no visible text that acts as the modal title. |
-| `aria-labelledby="[id of the .pf-c-modal-box__title element or another title element]"` | `.pf-c-modal-box` | Adds an accessible name to the modal. **Required** if `.pf-c-modal-box__title` or another title element is present. |
+| `aria-label="[text that labels the modal]"` | `.pf-c-modal-box` | Adds an accessible name to the modal. **Required** if there is no visible text that acts as the modal title. |
+| `aria-labelledby="[id of the element that labels the modal]"` | `.pf-c-modal-box` | Adds an accessible name to the modal. **Required** if `.pf-c-modal-box__title` or another title element is present. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Notifies users of assistive technologies that the contents underneath the modal are not available for interaction. This does not prevent other content from being interacted with, nor does it make the element a modal itself. **Required**. |
 | `role="dialog"` | `.pf-c-modal-box` | Identifies the element that serves as the modal container. **Required**. |
-| `tab-index="0"` | `.pf-c-modal-box__body` | Makes the modal body focusable via keyboard and other assistive technologies. **Required** if the modal body content renders a scrollbar due to overflow and if there is no other focusable element within the scrollable region. |
+| `aria-label="[text labeling the modal body]"` | `.pf-c-modal-box__body` | Adds an accessible name to the modal body. This attribute should only be passed in if the `role` attribute is also passed in. **Required** if the modal body content renders a scrollbar due to overflow. |
+| `role="[role of the modal body]"` | `.pf-c-modal-box__body` | Adds an accessible role to the modal body. Typically "region" is passed in as the role. **Required** if the modal body content renders a scrollbar due to overflow. |
+| `tab-index="0"` | `.pf-c-modal-box__body` | Makes the modal body focusable via keyboard and other assistive technologies. **Required** if the modal body content renders a scrollbar due to overflow. |
 | `aria-label="Close"` | `.pf-c-modal-box__close .pf-c-button` | Adds an accessible name to the close button of a modal. **Required**. |
 | `form="[id of the form element in the modal body]"` | `.pf-c-modal-box__footer .pf-c-button` | Links a "submit" button in the modal footer with a form in the modal body. **Required** when the submit button is outside of a `<form>` element. |
+| `aria-hidden="true"` | `.pf-c-modal-box .pf-c-button i`, `.pf-c-modal-box__header-help .pf-c-button i` | Removes the close button and help button icons from the accessibility tree, preventing assistive technologies from potentially announcing duplicate or unnecessary information without visually hiding it. **Required**. |
+| `.pf-screen-reader` | `.pf-c-modal-box__title span` | Should be used to add text to the modal title that is accessible only to assistive technologies and is not visually rendered. The text content of this element should state the status or severity of the modal and should preface the modal title. |
 | `aria-hidden="true"` | Parent element that contains the page contents | Removes the specified content from the accessibility tree, preventing assistive technologies from interacting with it. The `.pf-c-modal-box` element must not be a descendent of the element that has this attribute. **Required** when the modal is open. |
 
 ## Additional considerations
@@ -72,6 +79,14 @@ The following HTML attributes and PatternFly classes can be used for more fine-t
 Consumers must ensure they take any additional considerations when customizing a modal, using it in a way not described or recommended by PatternFly, or in various other specific use cases not outlined elsewhere on this page.
 
 ### Focus
+
+When a modal opens, the element that should receive focus will depend on the content and size of the modal. The following guidelines can help decide where to place focus for your use case.
+
+- If the modal contains semantic elements, such as lists or tables, that are necessary to perceive in order to better understand the modal content, place focus on a static element at the start of the content. The element that receives focus must have `tabindex="-1"`.
+- If the modal includes an irreversible action, such as deleting data, place focus on the least destructive action in the modal.
+- If the modal includes actions that simply provide additional information or continue processing, such as an "OK" or "Continue" button, place focus on the action that is likely to be most frequently used.
+- If none of the above apply, place focus on the first focusable element in the modal.
+- If placing focus on an element would cause the beginning of the modal content to scroll out of view, focus should instead be placed on a static element at the top of the modal. Typically this would be the modal title, but can also be the first paragraph element. The element that receives focus in this way must have `tabindex="-1"`.
 
 ## Further reading
 

--- a/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
@@ -4,6 +4,7 @@ section: components
 ---
 
 import { Checkbox, List, ListItem } from '@patternfly/react-core';
+import { Link } from '@patternfly/documentation-framework/components/link/link';
 
 ## Accessibility
 
@@ -19,7 +20,7 @@ At a minimum, a modal should meet the following criteria:
 
 <List isPlain>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about <a href="/v4/accessibility/product-development-guide/#trapping-focus">trapping focus</a> in our product development guide for accessibility.</span>} />
+    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about <Link href="/accessibility/product-development-guide/#trapping-focus">trapping focus</Link> in our product development guide for accessibility.</span>} />
   </ListItem>
   <ListItem>
     <Checkbox id="modal-a11y-checkbox-2" label="Standard keyboard navigation can be used to navigate between the contents of a modal." description={<span><kbd>Tab</kbd> navigates to the next focusable element inside a modal, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous focusable element.</span>} />

--- a/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
@@ -20,7 +20,7 @@ At a minimum, a modal should meet the following criteria:
 
 <List isPlain>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about <Link href="/accessibility/product-development-guide/#trapping-focus">trapping focus</Link> in our product development guide for accessibility.</span>} />
+    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about trapping focus in our <Link href="/accessibility/product-development-guide/#trapping-focus">product development guide</Link> for accessibility.</span>} />
   </ListItem>
   <ListItem>
     <Checkbox id="modal-a11y-checkbox-2" label="Standard keyboard navigation can be used to navigate between the contents of a modal." description={<span><kbd>Tab</kbd> navigates to the next focusable element inside a modal, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous focusable element.</span>} />

--- a/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
@@ -10,6 +10,7 @@ import { Checkbox, List, ListItem } from '@patternfly/react-core';
 To implement an accessible PatternFly **modal** component:
 
 - Add an `aria-label` to the modal if it doesn't have a visible text title
+- Provide at least one clickable button that can close the modal, such as the default close icon or a "cancel" button
 - Ensure any other PatternFly components follow their respective accessibility documentation
 
 ## Testing
@@ -18,16 +19,19 @@ At a minimum, a modal should meet the following criteria:
 
 <List isPlain>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page but outside of the modal cannot be interacted with or navigated to while the modal is open." />
+    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about <a href="/accessibility/product-development-guide/#trapping-focus">trapping focus</a> in our product development guide for accessibility.</span>} />
   </ListItem>
   <ListItem>
     <Checkbox id="modal-a11y-checkbox-2" label="Standard keyboard navigation can be used to navigate between the contents of a modal." description={<span><kbd>Tab</kbd> navigates to the next focusable element inside a modal, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous focusable element.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-3" label={<span>The <kbd>Escape</kbd> key should close the modal, if no components within the modal are open.</span>} description={<span>If a dropdown is open within an open modal, pressing <kbd>Escape</kbd> once should close the dropdown only, and pressing <kbd>Escape</kbd> again should close the modal.</span>} />
+    <Checkbox id="modal-a11y-checkbox-3" label={<span>The <kbd>Escape</kbd> key should close the modal only if no other components within the modal are open.</span>} description={<span>If a dropdown is open within an open modal, pressing <kbd>Escape</kbd> once should close the dropdown only, and pressing <kbd>Escape</kbd> again should close the modal itself.</span>} />
   </ListItem>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-4" label="When a modal closes, focus should return to the last focused item before the modal was opened." description="Exceptions to this include if the last focused item no longer exists, or if focusing another element makes more sense from a work flow perspective." />
+    <Checkbox id="modal-a11y-checkbox-4" label="There is at least one clickable button that will close the modal, such as the close icon in the modal header or a 'cancel' button in the footer." />
+  </ListItem>
+  <ListItem>
+    <Checkbox id="modal-a11y-checkbox-5" label="When a modal closes, focus should return to the last focused item before the modal was opened." description="Exceptions to this include if the last focused item no longer exists, or if focusing another element makes more sense from a work flow perspective." />
   </ListItem>
 </List>
 
@@ -37,7 +41,15 @@ The following React props have been provided for more fine-tuned control over ac
 
 | Prop | Applied to | Reason | 
 |---|---|---|
-
+| `aria-describedby="[id of the element that describes the modal"` | `Modal` | Adds an accessible description to the modal. Typically this will be the id of the primary modal content. |
+| `aria-label="[text that labels the modal]"` | `Modal` | Adds an accessible name to the modal. **Required** if there is no visible text that acts as the modal title, such as from the `title` or `header` props. |
+| `aria-labelledby="[id of the element that labels the modal]"` | `Modal` | Adds an accessible name to the modal. **Required** if using the `header` prop rather than the `title` prop. |
+| `bodyAriaLabel` | `Modal` | Adds an accessible name to the modal body. **Required** when the content of the modal body overflows and triggers a scrollbar.<br/><br/>When passed in, the accessible `role` of the modal body will be set to `region` by default. |
+| `bodyAriaRole` | `Modal` | Adds an accessible role to the modal body. Passing this prop in will override the default `region` role when `bodyAriaLabel` is passed in. |
+| `disableFocusTrap` | `Modal` | Disables the built-in focus trap functionality and allowing custom focus management when the modal is opened. When passing this prop in, you must manually trap focus yourself so that content outside of the open modal cannot be interacted with or navigated to. |
+| `title` | `Modal` | Adds a visible text title to the modal and automatically sets the `aria-labelledby` of the modal. It is recommended to pass this prop in when also passing in the `titleIconVariant` prop to provide more context to users. |
+| `titleIconVariant` | `Modal` | Adds an icon to the modal title. When passing in a custom icon that conveys status or severity, you must also pass in the `titleLabel` prop. |
+| `titleLabel` | `Modal` | Adds visually hidden text before the modal title in order to describe the status or severity of the modal. If a predefined value is passed to `titleIconVariant`, the visually hidden text is automatically set to `[variant] alert:`, but can be overridden with this prop. |
 
 ## HTML/CSS customization
 
@@ -63,6 +75,6 @@ Consumers must ensure they take any additional considerations when customizing a
 
 ## Further reading
 
-To read more about accessibility with a modal, refer to the following resources:
+To read more about accessibility with a modal (also known as a dialog), refer to the following resources:
 
 - [ARIA Authoring Practices Guide - Dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/)

--- a/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
+++ b/packages/v4/patternfly-docs/content/accessibility/modal/modal.md
@@ -19,7 +19,7 @@ At a minimum, a modal should meet the following criteria:
 
 <List isPlain>
   <ListItem>
-    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about <a href="/accessibility/product-development-guide/#trapping-focus">trapping focus</a> in our product development guide for accessibility.</span>} />
+    <Checkbox id="modal-a11y-checkbox-1" label="Any content that is on the page, but outside of the modal, cannot be interacted with or navigated to while the modal is open." description={<span>Learn more about <a href="/v4/accessibility/product-development-guide/#trapping-focus">trapping focus</a> in our product development guide for accessibility.</span>} />
   </ListItem>
   <ListItem>
     <Checkbox id="modal-a11y-checkbox-2" label="Standard keyboard navigation can be used to navigate between the contents of a modal." description={<span><kbd>Tab</kbd> navigates to the next focusable element inside a modal, and <kbd>Shift</kbd> + <kbd>Tab</kbd> navigates to the previous focusable element.</span>} />


### PR DESCRIPTION
Closes #2500, closes #3346 

This would require updates in React, possibly Core. For Core it'd probably just be updating/adding an example to show modal content overflowing, while React would need to add in functionality to set things under the hood for when modal content overflows. Would most likely be similar to the Accordion PRs that made similar updates (https://github.com/patternfly/patternfly/pull/5130 and https://github.com/patternfly/patternfly-react/pull/8515)