### PR TITLE
chore(docs): updated to GA4 tag

### DIFF
--- a/packages/documentation-framework/app.js
+++ b/packages/documentation-framework/app.js
@@ -19,7 +19,7 @@ import './layouts/sideNavLayout/sideNavLayout.css';
 const AppRoute = ({ child, katacodaLayout, title, path }) => {
   const pathname = useLocation().pathname;
   if (typeof window !== 'undefined' && window.gtag) {
-    gtag('config', 'UA-47523816-6', {
+    gtag('config', 'G-XRM3R81HJ6', {
       'page_path': pathname,
       'page_title': (title || pathname)
     });

--- a/packages/v4/patternfly-docs/patternfly-docs.config.js
+++ b/packages/v4/patternfly-docs/patternfly-docs.config.js
@@ -3,7 +3,7 @@ const componentsData = require('./components-data.json');
 // This module is shared between NodeJS and babelled ES5
 module.exports = {
   pathPrefix: '/v4',
-  googleAnalyticsID: 'UA-47523816-6',
+  googleAnalyticsID: 'G-XRM3R81HJ6',
   algolia: {
     apiKey: 'a8fb1726b78594ff97a3418757514404',
     appId: '79P4ZBH7A3',


### PR DESCRIPTION
Closes #2944 

This PR updates the GA tag on patternfly.org to GA4.