### PR TITLE
chore: add v4 link in version switcher

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -146,7 +146,16 @@ const HeaderTools = ({
                   >
                     PatternFly 3
                     <ExternalLinkAltIcon />
-                  </DropdownItem>
+                  </DropdownItem>,
+                  <DropdownItem
+                    key="PatternFly 4"
+                    className="ws-patternfly-3"
+                    target="_blank"
+                    href="#"
+                  >
+                    PatternFly 4
+                    <ExternalLinkAltIcon />
+                </DropdownItem>
                 ]}
               />
             </ToolbarItem>


### PR DESCRIPTION
Closes #3272

Adds a basic link to the version switcher. The link itself needs to be updated to point to wherever we decide to move `v4` (and if we choose `v4.patternfly.org` to match `v3`, then we also need to move the `core` site - maybe to `core.patternfly.org`?).

Also, do we want v4 to come before or after v3 in the list as v4 is more recent?