### PR TITLE
chore: add v4 version switcher link

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -151,6 +151,15 @@ const HeaderTools = ({
                     >
                       PatternFly 3
                     </DropdownItem>
+                    <DropdownItem
+                      key="PatternFly 4"
+                      className="ws-patternfly-3"
+                      target="_blank"
+                      href="#"
+                    >
+                      PatternFly 4
+                      <ExternalLinkAltIcon />
+                    </DropdownItem>
                   </DropdownList>
                 </DropdownGroup>
               </Dropdown>

--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -143,15 +143,6 @@ const HeaderTools = ({
                 <DropdownGroup key="Previous versions" label="Previous versions">
                   <DropdownList>
                     <DropdownItem
-                      key="PatternFly 3"
-                      className="ws-patternfly-3"
-                      isExternalLink
-                      to="https://pf3.patternfly.org/"
-                      itemId="patternfly-3"
-                    >
-                      PatternFly 3
-                    </DropdownItem>
-                    <DropdownItem
                       key="PatternFly 4"
                       className="ws-patternfly-3"
                       isExternalLink
@@ -159,7 +150,15 @@ const HeaderTools = ({
                       itemId="patternfly-4"
                     >
                       PatternFly 4
-                      <ExternalLinkAltIcon />
+                    </DropdownItem>
+                    <DropdownItem
+                      key="PatternFly 3"
+                      className="ws-patternfly-3"
+                      isExternalLink
+                      to="https://pf3.patternfly.org/"
+                      itemId="patternfly-3"
+                    >
+                      PatternFly 3
                     </DropdownItem>
                   </DropdownList>
                 </DropdownGroup>

--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -154,8 +154,9 @@ const HeaderTools = ({
                     <DropdownItem
                       key="PatternFly 4"
                       className="ws-patternfly-3"
-                      target="_blank"
-                      href="#"
+                      isExternalLink
+                      to="http://v4-archive.patternfly.org/v4/"
+                      itemId="patternfly-4"
                     >
                       PatternFly 4
                       <ExternalLinkAltIcon />


### PR DESCRIPTION
Closes #3272

Adds a basic link to the version switcher. The link itself needs to be updated to point to wherever we decide to move `v4` (and if we choose `v4.patternfly.org` to match `v3`, then we also need to move the `core` site - maybe to `core.patternfly.org`?).

Also, do we want v4 to come before or after v3 in the list as v4 is more recent?