### PR TITLE
chore(v5): update v4 references to v5

### DIFF
--- a/.github/upload-preview.js
+++ b/.github/upload-preview.js
@@ -56,8 +56,8 @@ if (prnum) {
         commentBody += '\n';
       }
 
-      if (uploadName === 'v4') {
-        commentBody += tryAddComment(`PF4 preview: https://${uploadURL}/v4`, commentBody);
+      if (uploadName === 'v5') {
+        commentBody += tryAddComment(`PF4 preview: https://${uploadURL}/v5`, commentBody);
       }
       else if (uploadFolderName === 'coverage') {
         commentBody += tryAddComment(`A11y report: https://${uploadURL}`, commentBody);

--- a/.github/workflows-src/partials/build.yml
+++ b/.github/workflows-src/partials/build.yml
@@ -3,18 +3,18 @@
     node-version: '16'
 - uses: actions/cache@v2
   id: yarn-cache
-  name: Load  v4 npm deps from cache
+  name: Load  v5 npm deps from cache
   with:
     path: '**/node_modules'
     key: ${{ runner.os }}-yarn-14-${{ hashFiles('yarn.lock') }}
 - run: yarn install --frozen-lockfile
   if: steps.yarn-cache.outputs.cache-hit != 'true'
-# v4 build
+# v5 build
 - uses: actions/cache@v2
-  id: v4-cache
+  id: v5-cache
   name: Load webpack cache
   with:
-    path: 'packages/v4/.cache'
-    key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
-- run: yarn build:v4
+    path: 'packages/v5/.cache'
+    key: ${{ runner.os }}-v5-${{ hashFiles('yarn.lock') }}
+- run: yarn build:v5
   name: Build docs

--- a/.github/workflows-src/pr-preview.yml
+++ b/.github/workflows-src/pr-preview.yml
@@ -16,5 +16,5 @@ jobs:
           git checkout tmp
       # Injected by generate-workflows.js
       %build%
-      - run: node .github/upload-preview.js build/patternfly-org v4
+      - run: node .github/upload-preview.js build/patternfly-org v5
         name: Upload docs

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,20 +21,20 @@ jobs:
           node-version: '16'
       - uses: actions/cache@v2
         id: yarn-cache
-        name: Load  v4 npm deps from cache
+        name: Load  v5 npm deps from cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-yarn-14-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-      # v4 build
+      # v5 build
       - uses: actions/cache@v2
-        id: v4-cache
+        id: v5-cache
         name: Load webpack cache
         with:
-          path: 'packages/v4/.cache'
-          key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
-      - run: yarn build:v4
+          path: 'packages/v5/.cache'
+          key: ${{ runner.os }}-v5-${{ hashFiles('yarn.lock') }}
+      - run: yarn build:v5
         name: Build docs
-      - run: node .github/upload-preview.js build/patternfly-org v4
+      - run: node .github/upload-preview.js build/patternfly-org v5
         name: Upload docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,20 +22,20 @@ jobs:
           node-version: '16'
       - uses: actions/cache@v2
         id: yarn-cache
-        name: Load  v4 npm deps from cache
+        name: Load  v5 npm deps from cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-yarn-14-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-      # v4 build
+      # v5 build
       - uses: actions/cache@v2
-        id: v4-cache
+        id: v5-cache
         name: Load webpack cache
         with:
-          path: 'packages/v4/.cache'
-          key: ${{ runner.os }}-v4-${{ hashFiles('yarn.lock') }}
-      - run: yarn build:v4
+          path: 'packages/v5/.cache'
+          key: ${{ runner.os }}-v5-${{ hashFiles('yarn.lock') }}
+      - run: yarn build:v5
         name: Build docs
       - run: .github/release.sh
       - name: Configure AWS Credentials

--- a/lerna.json
+++ b/lerna.json
@@ -13,7 +13,7 @@
   "packages": [
     "packages/ast-helpers",
     "packages/documentation-framework",
-    "packages/v4"
+    "packages/v5"
   ],
   "version": "independent",
   "allowBranch": ["main", "v5"]

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
   "license": "MIT",
   "scripts": {
     "analyze": "yarn workspace patternfly-org-4 analyze",
-    "develop": "yarn develop:v4",
-    "develop:v4": "yarn workspace patternfly-org-4 develop",
-    "build": "yarn build:v4",
-    "build:analyze": "yarn workspace patternfly-org-4 build:analyze && yarn copy:v4",
-    "build:v4": "yarn workspace patternfly-org-4 build && yarn copy:v4",
-    "copy:v4": "rm -rf build/patternfly-org/v4 && mkdir -p build/patternfly-org && cp -r packages/v4/public build/patternfly-org/v4 && cp -r build/patternfly-org/v4/assets build/patternfly-org/assets",
+    "develop": "yarn develop:v5",
+    "develop:v5": "yarn workspace patternfly-org-4 develop",
+    "build": "yarn build:v5",
+    "build:analyze": "yarn workspace patternfly-org-4 build:analyze && yarn copy:v5",
+    "build:v5": "yarn workspace patternfly-org-4 build && yarn copy:v5",
+    "copy:v5": "rm -rf build/patternfly-org/v5 && mkdir -p build/patternfly-org && cp -r packages/v5/public build/patternfly-org/v5 && cp -r build/patternfly-org/v5/assets build/patternfly-org/assets",
     "clean": "lerna run clean && rm -rf build",
     "serve": "pf-docs-framework serve build/patternfly-org",
-    "test:v4": "yarn workspace patternfly-org-4 test:a11y:ci",
+    "test:v5": "yarn workspace patternfly-org-4 test:a11y:ci",
     "screenshots": "yarn workspace patternfly-org-4 screenshots",
-    "start": "yarn start:v4",
-    "start:v4": "yarn develop:v4",
+    "start": "yarn start:v5",
+    "start:v5": "yarn develop:v5",
     "uninstall": "find . -name node_modules | xargs rm -rf",
     "workflows": "node .github/generate-workflows",
     "test:a11y": "yarn workspace patternfly-org-4 test:a11y"
@@ -26,7 +26,7 @@
     "packages": [
       "packages/ast-helpers",
       "packages/documentation-framework",
-      "packages/v4"
+      "packages/v5"
     ]
   },
   "devDependencies": {

--- a/packages/documentation-framework/helpers/codesandbox.js
+++ b/packages/documentation-framework/helpers/codesandbox.js
@@ -10,7 +10,7 @@ const getStaticParams = (title, html) => {
   let imgAsset;
   while ((imgAsset = imgAssetRegex.exec(html))) {
     const imgName = imgAsset[1];
-    html = html.replace(imgName, `https://www.patternfly.org/v4${imgName}`);
+    html = html.replace(imgName, `https://www.patternfly.org/v5${imgName}`);
   }
 
   return {

--- a/packages/documentation-framework/scripts/cli/cli.js
+++ b/packages/documentation-framework/scripts/cli/cli.js
@@ -43,7 +43,7 @@ program
 
 program
   .command('screenshots')
-  .option('-u, --urlPrefix <prefix>', 'where fullscreen pages are hosted', 'http://localhost:5000/v4')
+  .option('-u, --urlPrefix <prefix>', 'where fullscreen pages are hosted', 'http://localhost:5000/v5')
   .description('updates screenshots for generated components')
   .action(options => {
     const { writeScreenshots } = require('../writeScreenshots');

--- a/packages/documentation-framework/templates/sitemap.ejs
+++ b/packages/documentation-framework/templates/sitemap.ejs
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <% urls.forEach(url => {%>
   <url>
-    <loc>https://www.patternfly.org/v4<%=url%></loc>
+    <loc>https://www.patternfly.org/v5<%=url%></loc>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/packages/v4/patternfly-a11y.config.js
+++ b/packages/v4/patternfly-a11y.config.js
@@ -8,7 +8,7 @@ async function waitFor(page) {
 }
 
 module.exports = {
-  prefix: 'http://localhost:5000/v4',
+  prefix: 'http://localhost:5000/v5',
   waitFor,
   crawl: true,
   urls: [

--- a/packages/v4/patternfly-docs/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs/patternfly-docs.config.js
@@ -2,7 +2,7 @@ const componentsData = require('./components-data.json');
 
 // This module is shared between NodeJS and babelled ES5
 module.exports = {
-  pathPrefix: '/v4',
+  pathPrefix: '/v5',
   googleAnalyticsID: 'UA-47523816-6',
   algolia: {
     apiKey: 'a8fb1726b78594ff97a3418757514404',

--- a/scripts/writeV3Redirects.js
+++ b/scripts/writeV3Redirects.js
@@ -20,9 +20,9 @@ If you are not redirected automatically, click <a href='${to}'>here.</a>
 }
 
 // Write static files
-writeRedirect(`${outDir}/index.html`, '/v4/');
-writeRedirect(`${outDir}/404.html`, '/v4/404/');
-writeRedirect(`${outDir}/v4/developer-resources/accessibility-guide`, '/v4/accessibility/accessibility-fundamentals');
+writeRedirect(`${outDir}/index.html`, '/v5/');
+writeRedirect(`${outDir}/404.html`, '/v5/404/');
+writeRedirect(`${outDir}/v5/developer-resources/accessibility-guide`, '/v5/accessibility/accessibility-fundamentals');
 fs.writeFileSync(`${outDir}/robots.txt`,
 `User-agent: *
 Allow: /
@@ -32,7 +32,7 @@ fs.writeFileSync(`${outDir}/sitemap.xml`,
 `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://www.patternfly.org/v4/sitemap.xml</loc>
+    <loc>https://www.patternfly.org/v5/sitemap.xml</loc>
   </sitemap>
 </sitemapindex>`);
 console.log('Wrote 4 static files');

--- a/scripts/writeVersionPrefix.js
+++ b/scripts/writeVersionPrefix.js
@@ -5,14 +5,14 @@ const versions = require('@patternfly/documentation-framework/versions.json');
 
 const version = versions.Releases.find(release => release.latest).name;
 
-glob.sync(path.join(__dirname, '../build/patternfly-org/v4/**'))
+glob.sync(path.join(__dirname, '../build/patternfly-org/v5/**'))
   .filter(file => fs.lstatSync(file).isFile())
   .forEach(file => {
-    const newPath = file.replace('patternfly-org/v4', `patternfly-org/${version}`);
+    const newPath = file.replace('patternfly-org/v5', `patternfly-org/${version}`);
 
     if (file.endsWith('.js') || file.endsWith('.html')) {
       let contents = fs.readFileSync(file, 'utf8');
-      contents = contents.replace(/\/v4/g, `/${version}`);
+      contents = contents.replace(/\/v5/g, `/${version}`);
       fs.outputFileSync(newPath, contents);
     } else {
       fs.ensureDirSync(path.dirname(newPath));


### PR DESCRIPTION
This PR updates remaining Github & other related build process files from v4 to v5.  V4 references in content, such as links, are unchanged with this PR.