### PR TITLE
feat(labels): add deprecated/demo/beta labels to headers + nav items

### DIFF
--- a/packages/documentation-framework/components/autoLinkHeader/autoLinkHeader.js
+++ b/packages/documentation-framework/components/autoLinkHeader/autoLinkHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Title } from '@patternfly/react-core';
+import { Title, Flex, FlexItem } from '@patternfly/react-core';
 import LinkIcon from '@patternfly/react-icons/dist/esm/icons/link-icon';
 import { Link } from '../link/link';
 import { slugger } from '../../helpers/slugger';
@@ -25,17 +25,22 @@ export const AutoLinkHeader = ({
   const slug = id || slugger(children);
 
   return (
-    <Title
-      id={slug}
-      size={sizes[size]}
-      headingLevel={headingLevel || size}
-      className={`ws-heading ${className}`}
-      tabIndex={-1}
-    >
-      <Link href={`#${slug}`} className="ws-heading-anchor" tabIndex="-1" aria-hidden>
-        <LinkIcon className="ws-heading-anchor-icon" style={{ verticalAlign: 'middle' }} />
-      </Link>
-      {children} {metaText}
-    </Title>
+    <Flex alignItems={{ default: 'alignItemsCenter'}} spaceItems={{ default: 'spaceItemsNone' }}>
+      <FlexItem>
+        <Title
+          id={slug}
+          size={sizes[size]}
+          headingLevel={headingLevel || size}
+          className={`ws-heading ${className}`}
+          tabIndex={-1}
+        >
+          <Link href={`#${slug}`} className="ws-heading-anchor" tabIndex="-1" aria-hidden>
+            <LinkIcon className="ws-heading-anchor-icon" style={{ verticalAlign: 'middle' }} />
+          </Link>
+          {children}
+        </Title>
+      </FlexItem>
+      <FlexItem>  {metaText}</FlexItem>
+    </Flex>
   )
 };

--- a/packages/documentation-framework/components/cssVariables/cssVariables.js
+++ b/packages/documentation-framework/components/cssVariables/cssVariables.js
@@ -8,6 +8,7 @@ import {
   Tbody,
   Td
 } from "@patternfly/react-table";
+import { AutoLinkHeader } from "../autoLinkHeader/autoLinkHeader";
 import * as tokensModule from "@patternfly/react-tokens/dist/esm/componentIndex";
 import global_spacer_md from "@patternfly/react-tokens/dist/esm/global_spacer_md";
 import LevelUpAltIcon from "@patternfly/react-icons/dist/esm/icons/level-up-alt-icon";
@@ -59,12 +60,9 @@ const flattenList = files => {
 export class CSSVariables extends React.Component {
   constructor(props) {
     super(props);
-    // Ensure array in case of multiple prefixes
-    this.prefix =
-      typeof props.prefix === "string" ? [props.prefix] : props.prefix;
-    const prefixTokens = this.prefix.map(prefix => prefix.replace("pf-", "").replace(/-+/g, "_"));
+    const prefixToken = props.prefix.replace("pf-v5-", "").replace(/-+/g, "_");
     const applicableFiles = Object.entries(tokensModule)
-      .filter(([key, val]) => prefixTokens.includes(key))
+      .filter(([key, val]) => prefixToken === key)
       .sort(([key1], [key2]) => key1.localeCompare(key2))
       .map(([key, val]) => {
         if (props.selector) {
@@ -170,10 +168,11 @@ export class CSSVariables extends React.Component {
   render() {
     return (
       <React.Fragment>
+        {this.props.autoLinkHeader && <AutoLinkHeader size="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-md">{`Prefixed with '${this.props.prefix}'`}</AutoLinkHeader>}
         <CSSSearch getDebouncedFilteredRows={this.getDebouncedFilteredRows} />
         <Table
           variant="compact"
-          aria-label={`CSS Variables for prefixes ${this.prefix.join(" ")}`}
+          aria-label={`CSS Variables prefixed with ${this.props.prefix}`}
         >
           <Thead>
             <Tr>

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLocation } from '@reach/router';
-import { Badge, CodeBlock, CodeBlockCode, debounce, Switch } from '@patternfly/react-core';
+import { Button, CodeBlock, CodeBlockCode, debounce, Label, Switch, Tooltip } from '@patternfly/react-core';
 import * as reactCoreModule from '@patternfly/react-core';
 import * as reactCoreNextModule from '@patternfly/react-core/next';
 import * as reactCoreDeprecatedModule from '@patternfly/react-core/deprecated';
@@ -71,7 +71,11 @@ export const Example = ({
   // The image src thumbnail for the example
   thumbnail = missingThumbnail,
   // Whether the example shows demo capability
+  isDemo,
+  // Whether the example is open to further evolution
   isBeta,
+  // Whether the example is deprecated
+  isDeprecated,
   // Slugified source + title
   id,
   // Section in frontmatter of MD file (components, demos, etc)
@@ -173,12 +177,36 @@ export const Example = ({
     + (loc.pathname.endsWith(source) ? '' : `/${source}`)
     + '/'
     + slugger(title);
-    
+
   return (
     <div className="ws-example">
       <div className="ws-example-header">
         <AutoLinkHeader
-          metaText={isBeta && <Badge className="ws-beta-badge pf-v5-u-ml-xs">Beta</Badge>}
+          metaText={
+            <React.Fragment>
+              {isBeta && (
+                <Tooltip content="This beta component is currently under review and is still open for further evolution.">
+                  <Button variant="plain">
+                    <Label isCompact color="blue">Beta</Label>
+                  </Button>
+                </Tooltip>
+              )}
+              {isDemo && (
+                <Tooltip content="Demos show how multiple components can be used in a single design.">
+                  <Button variant="plain">
+                    <Label isCompact color="purple">Demo</Label>
+                  </Button>
+                </Tooltip>
+              )}
+              {isDeprecated && (
+                <Tooltip content="Deprecated components are available for use but are no longer being maintained or enhanced.">
+                  <Button variant="plain">
+                    <Label isCompact color="grey">Deprecated</Label>
+                  </Button>
+                </Tooltip>
+              )}
+            </React.Fragment>
+          }
           size="h4"
           headingLevel="h3"
           className="ws-example-heading"

--- a/packages/documentation-framework/components/sideNav/sideNav.js
+++ b/packages/documentation-framework/components/sideNav/sideNav.js
@@ -33,7 +33,7 @@ const NavItem = ({ text, href, isDeprecated, isBeta, isDemo }) => {
               }
               tabIndex={isNavOpen ? undefined : -1}
             >
-              <Flex>
+              <Flex spaceItems={{ default: 'spaceItemsSm'}}>
                 <FlexItem>{text}</FlexItem>
                 {(isBeta || isDemo || isDeprecated) && (
                   <FlexItem>

--- a/packages/documentation-framework/components/sideNav/sideNav.js
+++ b/packages/documentation-framework/components/sideNav/sideNav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from '../link/link';
-import { Nav, NavList, NavExpandable, PageContextConsumer, capitalize } from '@patternfly/react-core';
+import { Label, Nav, NavList, NavExpandable, PageContextConsumer, capitalize, Flex, FlexItem } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { Location } from '@reach/router';
 import { makeSlug } from '../../helpers';
@@ -14,7 +14,7 @@ const getIsActive = (location, section, subsection = null) => {
 
 const defaultValue = 50;
 
-const NavItem = ({ text, href }) => {
+const NavItem = ({ text, href, isDeprecated, isBeta, isDemo }) => {
   const isMobileView = window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
   return (
     <PageContextConsumer key={href + text}>
@@ -33,7 +33,18 @@ const NavItem = ({ text, href }) => {
               }
               tabIndex={isNavOpen ? undefined : -1}
             >
-              {text}
+              <Flex>
+                <FlexItem>{text}</FlexItem>
+                {(isBeta || isDemo || isDeprecated) && (
+                  <FlexItem>
+                    {isBeta && (<Label color="blue" isCompact>Beta</Label>)}
+                    {!isBeta && isDemo && (<Label color="purple" isCompact>Demo</Label>)}
+                    {!isBeta && !isDemo && isDeprecated && (<Label color="grey" isCompact>Deprecated</Label>)}
+                  </FlexItem>
+                )}
+              </Flex>
+
+
             </Link>
           </li>
       )}
@@ -70,7 +81,7 @@ const ExpandableNav = ({groupedRoutes, location, section, subsection = null}) =>
     >
       {Object.entries(routes || {})
         .filter(([id, navObj]) => !Boolean(navObj.hideNavItem) && (Object.entries(navObj).length > 0))
-        .map(([id, { slug, isSubsection = false, sortValue = defaultValue, subsectionSortValue = defaultValue }]) => ({ text: id, href: slug, isSubsection, sortValue: (isSubsection ? subsectionSortValue : sortValue) }))
+        .map(([id, { slug, isSubsection = false, sortValue = defaultValue, subsectionSortValue = defaultValue, sources }]) => ({ text: id, href: slug, isSubsection, sortValue: (isSubsection ? subsectionSortValue : sortValue), sources }))
         .sort(({text: text1, sortValue: sortValue1}, {text: text2, sortValue: sortValue2}) => {
           if (sortValue1 === sortValue2) {
             return text1.localeCompare(text2);
@@ -78,10 +89,14 @@ const ExpandableNav = ({groupedRoutes, location, section, subsection = null}) =>
           return sortValue1 > sortValue2 ? 1 : -1;
         })
         .map(navObj => navObj.isSubsection
-          ? ExpandableNav({groupedRoutes, location, section, subsection: navObj.text})
-          : NavItem(navObj)
-        )
-      }
+            ? ExpandableNav({groupedRoutes, location, section, subsection: navObj.text})
+            : NavItem({
+              ...navObj,
+              isDeprecated: navObj.href?.includes('components') && navObj.sources.some(source => source.source === "react-deprecated") && !navObj.sources.some(source => source.source === "react"),
+              isBeta: navObj.sources.some(source => source.beta),
+              isDemo: navObj.sources.some(source => source.source === "react-demos" || source.source === "html-demos") && !navObj.sources.some(source => source.source === "react" || source.source === "html")
+            })
+        )}
     </NavExpandable>
   );
 }
@@ -101,7 +116,7 @@ export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
       lastElement.scrollIntoView({ block: 'center' });
     }
   }, []);
-  
+
   return (
     <Nav aria-label="Side Nav" theme="light">
       <NavList className="ws-side-nav-list">

--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -84,10 +84,10 @@
     "webpack-merge": "5.8.0"
   },
   "peerDependencies": {
-    "@patternfly/patternfly": "^5.0.0-alpha.46",
-    "@patternfly/react-code-editor": "^5.0.0-alpha.92",
-    "@patternfly/react-core": "^5.0.0-alpha.91",
-    "@patternfly/react-table": "^5.0.0-alpha.93",
+    "@patternfly/patternfly": "^5.0.0-alpha.64",
+    "@patternfly/react-code-editor": "^5.0.0-alpha.116",
+    "@patternfly/react-core": "^5.0.0-alpha.115",
+    "@patternfly/react-table": "^5.0.0-alpha.117",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   }

--- a/packages/documentation-framework/routes.js
+++ b/packages/documentation-framework/routes.js
@@ -78,10 +78,8 @@ const groupedRoutes = Object.entries(routes)
 const sourceOrder = {
   react: 1,
   'react-next': 1.1,
-  'react-composable': 1.2,
-  'react-deprecated': 1.3,
-  'react-legacy': 1.4,
   'react-demos': 2,
+  'react-deprecated': 2.1,
   html: 3,
   'html-demos': 4,
   'design-guidelines': 99,

--- a/packages/documentation-framework/scripts/md/parseMD.js
+++ b/packages/documentation-framework/scripts/md/parseMD.js
@@ -104,6 +104,9 @@ function toReactComponent(mdFilePath, source, buildMode) {
         id: frontmatter.id,
         section: frontmatter.section || '',
         subsection: frontmatter.subsection || '',
+        deprecated: frontmatter.deprecated || false,
+        beta: frontmatter.beta || false,
+        demo: frontmatter.demo || false,
         source,
         tabName: frontmatter.tabName || null,
         slug,
@@ -132,9 +135,6 @@ function toReactComponent(mdFilePath, source, buildMode) {
       }
       if (frontmatter.optIn) {
         pageData.optIn = frontmatter.optIn;
-      }
-      if (frontmatter.beta) {
-        pageData.beta = frontmatter.beta;
       }
       if (frontmatter.cssPrefix) {
         pageData.cssPrefix = Array.isArray(frontmatter.cssPrefix)
@@ -293,6 +293,8 @@ function sourceMDFile(file, source, buildMode) {
       tabName: pageData.tabName,
       ...(pageData.hideNavItem && { hideNavItem: pageData.hideNavItem }),
       ...(pageData.beta && { beta: pageData.beta }),
+      ...(pageData.deprecated && { deprecated: pageData.deprecated }),
+      ...(pageData.demo && { demo: pageData.demo }),
       ...(pageData.sortValue && { sortValue: pageData.sortValue }),
       ...(pageData.subsectionSortValue && { subsectionSortValue: pageData.subsectionSortValue })
     };

--- a/packages/documentation-framework/scripts/md/parseMD.js
+++ b/packages/documentation-framework/scripts/md/parseMD.js
@@ -107,6 +107,7 @@ function toReactComponent(mdFilePath, source, buildMode) {
         deprecated: frontmatter.deprecated || false,
         beta: frontmatter.beta || false,
         demo: frontmatter.demo || false,
+        newImplementationLink: frontmatter.newImplementationLink || false,
         source,
         tabName: frontmatter.tabName || null,
         slug,

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PageSection, Title, PageSectionVariants, BackToTop, PageGroup, Page, Text, TextContent } from '@patternfly/react-core';
+import { PageSection, Title, Tooltip, PageSectionVariants, Button, BackToTop, Flex, FlexItem, PageGroup, Page, Text, TextContent, Label } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Router, useLocation } from '@reach/router';
@@ -22,6 +22,8 @@ const MDXChildTemplate = ({
     cssPrefix = [],
     optIn,
     beta,
+    deprecated,
+    newImplementationLink,
     functionDocumentation = []
   } = Component.getPageData();
   const cssVarsTitle = cssPrefix.length > 0 && 'CSS variables';
@@ -60,9 +62,19 @@ const MDXChildTemplate = ({
           To learn more about the process, visit our <Link to="/get-started/about#beta-components">about page</Link> or our <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">Beta components</a> page on GitHub.
         </InlineAlert>
       )}
+      {deprecated && (
+        <InlineAlert title="Deprecated feature" variant="warning">
+          This implementation has been deprecated in favor of a newer implementation, and is no longer getting maintained or enhanced.
+          {newImplementationLink && (
+            <React.Fragment>
+              You can find the <Link to={newImplementationLink}>updated implementation here</Link>.
+            </React.Fragment>
+          )}
+          To learn more about the process, visit our <Link to="/get-started/about#major-release-cadence">about page</Link>.
+        </InlineAlert>
+      )}
     </React.Fragment>
   );
-  console.log(id);
   // Create dynamic component for @reach/router
   const ChildComponent = () => (
     <div className="pf-v5-u-display-flex ws-mdx-child-template">
@@ -126,6 +138,9 @@ export const MDXTemplate = ({
   id,
   componentsData
 }) => {
+  const isDeprecated = sources.some(source => source.source === "react-deprecated") && !sources.some(source => source.source === "react");
+  const isBeta = sources.some(source => source.beta)
+  const isDemo = sources.some(source => source.source === "react-demos" || source.source === "html-demos") && !sources.some(source => source.source === "react" || source.source === "html");
   // Build obj mapping source names to text displayed on tabs
   const tabNames = sources.reduce((acc, curSrc) => {
     const { source, tabName } = curSrc;
@@ -137,7 +152,7 @@ export const MDXTemplate = ({
   const sourceKeys = Object.keys(tabNames);
   const isSinglePage = sourceKeys.length === 1;
 
-  let isDevResources, isComponent, isExtension, isChart, isDemo, isLayout, isUtility;
+  let isDevResources, isComponent, isExtension, isChart, isPattern, isLayout, isUtility;
 
   const getSection = () => {
     return sources.some((source) => {
@@ -154,8 +169,8 @@ export const MDXTemplate = ({
         case "charts":
           isChart = true;
           return;
-        case "demos":
-          isDemo = true;
+        case "patterns":
+          isPattern = true;
           return;
         case "layouts":
           isLayout = true;
@@ -198,7 +213,7 @@ export const MDXTemplate = ({
         return "pf-m-light-100";
       }
       return "pf-m-light";
-    } else if (isUtility || isDemo || isLayout || isComponent) {
+    } else if (isUtility || isPattern || isLayout || isComponent) {
       return "pf-m-light";
     }
     return "pf-m-light-100";
@@ -208,10 +223,9 @@ export const MDXTemplate = ({
     (!isSinglePage && !hideTabName) ||
     isComponent ||
     isUtility ||
-    isDemo
+    isPattern
   );
 
-  console.log(id);
   return (
     <React.Fragment>
       <PageGroup>
@@ -221,7 +235,44 @@ export const MDXTemplate = ({
           isWidthLimited
         >
           <TextContent>
-            <Title headingLevel='h1' size='4xl' id="ws-page-title">{title}</Title>
+            <Flex alignItems={{ default: 'alignItemsCenter'}}>
+              <FlexItem>
+                <Title headingLevel='h1' size='4xl' id="ws-page-title">
+                  {title}
+                </Title>
+              </FlexItem>
+              <FlexItem>
+                <Flex display={{ default: 'inlineFlex' }}>
+                  {isDeprecated && (
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                      <Tooltip content="Deprecated components are available for use, but are no longer being enhanced">
+                        <Button isInline component="span" variant="link">
+                          <Label color="grey">Deprecated</Label>
+                        </Button>
+                      </Tooltip>
+                    </FlexItem>
+                  )}
+                  {isDemo && (
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                      <Tooltip content="Demos show how multiple components can be used in a single design">
+                        <Button isInline component="span" variant="link">
+                          <Label color="purple">Demo</Label>
+                        </Button>
+                      </Tooltip>
+                    </FlexItem>
+                  )}
+                  {isBeta && (
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                      <Tooltip content="This beta component is currently under review and is still open for further evolution">
+                        <Button isInline component="span" variant="link">
+                          <Label color="blue">Beta</Label>
+                        </Button>
+                      </Tooltip>
+                    </FlexItem>
+                  )}
+                </Flex>
+              </FlexItem>
+            </Flex>
             {isComponent && summary && (<SummaryComponent />)}
           </TextContent>
         </PageSection>

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -62,7 +62,7 @@ const MDXChildTemplate = ({
           To learn more about the process, visit our <Link to="/get-started/about#beta-components">about page</Link> or our <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">Beta components</a> page on GitHub.
         </InlineAlert>
       )}
-      {deprecated && (
+      {(deprecated || source === 'react-deprecated') && (
         <InlineAlert title="Deprecated feature" variant="warning">
           This implementation has been deprecated in favor of a newer implementation, and is no longer getting maintained or enhanced.
           {newImplementationLink && (

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -60,9 +60,7 @@ const MDXChildTemplate = ({
       )}
       {beta && (
         <InlineAlert title="Beta feature">
-          This beta component is currently under review and is still open for further evolution. It is available for use in product.
-          Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>.
-          To learn more about the process, visit our <Link to="/get-started/about#beta-components">about page</Link> or our <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">Beta components</a> page on GitHub.
+          This beta component is currently under review and is still open for further evolution. It is available for use in product. Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>. To learn more about the process, visit our <Link to="/get-started/about#beta-components">about page</Link> or our <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">Beta components</a> page on GitHub.
         </InlineAlert>
       )}
       {(deprecated || source === 'react-deprecated') && (
@@ -73,7 +71,7 @@ const MDXChildTemplate = ({
               You can find the <Link to={newImplementationLink}>updated implementation here</Link>.
             </React.Fragment>
           )}
-          To learn more about the process, visit our <Link to="/get-started/about#major-release-cadence">about page</Link>.
+          {' '}To learn more about the process, visit our <Link to="/get-started/about#major-release-cadence">about page</Link>.
         </InlineAlert>
       )}
     </React.Fragment>
@@ -250,7 +248,7 @@ export const MDXTemplate = ({
                 <Flex display={{ default: 'inlineFlex' }}>
                   {isDeprecated && (
                     <FlexItem spacer={{ default: 'spacerSm' }}>
-                      <Tooltip content="Deprecated components are available for use, but are no longer being enhanced">
+                      <Tooltip content="Deprecated components are available for use but are no longer being maintained or enhanced.">
                         <Button isInline component="span" variant="link">
                           <Label color="grey">Deprecated</Label>
                         </Button>
@@ -259,7 +257,7 @@ export const MDXTemplate = ({
                   )}
                   {isDemo && (
                     <FlexItem spacer={{ default: 'spacerSm' }}>
-                      <Tooltip content="Demos show how multiple components can be used in a single design">
+                      <Tooltip content="Demos show how multiple components can be used in a single design.">
                         <Button isInline component="span" variant="link">
                           <Label color="purple">Demo</Label>
                         </Button>
@@ -268,7 +266,7 @@ export const MDXTemplate = ({
                   )}
                   {isBeta && (
                     <FlexItem spacer={{ default: 'spacerSm' }}>
-                      <Tooltip content="This beta component is currently under review and is still open for further evolution">
+                      <Tooltip content="This beta component is currently under review and is still open for further evolution.">
                         <Button isInline component="span" variant="link">
                           <Label color="blue">Beta</Label>
                         </Button>

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -34,6 +34,9 @@ const MDXChildTemplate = ({
   }
   if (cssVarsTitle && !toc.find(item => item.text === cssVarsTitle)) {
     toc.push({ text: cssVarsTitle });
+    if (cssPrefix.length > 1) {
+      toc.push(cssPrefix.map(cssPrefix => ({ text: `Prefixed with '${cssPrefix}'` })));
+    }
   }
   // We don't add `id`s in anchor-header.js for items where id === slugger(text)
   // in order to save ~10KB bandwidth.
@@ -109,12 +112,14 @@ const MDXChildTemplate = ({
               ))}
             </React.Fragment>
           )}
-          {cssVarsTitle && (
+          {cssPrefix.length > 0 && (
             <React.Fragment>
               <AutoLinkHeader size="h2" className="ws-h2" id="css-variables">
                 {cssVarsTitle}
               </AutoLinkHeader>
-              <CSSVariables prefix={cssPrefix} />
+              {cssPrefix.map(prefix => (
+                <CSSVariables autoLinkHeader={cssPrefix.length > 1} prefix={prefix} />
+              ))}
             </React.Fragment>
           )}
           {sourceLink && (

--- a/packages/v4/package.json
+++ b/packages/v4/package.json
@@ -21,7 +21,7 @@
     "@patternfly/quickstarts": "^2.4.0",
     "@patternfly/react-catalog-view-extension": "5.0.0-alpha.1",
     "@patternfly/react-console": "^5.0.0-alpha.1",
-    "@patternfly/react-docs": "6.0.0-alpha.98",
+    "@patternfly/react-docs": "6.0.0-alpha.123",
     "@patternfly/react-log-viewer": "4.87.100",
     "@patternfly/react-topology": "^4.91.40",
     "react": "^17.0.0 || ^18.0.0",

--- a/packages/v4/patternfly-a11y.config.js
+++ b/packages/v4/patternfly-a11y.config.js
@@ -67,5 +67,5 @@ module.exports = {
     }
   ],
   ignoreIncomplete: true,
-  skip: '(mailto)|(/(react|react-next|react-demos|react-legacy|react-composable|html|html-demos)/.+)|(/react$)'
+  skip: '(mailto)|(/(react|react-next|react-demos|react-deprecated|html|html-demos)/.+)|(/react$)'
 };

--- a/packages/v4/patternfly-docs/content/get-started/about.md
+++ b/packages/v4/patternfly-docs/content/get-started/about.md
@@ -104,3 +104,15 @@ for further updates pending testing and feedback, then the newly introduced CSS 
 as well as relevant examples in the documentation are all labeled as beta.
 
 For more information about beta components, visit [this page](https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion).
+
+### Major release cadence
+
+Currently, PatternFly plans to release a new major release each June. Major releases will be the only releases with 
+planned breaking changes. Along with each major release, the PatternFly team will provide thorough migration guides and 
+code mods to aid product teams in upgrading.
+
+Periodically, previews of updated React implementations of PatternFly components will be made available under a 'React 
+next' tab in the component docs. During major releases, these React next implementations may be promoted to the
+recommended implementation. In such instances, the previous implementation will be marked deprecated. Any deprecated 
+implementation of components will remain available (though will not be further enhanced or maintained) until at least 
+the subsequent major release.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,10 +2490,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.222.4.tgz#5d988779c50df3dafc989d6e807d16971e34d228"
   integrity sha512-+0fk4dzxEbWn+hgaOnR0BjfeUdEeVVrqfH7+GFeFc+RKjEMjIR/BZbWWN8YQDezmDv6A32gHmEKaY3Uwbt06Lw==
 
-"@patternfly/patternfly@5.0.0-alpha.46":
-  version "5.0.0-alpha.46"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-5.0.0-alpha.46.tgz#08d4102019bf97e923067198d1032304db5a3c7c"
-  integrity sha512-170dUkmqQOeO7TAv/GT14fTMV1zKwe/vcCkP29XEGsmJT/WshCvcd6LjfZ4esFgckZMcc5G4IlHCRZRuA///OA==
+"@patternfly/patternfly@5.0.0-alpha.64":
+  version "5.0.0-alpha.64"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-5.0.0-alpha.64.tgz#15832ce41048d9e5d89446ce6d4edaf07f308899"
+  integrity sha512-VJOCpS/WyhjkKqoaCo3usQxoXAj90p81NDHDE3/4/xTUYb53xNNXDJ1YwkPkG0RDvs6DaS9U/hEmu1AbCa9VEw==
 
 "@patternfly/quickstarts@^2.4.0":
   version "2.4.0"
@@ -2522,13 +2522,13 @@
     "@patternfly/react-core" "^4.267.6"
     "@patternfly/react-styles" "^4.92.3"
 
-"@patternfly/react-charts@^7.0.0-alpha.23":
-  version "7.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-7.0.0-alpha.23.tgz#cb5c72115a08e2ccf09520d2dc168ab9ec41c50e"
-  integrity sha512-CNnxE9mbWjjRWCSwVTaETIJpVjBPfC/lXpIFLvhMQiaExMLTvscYGSD8xyYD1yBgRuLdaXlqyp1EUxdFiQWxSg==
+"@patternfly/react-charts@^7.0.0-alpha.31":
+  version "7.0.0-alpha.31"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-7.0.0-alpha.31.tgz#e4054a9d6a1103416a6849f3522595d20703180f"
+  integrity sha512-yquGxVanDkfLFIssKaXL1klz1acraldQtR2ocDvXAzzPz55dye0BxOhmIQ/ALuftzbeHw1vfWCNaAqtSLWULjQ==
   dependencies:
-    "@patternfly/react-styles" "^5.0.0-alpha.10"
-    "@patternfly/react-tokens" "^5.0.0-alpha.9"
+    "@patternfly/react-styles" "^5.0.0-alpha.16"
+    "@patternfly/react-tokens" "^5.0.0-alpha.14"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "^2.5.0"
@@ -2550,14 +2550,14 @@
     victory-voronoi-container "^36.6.10"
     victory-zoom-container "^36.6.10"
 
-"@patternfly/react-code-editor@^5.0.0-alpha.92":
-  version "5.0.0-alpha.92"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-5.0.0-alpha.92.tgz#733838c052dcae8fa9438068b751565209d301c1"
-  integrity sha512-RQ73HO9DYMky8G5Q9psLr1pDJCsESLPJDkR0Gl1qvabz76CXZ4YKJ0KAGIowiC4B7FwgHctxfYGGUPpiJ4s9Zg==
+"@patternfly/react-code-editor@^5.0.0-alpha.116":
+  version "5.0.0-alpha.116"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-5.0.0-alpha.116.tgz#396a6eeb7d442ac1089e9fc75f257805b0b2c726"
+  integrity sha512-uuSSgwVdyIas8zIqAqMrrexrk77nTwhU7RrX36tpKBHqfTHkGnRa+covbR4RDdOZmaaM+TpOAMPEfIau4LrHBA==
   dependencies:
-    "@patternfly/react-core" "^5.0.0-alpha.91"
-    "@patternfly/react-icons" "^5.0.0-alpha.14"
-    "@patternfly/react-styles" "^5.0.0-alpha.10"
+    "@patternfly/react-core" "^5.0.0-alpha.115"
+    "@patternfly/react-icons" "^5.0.0-alpha.19"
+    "@patternfly/react-styles" "^5.0.0-alpha.16"
     react-dropzone "14.2.3"
     tslib "^2.5.0"
 
@@ -2600,6 +2600,18 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
+"@patternfly/react-core@^5.0.0-alpha.115":
+  version "5.0.0-alpha.115"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.0.0-alpha.115.tgz#e25b56e3b4fa44675d8ce8f764742e5fc6cb435e"
+  integrity sha512-hkpu7KbUeMGukuF34QxOuTHUd5EnVuhH5VZ0S9IaOrgRiXnK/xZsf5YQPj/2TL4lx8QOPiOOzDzvxLgpNSYaBQ==
+  dependencies:
+    "@patternfly/react-icons" "^5.0.0-alpha.19"
+    "@patternfly/react-styles" "^5.0.0-alpha.16"
+    "@patternfly/react-tokens" "^5.0.0-alpha.14"
+    focus-trap "7.4.2"
+    react-dropzone "^14.2.3"
+    tslib "^2.5.0"
+
 "@patternfly/react-core@^5.0.0-alpha.50":
   version "5.0.0-alpha.59"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.0.0-alpha.59.tgz#113de42c9ca6c90dedeaec88dc50b0fd1043d5ea"
@@ -2612,41 +2624,29 @@
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-core@^5.0.0-alpha.91":
-  version "5.0.0-alpha.91"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.0.0-alpha.91.tgz#ce0bbb9a207bf345be8cb99f0a261623779a4ce9"
-  integrity sha512-1OoSTjEVG/Lm+1u2msiEBc3Y71HeFPjWmC84RQaIOOBH/qlNBIrcIiyWIhJYW2c0VkVKT5A0scnsn+Cy6k+x5g==
+"@patternfly/react-docs@6.0.0-alpha.123":
+  version "6.0.0-alpha.123"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-6.0.0-alpha.123.tgz#03ca1b7280fdced9bf7cb6eeb081b6b2e1ae387c"
+  integrity sha512-cypm9dTcoF+G6v9vtmSEzp3ghhW8KOT8zgE1tpcD4fdJ/lpGssMedJIc/WqMJmvSPKf+euS5Q431EPnPCghPow==
   dependencies:
-    "@patternfly/react-icons" "^5.0.0-alpha.14"
-    "@patternfly/react-styles" "^5.0.0-alpha.10"
-    "@patternfly/react-tokens" "^5.0.0-alpha.9"
-    focus-trap "7.4.0"
-    react-dropzone "^14.2.3"
-    tslib "^2.5.0"
-
-"@patternfly/react-docs@6.0.0-alpha.98":
-  version "6.0.0-alpha.98"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-6.0.0-alpha.98.tgz#954d09f9fde6a0b2cded80bc5ada2c06edc6d197"
-  integrity sha512-frt0lC9+RySUB78g3jfrzNdC4p0OpioouAxzrX7MTFhvS2u4PN67pqDjgyA8CTC6kpbzeLMqUYkH4lDxM7g94A==
-  dependencies:
-    "@patternfly/patternfly" "5.0.0-alpha.46"
-    "@patternfly/react-charts" "^7.0.0-alpha.23"
-    "@patternfly/react-code-editor" "^5.0.0-alpha.92"
-    "@patternfly/react-core" "^5.0.0-alpha.91"
-    "@patternfly/react-icons" "^5.0.0-alpha.14"
-    "@patternfly/react-styles" "^5.0.0-alpha.10"
-    "@patternfly/react-table" "^5.0.0-alpha.93"
-    "@patternfly/react-tokens" "^5.0.0-alpha.9"
+    "@patternfly/patternfly" "5.0.0-alpha.64"
+    "@patternfly/react-charts" "^7.0.0-alpha.31"
+    "@patternfly/react-code-editor" "^5.0.0-alpha.116"
+    "@patternfly/react-core" "^5.0.0-alpha.115"
+    "@patternfly/react-icons" "^5.0.0-alpha.19"
+    "@patternfly/react-styles" "^5.0.0-alpha.16"
+    "@patternfly/react-table" "^5.0.0-alpha.117"
+    "@patternfly/react-tokens" "^5.0.0-alpha.14"
 
 "@patternfly/react-icons@^4.93.4", "@patternfly/react-icons@^4.93.6":
   version "4.93.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.6.tgz#4aff18724afa30157e3ffd6a6414951dbb39dcb3"
   integrity sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==
 
-"@patternfly/react-icons@^5.0.0-alpha.14":
-  version "5.0.0-alpha.14"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.0.0-alpha.14.tgz#32997dac8675d6024112f49111e2b2fbc8874105"
-  integrity sha512-+FXETYc+x0xKqktrcgrpxPTZgtaJ6rfpObu/qM4YGuwXkJRIu0OJaoNQTPH9QsxKAeZ+VUh9CnhOcNTRfq9plA==
+"@patternfly/react-icons@^5.0.0-alpha.19":
+  version "5.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.0.0-alpha.19.tgz#b94cc9352f5d2a11b8887fb9dc0732cc24c829ef"
+  integrity sha512-jyVSK6f9ueIO+pI2K2njI/4qdQR9WK953IUJtQ6PtNhLHKsAHOnqwHjBUrqxWOBZ+ty5MpqHPoB9Yd34i8vcxg==
 
 "@patternfly/react-icons@^5.0.0-alpha.9":
   version "5.0.0-alpha.9"
@@ -2675,25 +2675,25 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
   integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
 
-"@patternfly/react-styles@^5.0.0-alpha.10":
-  version "5.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-alpha.10.tgz#8946aa074ebdc3d7e3892c175c86cfc1a0096b0c"
-  integrity sha512-SJsLPtTKE1u6YpEAvx+zUre+u9poc/IIIKJ9dk0Jze94HtC/2kI4fhhvm2iQE5Z4rNAPrFlC4fVsvbr7skS3kg==
+"@patternfly/react-styles@^5.0.0-alpha.16":
+  version "5.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-alpha.16.tgz#d26453c44637c122f141c2fe1f0ba1f48e52282b"
+  integrity sha512-RxU8sSKY0tM40xZwk+BR5vWotP+LZOH2vqdNFEIT7a1+1Kr9qSm5ktq34gnzK0nyWUaH08qL9da4HVo3/O+R4A==
 
 "@patternfly/react-styles@^5.0.0-alpha.5", "@patternfly/react-styles@^5.0.0-alpha.6":
   version "5.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-alpha.6.tgz#8ad025291180d840ba376553d597d1a835a3858b"
   integrity sha512-bhhCFXJud5V3sXnDsPFFQ9QInwEyGdn8EjH+bKAJ2880rYeHL0Njhorzd7wbEvXE5yD2aA4LlNM3YCB66wraoQ==
 
-"@patternfly/react-table@^5.0.0-alpha.93":
-  version "5.0.0-alpha.93"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.0.0-alpha.93.tgz#7feef799cb8116df56633b2d0c010470904f910a"
-  integrity sha512-PMXChFiAb6N2m6filItokMsscRWu5r9LzGRrO1Ka1zMCVPMI3HEGAVh8WctLy/164W6d0cGJgpI6jQRwI6R3xw==
+"@patternfly/react-table@^5.0.0-alpha.117":
+  version "5.0.0-alpha.117"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.0.0-alpha.117.tgz#4a30f8f6996e362d0029ec92b4504bb2973d2f43"
+  integrity sha512-CnJEV6PzR4XpP9dQq0HRu4/w7g2vZErbuCtlCwaErhRopt8SH7EN5UeZ2AsdjwxjgOv9kuIq8HLr3ir6icMFjg==
   dependencies:
-    "@patternfly/react-core" "^5.0.0-alpha.91"
-    "@patternfly/react-icons" "^5.0.0-alpha.14"
-    "@patternfly/react-styles" "^5.0.0-alpha.10"
-    "@patternfly/react-tokens" "^5.0.0-alpha.9"
+    "@patternfly/react-core" "^5.0.0-alpha.115"
+    "@patternfly/react-icons" "^5.0.0-alpha.19"
+    "@patternfly/react-styles" "^5.0.0-alpha.16"
+    "@patternfly/react-tokens" "^5.0.0-alpha.14"
     lodash "^4.17.19"
     tslib "^2.5.0"
 
@@ -2702,15 +2702,15 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz#47c715721ad3dd315a523f352ba1a0de2b03f0bc"
   integrity sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==
 
+"@patternfly/react-tokens@^5.0.0-alpha.14":
+  version "5.0.0-alpha.14"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.0.0-alpha.14.tgz#fe7b61565041eebf2dc624ff8087818d1d8a0554"
+  integrity sha512-RWMKRYA+616XRWQLu5o5S0tFrE5koJW0QcE9ErZuFoWmojwJ/6bg9nAWbGxzR4xwAz2ERu2Tg50fqy5vQeOhWA==
+
 "@patternfly/react-tokens@^5.0.0-alpha.6":
   version "5.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.0.0-alpha.6.tgz#fda99c6f25386eab2c85d3118554fdde96db782d"
   integrity sha512-QYea/Y8Jj2feqlaDFCAspds/FQ+/fK8bcd8Q5bFcRiQ+Z0Prw62JuW1OPVi9Bx1xACsZ0FHRbW4iQKXQGLvKBA==
-
-"@patternfly/react-tokens@^5.0.0-alpha.9":
-  version "5.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.0.0-alpha.9.tgz#37898e47b2fe8c3f1cfda24cf54875fff58b00f9"
-  integrity sha512-8P8u9BJdQmiunZbGAlDIunlGI6D4V81YZA16z9hw5qXReWztWyF9IXXB4L6lG5+VJZEnocBpJPenNJ1n1FmiBQ==
 
 "@patternfly/react-topology@^4.91.40":
   version "4.91.40"
@@ -6378,6 +6378,13 @@ focus-trap@7.4.0:
   integrity sha512-yI7FwUqU4TVb+7t6PaQ3spT/42r/KLEi8mtdGoQo2li/kFzmu9URmalTvw7xCCJtSOyhBxscvEAmvjeN9iHARg==
   dependencies:
     tabbable "^6.1.1"
+
+focus-trap@7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.4.2.tgz#25ad602bfae3284639a26abbf176425d96e47561"
+  integrity sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==
+  dependencies:
+    tabbable "^6.1.2"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -11718,6 +11725,11 @@ tabbable@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.1.tgz#40cfead5ed11be49043f04436ef924c8890186a0"
   integrity sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==
+
+tabbable@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.2.tgz#b0d3ca81d582d48a80f71b267d1434b1469a3703"
+  integrity sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==
 
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-org/issues/3370
Closes https://github.com/patternfly/patternfly-org/issues/3371
Closes https://github.com/patternfly/patternfly-org/issues/3467
Closes https://github.com/patternfly/patternfly-org/issues/3489

Implements designs from design issue https://github.com/patternfly/patternfly-design/issues/1239

Note: I need to add some frontmatter metadata to a number of core/react to make banners appear at the top of some deprecated tabs. This PR is meant to enable the displaying of labels/banners, and still requires some follow up work in other repos. 