### PR TITLE
chore: update to createRoot/hydrateRoot for React 18

### DIFF
--- a/packages/documentation-framework/app.js
+++ b/packages/documentation-framework/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom/client';
 import { Router, useLocation } from '@reach/router';
 import 'client-styles'; // Webpack replaces this import: patternfly-docs.css.js
 import { SideNavLayout } from '@patternfly/documentation-framework/layouts';
@@ -104,11 +104,15 @@ export const App = () => (
 
 const isProd = process.env.NODE_ENV === 'production';
 const isPrerender = process.env.PRERENDER;
-// Don't use ReactDOM in SSR
+// Don't use ReactDOM in SSR (server-side rendering)
 if (!isPrerender) {
   function render() {
-    const renderFn = isProd ? ReactDOM.hydrate : ReactDOM.render;
-    renderFn(<App />, document.getElementById('root'));
+    const container = document.getElementById('root');
+    if (isProd) {
+        hydrateRoot(container, <App />);
+    } else {
+        createRoot(container).render(<App />);
+    }
   }
   // On first load, await promise for the current page to avoid flashing a "Loading..." state
   const Component = getAsyncComponent(null);


### PR DESCRIPTION
Should still be backwards compatible with previous React versions.

Until webpack is also updated, using node >16 requires a workaround for building and starting the dev server.