### PR TITLE
Feature requests as discussions

### DIFF
--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -147,11 +147,11 @@ export const Footer = () => (
                   <li className="ws-org-pfsite-footer-menu-list-item">
                     <Link
                       className="ws-org-pfsite-footer-menu-link"
-                      to="//forum.patternfly.org"
+                      to="//github.com/orgs/patternfly/discussions"
                       target="top"
-                      aria-label="Visit the PatternFly 4 forum"
+                      aria-label="Visit the PatternFly discussion forum"
                     >
-                      Forum
+                      Discussions
                     </Link>
                   </li>
                   <li className="ws-org-pfsite-footer-menu-list-item">

--- a/packages/v4/patternfly-docs/content/contribute/about/about.md
+++ b/packages/v4/patternfly-docs/content/contribute/about/about.md
@@ -13,7 +13,7 @@ PatternFly features go through a life-cycle development process that requires co
 
 ## PatternFly on GitHub
 PatternFly has a few repos you can contribute to:
-- [patternfly](https://github.com/patternfly/patternfly): For core HTML and CSS contributions. All component contributions should start in Core.
+- [patternfly](https://github.com/patternfly/patternfly) ("Core"): For core HTML and CSS contributions. All component contributions should start in Core.
 - [patternfly-react](https://github.com/patternfly/patternfly-react): For React contributions.
 - [patternfly-org](https://github.com/patternfly/patternfly-org): For PatternFly website content and design documentation contributions.
 

--- a/packages/v4/patternfly-docs/content/contribute/about/about.md
+++ b/packages/v4/patternfly-docs/content/contribute/about/about.md
@@ -5,11 +5,6 @@ section: contribute
 
 The PatternFly open source community depends on contributions to help our design system grow and evolve. We encourage everyone, regardless of background, to make suggestions for enhancements, contribute new design patterns and ideas, help identify bugs in code, and more. With your help, we can stay on top of the latest and greatest implementation solutions.  
 
-## PatternFly feature lifecycle
-
-PatternFly features go through a life-cycle development process that requires contributions from multiple disciplines including design, development, and content authoring. The typical feature lifecycle is illustrated below.
-
-![Contribution guide](./about-flowchart.png)
 
 ## PatternFly on GitHub
 PatternFly has a few repos you can contribute to:
@@ -17,7 +12,11 @@ PatternFly has a few repos you can contribute to:
 - [patternfly-react](https://github.com/patternfly/patternfly-react): For React contributions.
 - [patternfly-org](https://github.com/patternfly/patternfly-org): For PatternFly website content and design documentation contributions.
 
+## PatternFly feature lifecycle
 
+PatternFly features go through a life-cycle development process that requires contributions from multiple disciplines including design, development, and content authoring. The typical feature lifecycle is illustrated below.
+
+![Contribution guide](./about-flowchart.png)
 
 
 ## Get help

--- a/packages/v4/patternfly-docs/content/contribute/about/about.md
+++ b/packages/v4/patternfly-docs/content/contribute/about/about.md
@@ -5,24 +5,20 @@ section: contribute
 
 The PatternFly open source community depends on contributions to help our design system grow and evolve. We encourage everyone, regardless of background, to make suggestions for enhancements, contribute new design patterns and ideas, help identify bugs in code, and more. With your help, we can stay on top of the latest and greatest implementation solutions.  
 
+## PatternFly feature lifecycle
+
+PatternFly features go through a life-cycle development process that requires contributions from multiple disciplines including design, development, and content authoring. The typical feature lifecycle is illustrated below.
+
+![Contribution guide](./about-flowchart.png)
+
 ## PatternFly on GitHub
 PatternFly has a few repos you can contribute to:
 - [patternfly](https://github.com/patternfly/patternfly): For core HTML and CSS contributions. All component contributions should start in Core.
 - [patternfly-react](https://github.com/patternfly/patternfly-react): For React contributions.
 - [patternfly-org](https://github.com/patternfly/patternfly-org): For PatternFly website content and design documentation contributions.
 
-## Requesting new features and enhancements
-PatternFly is built on the needs of our community of stakeholders. To request a new feature or an enhancement to an existing feature, the first step is to open a new issue in the [patternfly-design repo](https://github.com/patternfly/patternfly-design/issues). Your issue should include the following:
-*    Requirements
-*    Use cases
-*    Preliminary designs (if available)
-*    Project timelines (dates needed, etc.)
 
-The PatternFly team will review and prioritize your issue, taking into account scope and technical constraints. If accepted, your feature request will be placed on the [PatternFly feature roadmap](https://github.com/orgs/patternfly/projects/4?fullscreen=true) and queued to the PatternFly design backlog. After this, the PatternFly design team will work with you to create a design proposal and facilitate reviews.
 
-### PatternFly feature lifecycle
-
-![Contribution guide](./about-flowchart.png)
 
 ## Get help
-If you run into trouble and need support, the PatternFly team is here to help. Simply go to the [PatternFly forum](https://forum.patternfly.org/c/support) and add a new topic to get in touch with us. We'll always do our best to answer your questions and connect you with the right people quickly.
+If you run into trouble and need support, the PatternFly team is here to help. Simply reach out to us on [Slack](https://patternfly.slack.com) to get in touch. We'll always do our best to answer your questions and connect you with the right people quickly.

--- a/packages/v4/patternfly-docs/content/get-started/about.md
+++ b/packages/v4/patternfly-docs/content/get-started/about.md
@@ -106,6 +106,6 @@ as well as relevant examples in the documentation are all labeled as beta.
 For more information about beta components, visit [this page](https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion).
 
 ## Requesting new features and enhancements
-PatternFly is built on the needs of our community of stakeholders. To request a new feature or an enhancement to an existing feature, the first step is to open a new discussion topic in the [PatternFly Feature Request discussion forum](https://github.com/orgs/patternfly/discussions/categories/feature-requests). 
+PatternFly is built on the needs of our community of stakeholders. To request a new feature or an enhancement to an existing feature, first open a new discussion topic in the [PatternFly Feature Request discussion forum](https://github.com/orgs/patternfly/discussions/categories/feature-requests). 
 
 The PatternFly team will review and prioritize your issue, taking into account scope and technical constraints. If accepted, your feature request will be placed on the PatternFly feature roadmap for fruther design and development. After this, the PatternFly design team will work with you to create a design proposal and facilitate reviews.

--- a/packages/v4/patternfly-docs/content/get-started/about.md
+++ b/packages/v4/patternfly-docs/content/get-started/about.md
@@ -104,3 +104,8 @@ for further updates pending testing and feedback, then the newly introduced CSS 
 as well as relevant examples in the documentation are all labeled as beta.
 
 For more information about beta components, visit [this page](https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion).
+
+## Requesting new features and enhancements
+PatternFly is built on the needs of our community of stakeholders. To request a new feature or an enhancement to an existing feature, the first step is to open a new discussion topic in the [PatternFly Feature Request discussion forum](https://github.com/orgs/patternfly/discussions/categories/feature-requests). 
+
+The PatternFly team will review and prioritize your issue, taking into account scope and technical constraints. If accepted, your feature request will be placed on the PatternFly feature roadmap for fruther design and development. After this, the PatternFly design team will work with you to create a design proposal and facilitate reviews.

--- a/packages/v4/patternfly-docs/content/get-started/about.md
+++ b/packages/v4/patternfly-docs/content/get-started/about.md
@@ -108,4 +108,4 @@ For more information about beta components, visit [this page](https://github.com
 ## Requesting new features and enhancements
 PatternFly is built on the needs of our community of stakeholders. To request a new feature or an enhancement to an existing feature, first open a new discussion topic in the [PatternFly Feature Request discussion forum](https://github.com/orgs/patternfly/discussions/categories/feature-requests). 
 
-The PatternFly team will review and prioritize your issue, taking into account scope and technical constraints. If accepted, your feature request will be placed on the PatternFly feature roadmap for fruther design and development. After this, the PatternFly design team will work with you to create a design proposal and facilitate reviews.
+The PatternFly team will review and prioritize your issue, taking into account scope and technical constraints. If accepted, your feature request will be placed on the PatternFly feature roadmap for further design and development. After this, the PatternFly design team will work with you to create a design proposal and facilitate reviews.

--- a/packages/v4/patternfly-docs/pages/community.js
+++ b/packages/v4/patternfly-docs/pages/community.js
@@ -55,7 +55,7 @@ const CommunityPage = () => {
             <img src={community2} alt="Map" className="ws-community-grid-img" />
             <Title size="xl" className="ws-title" headingLevel="h3">Building new features</Title>
             <p>
-              To continue to grow and improve our PatternFly component library, we welcome the ideas and contributions of our community. Visit our Disussions board to submit an idea or comment on or upvote an existing request.
+              To continue to grow and improve our PatternFly component library, we welcome ideas from our community. Visit our Disussions board to submit an idea, comment on, or upvote an existing request.
             </p>
             <Title size="xl" className="ws-title" headingLevel="h3">
               <a href="https://github.com/orgs/patternfly/discussions/categories/feature-requests"><strong>View or submit feature requests</strong></a>

--- a/packages/v4/patternfly-docs/pages/community.js
+++ b/packages/v4/patternfly-docs/pages/community.js
@@ -53,12 +53,12 @@ const CommunityPage = () => {
         <Card>
           <CardBody>
             <img src={community2} alt="Map" className="ws-community-grid-img" />
-            <Title size="xl" className="ws-title" headingLevel="h3">Building PatternFly roadmaps</Title>
+            <Title size="xl" className="ws-title" headingLevel="h3">Building new features</Title>
             <p>
-              To stay on top of all changes and keep everyone informed, we regularly update PatternFly roadmaps. This gives us an opportunity to share what Flyers are working on and what updates we’re planning.
+              To continue to grow and improve our PatternFly component library, we welcome the ideas and contributions of our community. Visit our Disussions board to submit an idea or comment on or upvote an existing request.
             </p>
             <Title size="xl" className="ws-title" headingLevel="h3">
-              <a href="https://github.com/orgs/patternfly/projects/4?fullscreen=true"><strong>Explore PatternFly roadmaps</strong></a>
+              <a href="https://github.com/orgs/patternfly/discussions/categories/feature-requests"><strong>View or submit feature requests</strong></a>
             </Title>
           </CardBody>
         </Card>

--- a/packages/v4/patternfly-docs/pages/community.js
+++ b/packages/v4/patternfly-docs/pages/community.js
@@ -55,7 +55,7 @@ const CommunityPage = () => {
             <img src={community2} alt="Map" className="ws-community-grid-img" />
             <Title size="xl" className="ws-title" headingLevel="h3">Building new features</Title>
             <p>
-              To continue to grow and improve our PatternFly component library, we welcome ideas from our community. Visit our Disussions board to submit an idea, comment on, or upvote an existing request.
+              To continue to grow and improve our PatternFly component library, we welcome ideas from our community. Visit our GitHub discussions board to submit an idea, comment on, or upvote an existing request.
             </p>
             <Title size="xl" className="ws-title" headingLevel="h3">
               <a href="https://github.com/orgs/patternfly/discussions/categories/feature-requests"><strong>View or submit feature requests</strong></a>

--- a/packages/v4/patternfly-docs/pages/community.js
+++ b/packages/v4/patternfly-docs/pages/community.js
@@ -118,7 +118,7 @@ const CommunityPage = () => {
             <SplitItem style={{ marginRight: '12px' }}><QuestionIcon /></SplitItem>
             <SplitItem isFilled>
               <Title size="lg" className="ws-title" headingLevel="h3">Ask a question</Title>
-              <a href="//forum.patternfly.org/" target="_blank" rel="noopener noreferrer">PatternFly forum</a>
+              <a href="//github.com/orgs/patternfly/discussions" target="_blank" rel="noopener noreferrer">PatternFly discussions</a>
             </SplitItem>
           </Split>
         </GridItem>


### PR DESCRIPTION
Move feature request instructions to the get-started/about page and replace references and links to the old PF Forum with links to GitHub Discussions. Updates include:

* Instructions about how to submit a feature request on Get Started/About
* Updates to the Community page to talk about requesting new features
* Change forum links to discussions in footer and Community page.