### PR TITLE
docs: fix minor typo in "React fundamentals training" page

### DIFF
--- a/packages/v4/patternfly-docs/content/training/react/fundamentals.md
+++ b/packages/v4/patternfly-docs/content/training/react/fundamentals.md
@@ -68,7 +68,7 @@ Add a close button to the `CardActions` component. Buttons communicate and trigg
 Add a button using the `plain` variant.
 
 <CopyCodeBlock>
-{`Button variant="plain"> </Button>`}
+{`<Button variant="plain"> </Button>`}
 </CopyCodeBlock>
 
 ### Step 2.3


### PR DESCRIPTION
Fixes a minor typo in the starting `<Button>` tag, at https://www.patternfly.org/v4/training/react-fundamentals-training/#step-2.2

![image](https://github.com/patternfly/patternfly-org/assets/4723983/457516dd-cba1-40ac-8a08-61b31cc92a99)
