### PR TITLE
fix(docs): fixes display & search bugs on icons page

### DIFF
--- a/packages/v4/patternfly-docs/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/v4/patternfly-docs/content/design-guidelines/styles/icons/IconsTable.js
@@ -75,6 +75,7 @@ export const IconsTable = () => {
         icon.Contextual_usage?.toLowerCase().includes(searchValue.toLowerCase()) ||
         icon.Extra_context?.toLowerCase().includes(searchValue.toLowerCase()) ||
         icon.Label?.toLowerCase().includes(searchValue.toLowerCase()) ||
+        icon.React_name.toLowerCase().includes(searchValue.toLowerCase()) ||
         (typeof icon.Type === "string" && icon.Type.toLowerCase().includes(searchValue.toLowerCase())) ||
         (Array.isArray(icon.Type) && icon.Type.filter((type) => type.toLowerCase().includes(searchValue.toLowerCase())).length > 0)
     });


### PR DESCRIPTION
Closes #3482 

This PR fixes a few small display/search functionality bugs in the tables on the icons page:

> - Full icons list should include react icon name in the search (currently if you search the exact react icon name you may get 0 results)
> - Recommended icons should only show "contextual usage" for the updated icon, not the old icon.
> - Recommended icons "contextual usage" should include line break when there is copy for more than 1 recommended icon, currently these descriptions run together
> - Recommended icons currently only searches through the first two icons, but needs to be dynamic as in some cases there are multiple "old icons" or multiple "updated icons" and not just one old icon mapped to one updated icon.