### PR TITLE
fix(doc-framework): undefined onNavToggle leads to page error

### DIFF
--- a/packages/documentation-framework/components/sideNav/sideNav.js
+++ b/packages/documentation-framework/components/sideNav/sideNav.js
@@ -19,7 +19,7 @@ const NavItem = ({ text, href }) => {
   return (
     <PageContextConsumer key={href + text}>
       {({onNavToggle, isNavOpen }) => (
-          <li key={href + text} className="pf-v5-c-nav__item" onClick={() => isMobileView && onNavToggle()}>
+          <li key={href + text} className="pf-v5-c-nav__item" onClick={() => isMobileView && onNavToggle && onNavToggle()}>
             <Link
               to={href}
               getProps={({ isCurrent, href, location }) => {


### PR DESCRIPTION
**What**: Closes #3553

NOTE: Ideally we could use optional chaining here (e.g. `onNavToggle?.()`), however that syntax is not permitted at the moment for this project file.