### PR TITLE
feat(docs): allow propComponents from another source

### DIFF
--- a/packages/documentation-framework/scripts/md/parseMD.js
+++ b/packages/documentation-framework/scripts/md/parseMD.js
@@ -61,7 +61,10 @@ function toReactComponent(mdFilePath, source, buildMode) {
       }
 
       const propComponents = [...new Set(frontmatter.propComponents || [])].reduce((acc, componentName) => {
-        const name = getTsDocName(componentName, getTsDocNameVariant(source));
+        // Use object properties if passed as propComponent
+        const component = componentName.component || componentName;
+        const src = componentName.source || source;
+        const name = getTsDocName(component, getTsDocNameVariant(src));
 
         if (tsDocs[name]) {
           acc.push(tsDocs[name]);

--- a/packages/documentation-framework/templates/patternfly-docs/content/extensions/extension/examples/basic.md
+++ b/packages/documentation-framework/templates/patternfly-docs/content/extensions/extension/examples/basic.md
@@ -9,6 +9,7 @@ id: My extension
 source: react
 # If you use typescript, the name of the interface to display props for
 # These are found through the sourceProps function provdided in patternfly-docs.source.js
+# Can also pass object { component: string, source: string } allowing to specify the source
 propComponents: ['Button']
 ---
 


### PR DESCRIPTION
Closes #3331 

This PR allows propComponents to be pulled in for components with a different source (such as a component in the `next` directory referencing props from a standard component) by allowing an object to be passed as a `propComponent` in place of the component name string. 

This object should contain a `component` property mapped to the component name, and a `source` property mapped to the name of the source (ex: `react`).  Example:
```
propComponents: [
  'Dropdown',
  'DropdownGroup',
  'DropdownItem',
  'DropdownList',
  {
    component: 'MenuToggle',
    source: 'react'
  }
]
```