### PR TITLE
fix(documentation-framework): Add missing pf5 styles to generated markdown tables

### DIFF
--- a/packages/documentation-framework/scripts/md/styled-tags.js
+++ b/packages/documentation-framework/scripts/md/styled-tags.js
@@ -32,14 +32,15 @@ function styledTags() {
           let columnHeaders = [];
           for (let child of node.children) {
             if (child.tagName === 'thead') {
+              child.properties.className = 'pf-v5-c-table__thead';
               // Find column headers
               const tr = child.children.find(child => child.tagName === 'tr');
               tr.properties.role = 'row';
+              tr.properties.className = 'pf-v5-c-table__tr';
               tr.children
                 .filter(child => child.tagName === 'th')
                 .forEach(th => {
-                  th.properties.className = th.properties.className || '';
-                  th.properties.className += ' pf-m-wrap';
+                  th.properties.className = `${th.properties.className} pf-v5-c-table__th pf-m-wrap`;
                   th.properties.role = 'columnheader';
                   th.properties.scope = 'col';
                   let colName = '';
@@ -56,14 +57,17 @@ function styledTags() {
             }
             else if (child.tagName === 'tbody') {
               child.properties.role = 'rowgroup';
+              child.properties.className = 'pf-v5-c-table__tbody';
               child.children
                 .filter(tr => tr.tagName === 'tr')
                 .forEach(tr => {
                   tr.properties.role = 'row';
+                  tr.properties.className = 'pf-v5-c-table__tr';
                   tr.children
                     .filter(td => td.tagName === 'td')
                     .forEach((td, i) => {
                       td.properties.role = 'cell';
+                      td.properties.className = 'pf-v5-c-table__td';
                       if (columnHeaders[i]) {
                         td.properties['data-label'] = columnHeaders[i];
                       }


### PR DESCRIPTION
**What**: Closes [#9179](https://github.com/patternfly/patternfly-react/issues/9179)

NOTE: Screenshots were taken using these documenation-framework changes locally and applying to @patternfly/patternfly-react's react-docs.

## Before

### Alert
<img width="1164" alt="image" src="https://github.com/patternfly/patternfly-org/assets/96431149/678e04d7-1d5e-4df5-a3f1-95d530ae0453">

### Button
<img width="1164" alt="image" src="https://github.com/patternfly/patternfly-org/assets/96431149/cf965781-5bb8-4016-b2aa-e2ac3ed31a0d">


## After

### Alert
<img width="1164" alt="image" src="https://github.com/patternfly/patternfly-org/assets/96431149/1f0fe1ad-5505-4d13-a540-30115ef9e700">

### Button
<img width="1169" alt="image" src="https://github.com/patternfly/patternfly-org/assets/96431149/702683f9-b505-4ba2-a69c-fdc740933d0a">


