### PR TITLE
fix(docs): fixed gallery styles affecting width, font vars

### DIFF
--- a/packages/documentation-framework/components/sectionGallery/sectionGallery.css
+++ b/packages/documentation-framework/components/sectionGallery/sectionGallery.css
@@ -1,5 +1,9 @@
-.ws-mdx-content-content {
-  max-width: initial !important;
+.ws-landing-page > * {
+  max-width: 832px;
+}
+
+.ws-landing-page > .ws-section-gallery-full-width {
+  max-width: initial;
 }
 
 .ws-section-gallery {

--- a/packages/documentation-framework/components/sectionGallery/sectionGallery.js
+++ b/packages/documentation-framework/components/sectionGallery/sectionGallery.js
@@ -18,6 +18,7 @@ import { SectionGalleryWrapper } from "./sectionGalleryWrapper";
  * @param {Boolean} [hasGridImages=false] - Optional boolean to toggle images on grid layout cards
  * @param {Boolean} [hasListText=false] - Optional boolean to toggle text on list layout rows
  * @param {Boolean} [hasListImages=false] - Optional boolean to toggle images on list layout rows
+ * @param {Boolean} [isFullWidth=true] - Optional boolean to disable component from exceeding default max-width for page
 */
 
 export const SectionGallery = ({
@@ -33,7 +34,8 @@ export const SectionGallery = ({
   hasGridText = false,
   hasGridImages = true,
   hasListText = true,
-  hasListImages = true
+  hasListImages = true,
+  isFullWidth = true
 }) => (
   <SectionGalleryWrapper
     illustrations={illustrations}
@@ -43,6 +45,7 @@ export const SectionGallery = ({
     parseSubsections={parseSubsections}
     galleryItemsData={galleryItemsData}
     initialLayout={initialLayout}
+    isFullWidth={isFullWidth}
   >
     {(sectionGalleryItems, searchTerm, setSearchTerm, layoutView, setLayoutView) => (
       <>

--- a/packages/documentation-framework/components/sectionGallery/sectionGalleryWrapper.js
+++ b/packages/documentation-framework/components/sectionGallery/sectionGalleryWrapper.js
@@ -9,6 +9,7 @@ export const SectionGalleryWrapper = ({
   includeSubsections,
   parseSubsections,
   initialLayout,
+  isFullWidth,
   children
 }) => {
   let sectionRoutes = subsection ? groupedRoutes[section][subsection] : groupedRoutes[section];
@@ -97,7 +98,7 @@ export const SectionGalleryWrapper = ({
     });
 
   return (
-    <div className="ws-section-gallery">
+    <div className={`ws-section-gallery${ isFullWidth ? ' ws-section-gallery-full-width' : '' }`}>
       { children(sectionGalleryItems, searchTerm, setSearchTerm, layoutView, setLayoutView) }
     </div>
   )

--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -86,7 +86,7 @@
   --pf-v5-c-content--FontSize: var(--pf-v5-global--FontSize--md);
   --pf-v5-c-content--FontWeight: var(--pf-v5-global--FontWeight--normal);
   --pf-v5-c-content--Color: var(--pf-v5-global--Color--100);
-  --pf-v5-c-content--heading--FontFamily: var(--pf-v5-global--FontFamily--heading--sans-serif);
+  --pf-v5-c-content--heading--FontFamily: var(--pf-v5-global--FontFamily--heading);
   --pf-v5-c-content--h1--MarginTop: var(--pf-v5-global--spacer--lg);
   --pf-v5-c-content--h1--MarginBottom: var(--pf-v5-global--spacer--sm);
   --pf-v5-c-content--h1--LineHeight: var(--pf-v5-global--LineHeight--sm);

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -83,7 +83,7 @@ const MDXChildTemplate = ({
         <TableOfContents items={toc} />
       )}
       <div className="ws-mdx-content">
-        <div className={id === 'All components' ? "" : "ws-mdx-content-content"}>
+        <div className={source === 'landing-pages' ? "ws-landing-page" : "ws-mdx-content-content"}>
           {InlineAlerts}
           <Component />
           {functionDocumentation.length > 0 && (

--- a/packages/v4/patternfly-docs/patternfly-docs.source.js
+++ b/packages/v4/patternfly-docs/patternfly-docs.source.js
@@ -16,7 +16,7 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
 
   // Gallery pages
   const galleryBase = path.join(__dirname, '../patternfly-docs/pages');
-  sourceMD(path.join(galleryBase, 'landing-pages/**/*.md'), 'pages-landing-page');
+  sourceMD(path.join(galleryBase, 'landing-pages/**/*.md'), 'landing-pages');
 
 
   // Theme pages


### PR DESCRIPTION
Closes #3595 

Preview:  https://patternfly-org-pr-3596-v4.surge.sh/v4/components/label

This PR:
- Updates logic behind `.ws-mdx-content-content` class being excluded on landing pages, and reverts style rule overriding 832px max-width for this class
- Applies new class to landing pages to separately apply max-width but allow override for gallery view to stretch full width
- Updates variable name referenced for header font