### PR TITLE
fix(docs-framework): skip topology in prerendering step

### DIFF
--- a/packages/documentation-framework/scripts/webpack/getHtmlWebpackPlugins.js
+++ b/packages/documentation-framework/scripts/webpack/getHtmlWebpackPlugins.js
@@ -20,7 +20,7 @@ async function getHtmlWebpackPlugin({
     templateParameters: {
       title: getTitle(title),
       // Don't prerender fullscreen pages (expensive!)
-      prerendering: (isProd && !isFullscreen && !url.includes('extensions')) ? await prerender(url, pathPrefix) : null,
+      prerendering: (isProd && !isFullscreen && !url.includes('topology') && !url.includes('extensions')) ? await prerender(url, pathPrefix) : null,
       // Don't use GA in dev mode
       googleAnalyticsID: isProd ? googleAnalyticsID : false,
       algolia


### PR DESCRIPTION
This is the docs-framework update to fix build in https://github.com/patternfly/patternfly-react/pull/8586