### PR TITLE
feat(docs-framework): add legacy ssl cli option

### DIFF
--- a/packages/documentation-framework/scripts/cli/build.js
+++ b/packages/documentation-framework/scripts/cli/build.js
@@ -50,6 +50,11 @@ async function execFile(file, args) {
     const child_execArgv = [
       '--max-old-space-size=4096'
     ];
+
+    if (args.legacySSL) {
+      child_execArgv.push('--openssl-legacy-provider')
+    }
+
     const child = fork(path.join(__dirname, file), child_argv, { execArgv: child_execArgv });
     function errorHandler(err) {
       console.error(err);
@@ -78,6 +83,7 @@ async function build(cmd, options) {
   const config = getConfig(options);
   config.analyze = options.analyze;
   config.output = options.output;
+  config.legacySSL = options.legacySSL
 
   // These get passed to `fork`ed builds
   process.env.pathPrefix = config.pathPrefix;

--- a/packages/documentation-framework/scripts/cli/cli.js
+++ b/packages/documentation-framework/scripts/cli/cli.js
@@ -26,6 +26,7 @@ program
   .command('build <server|client|all>')
   .option('-a, --analyze', 'use webpack-bundle-analyzer', false)
   .option('-o, --output <folder>', 'output folder', 'public')
+  .option('--legacySSL', 'use legacy version of openssl, needed to support Node 18 until we upgrade webpack to v5', false)
   .description('generates source files and runs webpack')
   .action((cmd, options) => {
     const { build } = require('./build');


### PR DESCRIPTION
Towards #3432

How to test:

0. Checkout branch
1. Set your node version to the latest LTS
2. Attempt to run `yarn build` to build the documentation, observe that it fails
3. `cd` to `packages/v4` and run `yarn build --legacySSL`, observe that it is now able to build

This shouldn't change how the package currently works, but will optionally enable use with node 18 (thus unblocking patternfly/patternfly-react#8303) until we are able to make the more substantial upgrade of webpack.