### PR TITLE
chore(Version Switcher): updated to Next Dropdown

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.css
@@ -12,10 +12,6 @@
   padding: 0 var(--pf-global--spacer--md);
 }
 
-.ws-patternfly-3 > svg {
-  margin-left: var(--pf-global--spacer--sm);
-}
-
 @media (min-width: 1200px) {
   .ws-page-sidebar {
     box-shadow: none !important;

--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -4,16 +4,13 @@ import {
   Page,
   PageSidebar,
   Brand,
-  Dropdown,
-  DropdownToggle,
-  DropdownItem,
-  DropdownGroup,
   Divider,
   Masthead,
   MastheadToggle,
   MastheadMain,
   MastheadContent,
   MastheadBrand,
+  MenuToggle,
   PageToggleButton,
   Toolbar,
   ToolbarGroup,
@@ -23,7 +20,7 @@ import {
   Switch,
   SearchInput
 } from '@patternfly/react-core';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import {Dropdown as DropdownNext, DropdownGroup as DropdownGroupNext, DropdownItem as DropdownItemNext, DropdownList} from '@patternfly/react-core/next';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import GithubIcon from '@patternfly/react-icons/dist/esm/icons/github-icon';
 import { SideNav, TopNav, GdprBanner } from '../../components';
@@ -48,14 +45,9 @@ const HeaderTools = ({
   const [isSearchExpanded, setIsSearchExpanded] = React.useState(false);
 
   const getDropdownItem = (version, isLatest = false) => (
-    <DropdownItem
-      key={version.name}
-      component={
-        <a href={isLatest ? '/' : `/${version.name}`}>
-          {`Release ${version.name}`}
-        </a>
-      }
-    />
+    <DropdownItemNext itemId={version.name} key={version.name} to={isLatest ? '/' : `/${version.name}`}>
+      {`Release ${version.name}`}
+    </DropdownItemNext>
   );
 
   const onChange = (_evt, value) => {
@@ -116,39 +108,49 @@ const HeaderTools = ({
           </ToolbarItem>
           {hasVersionSwitcher && (
             <ToolbarItem>
-              <Dropdown
-                isFullHeight
+              <DropdownNext
                 onSelect={() => setDropdownOpen(!isDropdownOpen)}
+                onOpenChange={(isOpen) => setDropdownOpen(isOpen)}
                 isOpen={isDropdownOpen}
-                toggle={(
-                  <DropdownToggle
-                    onToggle={() => setDropdownOpen(!isDropdownOpen)}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    isFullHeight
+                    ref={toggleRef}
+                    onClick={() => setDropdownOpen(!isDropdownOpen)}
+                    isExpanded={isDropdownOpen}
                   >
                     Release {initialVersion.name}
-                  </DropdownToggle>
+                  </MenuToggle>
                 )}
-                dropdownItems={[
-                  <DropdownGroup key="latest" label="Latest">
+              >
+                <DropdownGroupNext key="Latest" label="Latest">
+                  <DropdownList>
                     {getDropdownItem(latestVersion, true)}
-                  </DropdownGroup>,
-                  <DropdownGroup key="Previous" label="Previous releases">
-                    {Object.values(versions.Releases)
-                      .filter(version => !version.hidden && !version.latest)
-                      .slice(0,3)
-                      .map(version => getDropdownItem(version))}
-                  </DropdownGroup>,
-                  <Divider key="divider" className="ws-switcher-divider"/>,
-                  <DropdownItem
-                    key="PatternFly 3"
-                    className="ws-patternfly-3"
-                    target="_blank"
-                    href="https://pf3.patternfly.org/"
-                  >
-                    PatternFly 3
-                    <ExternalLinkAltIcon />
-                  </DropdownItem>
-                ]}
-              />
+                  </DropdownList>
+                </DropdownGroupNext>
+                <DropdownGroupNext key="Previous releases" label="Previous releases">
+                  <DropdownList>
+                  {Object.values(versions.Releases)
+                    .filter(version => !version.hidden && !version.latest)
+                    .slice(0,3)
+                    .map(version => getDropdownItem(version))}
+                  </DropdownList>
+                </DropdownGroupNext>
+                <Divider key="divider" className="ws-switcher-divider"/>
+                <DropdownGroupNext key="Previous versions" label="Previous versions">
+                  <DropdownList>
+                    <DropdownItemNext
+                      key="PatternFly 3"
+                      className="ws-patternfly-3"
+                      isExternalLink
+                      to="https://pf3.patternfly.org/"
+                      itemId="patternfly-3"
+                    >
+                      PatternFly 3 
+                    </DropdownItemNext>
+                  </DropdownList>
+                </DropdownGroupNext>
+              </DropdownNext>
             </ToolbarItem>
           )}
         </ToolbarGroup>


### PR DESCRIPTION
Draft for #3450 , should probably wait until Dropdown Next is promoted and then this can be updated again to point towards the correct package

Some updates need to be made in react-core:

- Allow focus to go to anchors (currently if the first item is an anchor, focus is not placed in the menu)
- Currently it does not seem like there's a way to make an anchor dropdown item open in a new tab/window

I also tested out adding visible text label above the Patternfly 3 link ("Previous versions"). That could possibly be confusing with the "Previous releases" label, and wouldn't be useful if we only plan to link to the most recent previous version (rather than PF3, PF4, etc).