### PR TITLE
chore: remove hard coded GA ID

### DIFF
--- a/packages/documentation-framework/app.js
+++ b/packages/documentation-framework/app.js
@@ -19,7 +19,7 @@ import './layouts/sideNavLayout/sideNavLayout.css';
 const AppRoute = ({ child, katacodaLayout, title, path }) => {
   const pathname = useLocation().pathname;
   if (typeof window !== 'undefined' && window.gtag) {
-    gtag('config', 'UA-47523816-6', {
+    gtag('config', process.env.googleAnalyticsID, {
       'page_path': pathname,
       'page_title': (title || pathname)
     });

--- a/packages/documentation-framework/scripts/webpack/webpack.base.config.js
+++ b/packages/documentation-framework/scripts/webpack/webpack.base.config.js
@@ -8,6 +8,7 @@ module.exports = (_env, argv) => {
   const {
     pathPrefix = '',
     mode,
+    googleAnalyticsID = false,
     algolia = {},
     hasGdprBanner = false,
     hasFooter = false,
@@ -136,6 +137,7 @@ module.exports = (_env, argv) => {
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(mode),
         'process.env.pathPrefix': JSON.stringify(isProd ? pathPrefix : ''),
+        'process.env.googleAnalyticsID': JSON.stringify(isProd ? googleAnalyticsID : ''),
         'process.env.algolia': JSON.stringify(algolia),
         'process.env.hasGdprBanner': JSON.stringify(hasGdprBanner),
         'process.env.hasFooter': JSON.stringify(hasFooter),


### PR DESCRIPTION
Closes #2944 

This PR removes the harded coded Google Analytics ID from the documentation framework, instead picking it up where it's passed through by the user as it does in other places.

Additionally, this PR confirms completion of GA4 setup which was completed through the analytics account and does not require additional code changes at this time (see issue for relevant page links).