### PR TITLE
fix(docs): fixed broken css vars header link

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/get-started/about.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/about.md
@@ -40,7 +40,7 @@ Extensions are holistic solutions that utilize multiple PatternFly components, t
 
 ## Additional developer resources
 
-### [CSS variable system](developer-resources/global-css-variables)
+### [CSS variable system](/developer-resources/global-css-variables)
 
 You can customize PatternFly for your project using the CSS variable system, which enables you to change style elements like color across your project. The CSS variable system is a two-layer theming system where global variables inform component variables.
 


### PR DESCRIPTION
Closes #3616 

This PR fixes the broken `CSS Variables` link on the Get started/About page.