### PR TITLE
fix: add extensions docs and release notes

### DIFF
--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -52,7 +52,6 @@ const MDXChildTemplate = ({
     ensureID(toc);
   }
   const innerContentWrapperClass = () => {
-    console.log(source);
     if (source === 'landing-page') {
       return 'landing-pages';
     }

--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -1,23 +1,24 @@
 {
   "Releases": [
     {
-      "name": "alphas",
-      "date": "2022-02-08",
+      "name": "5.0.0",
+      "date": "2023-07-07",
       "latest": true,
       "versions": {
-        "@patternfly/patternfly": "5.0.0-prerelease.10",
-        "@patternfly/react-charts": "7.0.0-prerelease.6",
-        "@patternfly/react-code-editor": "5.0.0-prerelease.13",
-        "@patternfly/react-core": "5.0.0-prerelease.13",
-        "@patternfly/react-icons": "5.0.0-prerelease.7",
-        "@patternfly/react-styles": "5.0.0-prerelease.5",
-        "@patternfly/react-table": "5.0.0-prerelease.13",
-        "@patternfly/react-tokens": "5.0.0-prerelease.5",
-        "@patternfly/react-catalog-view-extension": "5.0.0-alpha.2",
-        "@patternfly/react-console": "5.0.0-alpha.2",
-        "@patternfly/react-log-viewer": "5.0.0-alpha.2",
-        "@patternfly/react-topology": "5.0.0-alpha.2",
-        "@patternfly/react-virtualized-extension": "4.88.113"
+        "@patternfly/patternfly": "5.0.0",
+        "@patternfly/react-charts": "7.0.0",
+        "@patternfly/react-code-editor": "5.0.0",
+        "@patternfly/react-core": "5.0.0",
+        "@patternfly/react-icons": "5.0.0",
+        "@patternfly/react-styles": "5.0.0",
+        "@patternfly/react-table": "5.0.0",
+        "@patternfly/react-tokens": "5.0.0",
+        "@patternfly/react-catalog-view-extension": "5.0.0",
+        "@patternfly/react-console": "5.0.0",
+        "@patternfly/react-log-viewer": "5.0.0",
+        "@patternfly/react-topology": "5.0.0",
+        "@patternfly/react-user-feedback": "5.0.0",
+        "@patternfly/react-virtualized-extension": "5.0.0"
       }
     },
     {

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -19,11 +19,12 @@
   "dependencies": {
     "@patternfly/documentation-framework": "^5.0.1",
     "@patternfly/quickstarts": "^2.4.0",
-    "@patternfly/react-catalog-view-extension": "5.0.0-alpha.2",
-    "@patternfly/react-console": "^5.0.0-alpha.2",
+    "@patternfly/react-catalog-view-extension": "5.0.0-prerelease.1",
+    "@patternfly/react-console": "5.0.0-prerelease.1",
     "@patternfly/react-docs": "6.0.0-prerelease.13",
-    "@patternfly/react-log-viewer": "^5.0.0-alpha.2",
-    "@patternfly/react-topology": "^5.0.0-alpha.2",
+    "@patternfly/react-log-viewer": "5.0.0-prerelease.1",
+    "@patternfly/react-topology": "5.0.0-prerelease.1",
+    "@patternfly/react-user-feedback": "5.0.0-prerelease.1",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@patternfly/documentation-framework": "^5.0.1",
-    "@patternfly/quickstarts": "^2.4.0",
+    "@patternfly/quickstarts": "^5.0.0-prerelease.1",
     "@patternfly/react-catalog-view-extension": "5.0.0-prerelease.1",
     "@patternfly/react-console": "5.0.0-prerelease.1",
     "@patternfly/react-docs": "6.0.0-prerelease.13",

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-highlights.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-highlights.md
@@ -167,5 +167,5 @@ Whenever a new component or major component enhancement is introduced to Pattern
 
 ## Extensions updates
 
-All PatternFly extensions have been updated to be compatible with PatternFly 5. For details on the nature of the changes made to each extension, please see [the PatternFly 5 release notes](/get-started/release-notes).
+All PatternFly extensions have been updated to be compatible with PatternFly 5. For details on the nature of the changes made to each extension, please see [the PatternFly 5 release notes](/get-started/upgrade/release-notes).
 Most notably, topology's D3 dependency has been updated to version 7, and some event handler callback signatures were updated.

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-highlights.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-highlights.md
@@ -150,6 +150,7 @@ Whenever a new component or major component enhancement is introduced to Pattern
 - [Date picker](/components/date-and-time/date-picker)
 - [Dropdown-next (our new recommendation for dropdown)](/components/menus/dropdown)
 - [Icon](/components/icon)
+- [Log viewer extension](/extensions/log-viewer)
 - [Progress stepper](/components/progress-stepper)
 - [Progress with helper text](/components/progress#helper-text)
 - [Search input](/components/search-input)
@@ -163,3 +164,8 @@ Whenever a new component or major component enhancement is introduced to Pattern
 - [Tile](/components/tile)
 - [Truncate](/components/truncate)
 - [Wizard-next (our new recommendation for wizard)](/components/wizard)
+
+## Extensions updates
+
+All PatternFly extensions have been updated to be compatible with PatternFly 5. For details on the nature of the changes made to each extension, please see [the PatternFly 5 release notes](/get-started/release-notes).
+Most notably, topology's D3 dependency has been updated to version 7, and some event handler callback signatures were updated.

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-notes-data.js
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-notes-data.js
@@ -4834,14 +4834,14 @@ import { Wizard } from '@patternfly/react-core/deprecated';`}
     fixedWithCodeMod: false
   },
   {
-    component: "Quickstarts",
+    component: "Quick starts",
     description: "Made compatible with V5",
     pullRequestURL: ["https://github.com/patternfly/patternfly-quickstarts/pull/250", "https://github.com/patternfly/patternfly-quickstarts/pull/252"],
     repo: "Quickstarts",
     fixedWithCodeMod: false
   },
   {
-    component: "Quickstarts",
+    component: "Quick starts",
     description: "React 18, webpack 5, node 18 support, updated eslint & some other dependencies",
     pullRequestURL: "https://github.com/patternfly/patternfly-quickstarts/pull/247",
     repo: "Quickstarts",

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-notes-data.js
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-notes-data.js
@@ -4828,9 +4828,117 @@ import { Wizard } from '@patternfly/react-core/deprecated';`}
   {
     component: "Search input",
     description: "Removed component",
-    pullRequestURL: "https://github.com/patternfly/patternfly/pull/5506 ",
+    pullRequestURL: "https://github.com/patternfly/patternfly/pull/5506",
     details: "The search input component was removed in favor of the text input group component.",
     repo: "HTML/CSS",
     fixedWithCodeMod: false
-  }
+  },
+  {
+    component: "Quickstarts",
+    description: "Made compatible with V5",
+    pullRequestURL: ["https://github.com/patternfly/patternfly-quickstarts/pull/250", "https://github.com/patternfly/patternfly-quickstarts/pull/252"],
+    repo: "Quickstarts",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Quickstarts",
+    description: "React 18, webpack 5, node 18 support, updated eslint & some other dependencies",
+    pullRequestURL: "https://github.com/patternfly/patternfly-quickstarts/pull/247",
+    repo: "Quickstarts",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Made compatible with V5",
+    pullRequestURL: ["https://github.com/patternfly/react-topology/pull/72","https://github.com/patternfly/react-topology/pull/68"],
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Set strictFunctionTypes",
+    pullRequestURL: "https://github.com/patternfly/react-topology/pull/53",
+    details: "Topology code and demo code now enforce strict typing to allow for use in projects that have this requirement. You may need to update your custom components (nodes, edges) to take the GraphElement rather than the specific Node or Edge types.",
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Added lead icon to task nodes",
+    pullRequestURL: "https://github.com/patternfly/react-topology/pull/67",
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Fixed integralShapePath for almost parallel nodes",
+    pullRequestURL: "https://github.com/patternfly/react-topology/pull/47",
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Updated version of D3 to version 7",
+    pullRequestURL: "https://github.com/patternfly/react-topology/pull/59",
+    details: "This only requires a change on your part if your application uses D3 directly. If you have your own layout implementation that handles D3 events, you will need to update based on D3 updated API params.",
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Upgraded to latest mobx",
+    pullRequestURL: "https://github.com/patternfly/react-topology/pull/61",
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Topology",
+    description: "Added WithContextMenu support for Promise",
+    pullRequestURL: "https://github.com/patternfly/react-topology/pull/58",
+    repo: "react-topology",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Catalog view",
+    description: "Made compatible with V5",
+    pullRequestURL: ["https://github.com/patternfly/react-catalog-view/pull/44", "https://github.com/patternfly/react-catalog-view/pull/45"],
+    details: <>If you are using TypeScript and the <code className='ws-code'>CatalogTile</code> component, you may need to update the type of the event arg in their <code className='ws-code'>onClick</code> handler to <code className='ws-code'>{"React.FormEvent<HTMLInputElement> | React.MouseEvent<Element, MouseEvent>"}</code>.</>,
+    repo: "react-catalog-view",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Log viewer",
+    description: "Promoted log viewer out of beta",
+    pullRequestURL: "https://github.com/patternfly/react-log-viewer/pull/27",
+    repo: "react-log-viewer",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Log viewer",
+    description: "Made compatible with V5",
+    pullRequestURL: "https://github.com/patternfly/react-log-viewer/pull/31",
+    repo: "react-log-viewer",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "Console",
+    description: "Made compatible with V5",
+    pullRequestURL: "https://github.com/patternfly/react-console/pull/38",
+    repo: "react-console",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "User feedback",
+    description: "Made compatible with V5",
+    pullRequestURL: "https://github.com/patternfly/react-user-feedback/pull/60",
+    repo: "react-console",
+    fixedWithCodeMod: false
+  },
+  {
+    component: "User feedback",
+    description: "Added support for promises",
+    pullRequestURL: "https://github.com/patternfly/react-user-feedback/pull/51",
+    repo: "react-user-feedback",
+    fixedWithCodeMod: false
+  },
 ];

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-notes-table.js
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-notes-table.js
@@ -213,7 +213,9 @@ export const ReleaseNotesTable = () => {
       (typeof note.description === "string"
         ? note.description.search(searchValueExp) >= 0
         : findText(note.description)?.search(searchValueExp) >= 0) ||
-      note.pullRequestURL.search(searchValueExp) >= 0 ||
+      (typeof note.pullRequestURL === "string"
+        ? note.pullRequestURL.search(searchValueExp) >= 0
+        : note.pullRequestURL.findIndex(url => url.includes(searchValue)) >= 0) ||
       (note.details && findText(note.details)?.search(searchValueExp) >= 0);
 
     const hasRepoFilter =
@@ -305,7 +307,7 @@ export const ReleaseNotesTable = () => {
                       <Td dataLabel="PR link">
                         {typeof row.pullRequestURL === "string" ? (
                           <a target="_blank" href={row.pullRequestURL}>
-                            #{row.pullRequestURL.slice(-4)}
+                            #{row.pullRequestURL.match(/(\d+)/)[0]}
                           </a>
                         ) : (
                           <TextList isPlain>
@@ -314,7 +316,7 @@ export const ReleaseNotesTable = () => {
                                 key={`${rowIndex}-${url.slice(-4)}`}
                               >
                                 <a target="_blank" href={url}>
-                                  #{url.slice(-4)}
+                                  #{url.match(/(\d+)/)[0]}
                                 </a>
                               </TextListItem>
                             ))}

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-notes.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-notes.md
@@ -1,9 +1,11 @@
 ---
 id: Upgrade
 source: release-notes
-title: PatternFly 5 release notes
+title: PatternFly 5 Upgrade
 section: get-started
 ---
+
+## PatternFly 5 release notes
 
 import { ReleaseNotesTable } from './release-notes-table.js';
 

--- a/packages/documentation-site/patternfly-docs/patternfly-docs.source.js
+++ b/packages/documentation-site/patternfly-docs/patternfly-docs.source.js
@@ -51,9 +51,12 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
   const reactLogViewerPath = require
     .resolve('@patternfly/react-log-viewer/package.json')
     .replace('package.json', 'src');
-  //const reactTopologyPath = require
-  //  .resolve('@patternfly/react-topology/package.json')
-  //  .replace('package.json', 'src');
+  const reactTopologyPath = require
+   .resolve('@patternfly/react-topology/package.json')
+   .replace('package.json', 'patternfly-docs/content/examples');
+  const reactUserFeedbackPath = require
+   .resolve('@patternfly/react-user-feedback/package.json')
+   .replace('package.json', 'patternfly-docs/content/examples');
 
   const logViewerContentBase = require
     .resolve('@patternfly/react-log-viewer/package.json')
@@ -65,7 +68,8 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
   sourceProps(path.join(reactCodeEditorPath, '/**/*.tsx'),reactPropsIgnore);
   sourceProps(path.join(reactChartsPath, '/**/*.tsx'),reactPropsIgnore);
   sourceProps(path.join(reactLogViewerPath, '/**/*.tsx'), reactPropsIgnore);
-  //sourceProps(path.join(reactTopologyPath, '/**/*.tsx'), reactPropsIgnore);
+  sourceProps(path.join(reactTopologyPath, '/**/*.tsx'), reactPropsIgnore);
+  sourceProps(path.join(reactUserFeedbackPath, '/**/*.tsx'), reactPropsIgnore);
 
   // React MD
   sourceMD(path.join(reactCorePath, '/components/**/examples/*.md'), 'react');
@@ -90,8 +94,10 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
   sourceMD(path.join(logViewerContentBase, '/**/demos/*.md'), 'react-demos');
 
   // React-topology MD
-  // Topology mappings commented out until Topology is compatible with v5
-  // sourceMD(path.join(reactTopologyPath, '/**/examples/*.md'), 'react');
+  sourceMD(path.join(reactTopologyPath, '/**/*.md'), 'react');
+
+  // React-user-feedback MD
+  sourceMD(path.join(reactUserFeedbackPath, '/**/*.md'), 'react');
 
   // React OUIA MD
   sourceMD(path.join(reactCorePath, '/**/helpers/OUIA/*.md'), 'react');

--- a/packages/documentation-site/patternfly-docs/patternfly-docs.source.js
+++ b/packages/documentation-site/patternfly-docs/patternfly-docs.source.js
@@ -56,7 +56,7 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
    .replace('package.json', 'patternfly-docs/content/examples');
   const reactUserFeedbackPath = require
    .resolve('@patternfly/react-user-feedback/package.json')
-   .replace('package.json', 'patternfly-docs/content/examples');
+   .replace('package.json', 'patternfly-docs/');
 
   const logViewerContentBase = require
     .resolve('@patternfly/react-log-viewer/package.json')
@@ -97,7 +97,8 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
   sourceMD(path.join(reactTopologyPath, '/**/*.md'), 'react');
 
   // React-user-feedback MD
-  sourceMD(path.join(reactUserFeedbackPath, '/**/*.md'), 'react');
+  sourceMD(path.join(reactUserFeedbackPath, '/**/examples/*.md'), 'react');
+  sourceMD(path.join(reactUserFeedbackPath, '/**/design-guidelines/*.md'), 'design-guidelines');
 
   // React OUIA MD
   sourceMD(path.join(reactCorePath, '/**/helpers/OUIA/*.md'), 'react');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2485,42 +2485,28 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.222.4":
-  version "4.222.4"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.222.4.tgz#5d988779c50df3dafc989d6e807d16971e34d228"
-  integrity sha512-+0fk4dzxEbWn+hgaOnR0BjfeUdEeVVrqfH7+GFeFc+RKjEMjIR/BZbWWN8YQDezmDv6A32gHmEKaY3Uwbt06Lw==
-
 "@patternfly/patternfly@5.0.0-prerelease.10":
   version "5.0.0-prerelease.10"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-5.0.0-prerelease.10.tgz#b5993d04be650f5103edb431436695c7c23c03cc"
   integrity sha512-jVAqCl2UHiB4246fzLBNTcrY6iwllZ5V14KV4kN4/PIPGb3lgM7jpFxWSISsT6yApsVQ8mQngiWhwfqpDZpVaw==
 
-"@patternfly/quickstarts@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.4.0.tgz#2244fc93fe72d9936609ffa1dff25fcd1efc28b3"
-  integrity sha512-dlGtAX8iQarFvmflEvZ7rHaJb1aaBrcqkbzwx0wy2QLL/BID7Y+UQ9ht7k+TBNfnxhPOljM2YTp0rugG5S9q4g==
+"@patternfly/quickstarts@^5.0.0-prerelease.1":
+  version "5.0.0-prerelease.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-5.0.0-prerelease.1.tgz#af5792d29ce96c43a29b0fc04305e5d0adbfb97c"
+  integrity sha512-gs2UzRN/RGHcL75+6fGaFYO+0K4gQG7vYzdu21FqNJ8Ih8Py5HFKdaOI6iHgynqaGicNu67B4/wklV45/VNQLw==
   dependencies:
-    "@patternfly/react-catalog-view-extension" "^4.93.15"
+    "@patternfly/react-catalog-view-extension" "^5.0.0-prerelease.1"
     dompurify "^2.2.6"
     history "^5.0.0"
     showdown "1.8.6"
 
-"@patternfly/react-catalog-view-extension@5.0.0-prerelease.1":
+"@patternfly/react-catalog-view-extension@5.0.0-prerelease.1", "@patternfly/react-catalog-view-extension@^5.0.0-prerelease.1":
   version "5.0.0-prerelease.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-5.0.0-prerelease.1.tgz#72b5acb3d94cb96a5d891a47765a947760b89cdb"
   integrity sha512-gNQrllrvuXZ6i2AuXEKnBNnPo5ZOu2JvgYhS1UHd9b96EL4kDQGoBe9t7Ez9Kt9fCZgqYRV8jVBxIT5qc3h0ig==
   dependencies:
     "@patternfly/react-core" "^5.0.0-prerelease.13"
     "@patternfly/react-styles" "^5.0.0-prerelease.5"
-
-"@patternfly/react-catalog-view-extension@^4.93.15":
-  version "4.95.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.95.1.tgz#a8ff4b14364a8505ff5156e3be6737032a70e277"
-  integrity sha512-GqWyih2GHagI+Yt9+VDmGRC8pv/989nExrisDLWbMNYaRKeZXEmr/LaWXTGJzD+fmZFYjc4wqd5tuJ0VkAp/jg==
-  dependencies:
-    "@patternfly/patternfly" "4.222.4"
-    "@patternfly/react-core" "^4.267.6"
-    "@patternfly/react-styles" "^4.92.3"
 
 "@patternfly/react-charts@^7.0.0-prerelease.6":
   version "7.0.0-prerelease.6"
@@ -2586,19 +2572,6 @@
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-core@^4.267.6":
-  version "4.276.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.8.tgz#7ef52830dcdda954bd5bec40132da6eef49aba6f"
-  integrity sha512-dn322rEzBeiVztZEuCZMUUittNb8l1hk30h9ZN31FLZLLVtXGlThFNV9ieqOJYA9zrYxYZrHMkTnOxSWVacMZg==
-  dependencies:
-    "@patternfly/react-icons" "^4.93.6"
-    "@patternfly/react-styles" "^4.92.6"
-    "@patternfly/react-tokens" "^4.94.6"
-    focus-trap "6.9.2"
-    react-dropzone "9.0.0"
-    tippy.js "5.1.2"
-    tslib "^2.0.0"
-
 "@patternfly/react-docs@6.0.0-prerelease.13":
   version "6.0.0-prerelease.13"
   resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-6.0.0-prerelease.13.tgz#c9a2b13e363b36ab32a5f9147a2137ef6ae1a2bc"
@@ -2618,11 +2591,6 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.0.0-prerelease.7.tgz#f98dd22e363324a6174e70fcaaaa8f834316f2fc"
   integrity sha512-nR4kv5pKN9csN6uZ/0HZg55ZM9S2ngpCL8s/pAc1PtwdOpvm5fUEb3HnCKJmf2pjRxPr7FKIF3aAAAGRd1ORIA==
 
-"@patternfly/react-icons@^4.93.6":
-  version "4.93.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.6.tgz#4aff18724afa30157e3ffd6a6414951dbb39dcb3"
-  integrity sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==
-
 "@patternfly/react-log-viewer@5.0.0-prerelease.1":
   version "5.0.0-prerelease.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-5.0.0-prerelease.1.tgz#b523efe96b47f56933c5747681fa70c351fd2286"
@@ -2638,11 +2606,6 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-prerelease.5.tgz#cdd20855331fd1fde670c764cb3ec7faf3be93e4"
   integrity sha512-1hMBVpW/LXuDOyfGhI7hhaBnUJn18wh2+Zbfj3Xh4J3jhI1iVr9XIudu/rjwheCKLcELid41IYWF43Pg6FmNSQ==
 
-"@patternfly/react-styles@^4.92.3", "@patternfly/react-styles@^4.92.6":
-  version "4.92.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
-  integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
-
 "@patternfly/react-table@^5.0.0-prerelease.13":
   version "5.0.0-prerelease.13"
   resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.0.0-prerelease.13.tgz#01b99204b397f2f1e0da8a02290c050d228cf37a"
@@ -2654,11 +2617,6 @@
     "@patternfly/react-tokens" "^5.0.0-prerelease.5"
     lodash "^4.17.19"
     tslib "^2.5.0"
-
-"@patternfly/react-tokens@^4.94.6":
-  version "4.94.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz#47c715721ad3dd315a523f352ba1a0de2b03f0bc"
-  integrity sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==
 
 "@patternfly/react-tokens@^5.0.0-prerelease.5":
   version "5.0.0-prerelease.5"
@@ -3772,13 +3730,6 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
-attr-accept@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
-  integrity sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==
-  dependencies:
-    core-js "^2.5.0"
 
 attr-accept@^2.2.2:
   version "2.2.2"
@@ -4913,11 +4864,6 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1:
   dependencies:
     browserslist "^4.21.0"
     semver "7.0.0"
-
-core-js@^2.5.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -6202,13 +6148,6 @@ file-saver@1.3.8, file-saver@^1.3.8:
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
   integrity sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==
 
-file-selector@^0.1.8:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.13.tgz#5efd977ca2bca1700992df1b10e254f4e73d2df4"
-  integrity sha512-T2efCBY6Ps+jLIWdNQsmzt/UnAjKOEAlsZVdnQztg/BtAZGNL4uX1Jet9cMM8gify/x4CSudreji2HssGBNVIQ==
-  dependencies:
-    tslib "^2.0.1"
-
 file-selector@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
@@ -6299,13 +6238,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-focus-trap@6.9.2:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.9.2.tgz#a9ef72847869bd2cbf62cb930aaf8e138fef1ca9"
-  integrity sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==
-  dependencies:
-    tabbable "^5.3.2"
 
 focus-trap@7.4.3:
   version "7.4.3"
@@ -9811,7 +9743,7 @@ point-in-svg-path@^1.0.1:
   resolved "https://registry.yarnpkg.com/point-in-svg-path/-/point-in-svg-path-1.0.1.tgz#71c2f40c89ed6c8a212add6577c20df463ae01df"
   integrity sha512-1bAyu3as3lPPFaqrShYVJxg7czrLFdLuudprTV7FZKREOeQ7ZbTZ4KRHB1QdtwNFnOxWQA14J4aQi6Cr1fOrYg==
 
-popper.js@^1.16.0, popper.js@^1.16.1:
+popper.js@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -9991,14 +9923,6 @@ promzard@^0.3.0:
   integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
   dependencies:
     read "1"
-
-prop-types-extra@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
-  integrity sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==
-  dependencies:
-    react-is "^16.3.2"
-    warning "^4.0.0"
 
 prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
@@ -10238,22 +10162,12 @@ react-dropzone@14.2.3, react-dropzone@^14.2.3:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
-react-dropzone@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-9.0.0.tgz#4f5223cdcb4d3bd8a66e3298c4041eb0c75c4634"
-  integrity sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==
-  dependencies:
-    attr-accept "^1.1.3"
-    file-selector "^0.1.8"
-    prop-types "^15.6.2"
-    prop-types-extra "^1.1.0"
-
 react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -11656,11 +11570,6 @@ surge@^0.23.1:
     tarr "1.1.0"
     url-parse-as-address "1.0.0"
 
-tabbable@^5.3.2:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
-  integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
-
 tabbable@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.2.tgz#b0d3ca81d582d48a80f71b267d1434b1469a3703"
@@ -11849,13 +11758,6 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
-tippy.js@5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-5.1.2.tgz#5ac91233c59ab482ef5988cffe6e08bd26528e66"
-  integrity sha512-Qtrv2wqbRbaKMUb6bWWBQWPayvcDKNrGlvihxtsyowhT7RLGEh1STWuy6EMXC6QLkfKPB2MLnf8W2mzql9VDAw==
-  dependencies:
-    popper.js "^1.16.0"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -12686,13 +12588,6 @@ walk-up-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-1.0.0.tgz#d4745e893dd5fd0dbb58dd0a4c6a33d9c9fec53e"
   integrity sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==
-
-warning@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack@^2.4.0:
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,13 +2505,13 @@
     history "^5.0.0"
     showdown "1.8.6"
 
-"@patternfly/react-catalog-view-extension@5.0.0-alpha.2":
-  version "5.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-5.0.0-alpha.2.tgz#2471fb05b791426164f4bb3053fd62d13e5711f6"
-  integrity sha512-FgRGLkxqcXqChJVNciVY+CySPyIFA9WQXVN/Ju3lc9hdyI3gNhxmXoPZGy3CTg6YeAi8XYPDnpT1NPvV6fZoag==
+"@patternfly/react-catalog-view-extension@5.0.0-prerelease.1":
+  version "5.0.0-prerelease.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-5.0.0-prerelease.1.tgz#72b5acb3d94cb96a5d891a47765a947760b89cdb"
+  integrity sha512-gNQrllrvuXZ6i2AuXEKnBNnPo5ZOu2JvgYhS1UHd9b96EL4kDQGoBe9t7Ez9Kt9fCZgqYRV8jVBxIT5qc3h0ig==
   dependencies:
-    "@patternfly/react-core" "5.0.0-prerelease.7"
-    "@patternfly/react-styles" "5.0.0-prerelease.2"
+    "@patternfly/react-core" "^5.0.0-prerelease.13"
+    "@patternfly/react-styles" "^5.0.0-prerelease.5"
 
 "@patternfly/react-catalog-view-extension@^4.93.15":
   version "4.95.1"
@@ -2561,27 +2561,27 @@
     react-dropzone "14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-console@^5.0.0-alpha.2":
-  version "5.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-console/-/react-console-5.0.0-alpha.2.tgz#1b22a354994fdcefb40fc1d99c62fcd581628859"
-  integrity sha512-D7NyvAIZXmnRKNzn07FqHfJHX0haE430yEQK7GyyMGJzq7HPIKS7ThoqVCuoeD32dBf8zPaIw+F9UDyHWSu97Q==
+"@patternfly/react-console@5.0.0-prerelease.1":
+  version "5.0.0-prerelease.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-console/-/react-console-5.0.0-prerelease.1.tgz#dba2c6f966465c73cc7256f95a67f2af026a9ec5"
+  integrity sha512-v7JZ6Px3UaZ405C/4Vhzz5mTq18kBGeTCgVbz3k0FLX6gdAz1E3zIUaXTPWh+hYJOiKdtb9x88dQo5iBN7ePZg==
   dependencies:
     "@novnc/novnc" "^1.3.0"
-    "@patternfly/react-core" "5.0.0-prerelease.7"
-    "@patternfly/react-styles" "5.0.0-prerelease.2"
+    "@patternfly/react-core" "^5.0.0-prerelease.13"
+    "@patternfly/react-styles" "^5.0.0-prerelease.5"
     "@spice-project/spice-html5" "^0.2.1"
     file-saver "^1.3.8"
     xterm "^4.8.1"
     xterm-addon-fit "^0.2.1"
 
-"@patternfly/react-core@5.0.0-prerelease.7":
-  version "5.0.0-prerelease.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.0.0-prerelease.7.tgz#93c9fb1316bf34dd5f65426abcf4086cf7a806b4"
-  integrity sha512-gCFKI7T2vTtogjMtyrYzHfPpC7KWNOcaa3nw5NKx3VVIcCEmf+Hp5XmIX8eDlElmIAQltRD/Q6vEtgXNh4QgcA==
+"@patternfly/react-core@5.0.0-prerelease.13", "@patternfly/react-core@^5.0.0-prerelease.13":
+  version "5.0.0-prerelease.13"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.0.0-prerelease.13.tgz#878b9d27b639bb870e79c6c388fcf617e3793641"
+  integrity sha512-NhZmaagCjEDhfOI0VPG5oeYeQkzUAUZB/gDg8VSDvs+2jnwrqRH/Wk+Sot9ix9GaU7Xad3jdkEY9HAqKomVsnw==
   dependencies:
-    "@patternfly/react-icons" "^5.0.0-prerelease.3"
-    "@patternfly/react-styles" "^5.0.0-prerelease.2"
-    "@patternfly/react-tokens" "^5.0.0-prerelease.2"
+    "@patternfly/react-icons" "^5.0.0-prerelease.7"
+    "@patternfly/react-styles" "^5.0.0-prerelease.5"
+    "@patternfly/react-tokens" "^5.0.0-prerelease.5"
     focus-trap "7.4.3"
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
@@ -2599,18 +2599,6 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^5.0.0-prerelease.13":
-  version "5.0.0-prerelease.13"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.0.0-prerelease.13.tgz#878b9d27b639bb870e79c6c388fcf617e3793641"
-  integrity sha512-NhZmaagCjEDhfOI0VPG5oeYeQkzUAUZB/gDg8VSDvs+2jnwrqRH/Wk+Sot9ix9GaU7Xad3jdkEY9HAqKomVsnw==
-  dependencies:
-    "@patternfly/react-icons" "^5.0.0-prerelease.7"
-    "@patternfly/react-styles" "^5.0.0-prerelease.5"
-    "@patternfly/react-tokens" "^5.0.0-prerelease.5"
-    focus-trap "7.4.3"
-    react-dropzone "^14.2.3"
-    tslib "^2.5.0"
-
 "@patternfly/react-docs@6.0.0-prerelease.13":
   version "6.0.0-prerelease.13"
   resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-6.0.0-prerelease.13.tgz#c9a2b13e363b36ab32a5f9147a2137ef6ae1a2bc"
@@ -2625,45 +2613,35 @@
     "@patternfly/react-table" "^5.0.0-prerelease.13"
     "@patternfly/react-tokens" "^5.0.0-prerelease.5"
 
-"@patternfly/react-icons@5.0.0-prerelease.3":
-  version "5.0.0-prerelease.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.0.0-prerelease.3.tgz#9077749e2e2e44f07c6942df8de027fa1cef066f"
-  integrity sha512-zLfS+Jxp70ybwYQvr0tLYTy7UEonlmzp/FkBX1/XVHeqM6ZYICO/tKnQZyk2j40PmlfGrQeD5moNz3SzZmQqjw==
+"@patternfly/react-icons@5.0.0-prerelease.7", "@patternfly/react-icons@^5.0.0-prerelease.7":
+  version "5.0.0-prerelease.7"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.0.0-prerelease.7.tgz#f98dd22e363324a6174e70fcaaaa8f834316f2fc"
+  integrity sha512-nR4kv5pKN9csN6uZ/0HZg55ZM9S2ngpCL8s/pAc1PtwdOpvm5fUEb3HnCKJmf2pjRxPr7FKIF3aAAAGRd1ORIA==
 
 "@patternfly/react-icons@^4.93.6":
   version "4.93.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.6.tgz#4aff18724afa30157e3ffd6a6414951dbb39dcb3"
   integrity sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==
 
-"@patternfly/react-icons@^5.0.0-prerelease.3", "@patternfly/react-icons@^5.0.0-prerelease.7":
-  version "5.0.0-prerelease.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.0.0-prerelease.7.tgz#f98dd22e363324a6174e70fcaaaa8f834316f2fc"
-  integrity sha512-nR4kv5pKN9csN6uZ/0HZg55ZM9S2ngpCL8s/pAc1PtwdOpvm5fUEb3HnCKJmf2pjRxPr7FKIF3aAAAGRd1ORIA==
-
-"@patternfly/react-log-viewer@^5.0.0-alpha.2":
-  version "5.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-5.0.0-alpha.2.tgz#9afa96d33951cc667298dc0fb6e3e4a3a8457728"
-  integrity sha512-On6nSK6mgJHBN7Lc0wPA4XUvf8wBrVV52c8V8ReIfOTi931FDWtvvOJ1dlNja7RNrYPq3mmMnV1rRwC2cLIV4w==
+"@patternfly/react-log-viewer@5.0.0-prerelease.1":
+  version "5.0.0-prerelease.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-log-viewer/-/react-log-viewer-5.0.0-prerelease.1.tgz#b523efe96b47f56933c5747681fa70c351fd2286"
+  integrity sha512-XAfMOunP3IzMLZ53A1pyubWCRSUww9zu36bpjXwkhacy8fcJUgjRXwj4yWCIPpjqqYtX1KJG80tEKPMdOPgHDQ==
   dependencies:
-    "@patternfly/react-core" "5.0.0-prerelease.7"
-    "@patternfly/react-icons" "5.0.0-prerelease.3"
-    "@patternfly/react-styles" "5.0.0-prerelease.2"
+    "@patternfly/react-core" "5.0.0-prerelease.13"
+    "@patternfly/react-icons" "5.0.0-prerelease.7"
+    "@patternfly/react-styles" "5.0.0-prerelease.5"
     memoize-one "^5.1.0"
 
-"@patternfly/react-styles@5.0.0-prerelease.2":
-  version "5.0.0-prerelease.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-prerelease.2.tgz#56604bf052e41a43e0b433b1e69d016e1ea3a277"
-  integrity sha512-IP/E6fHQn6qHKD+B8LDc6GyNNcSv57JsRTDvoG8rL6Ju9V4DGnEfV4M5xxUHbJ3GRWa5XSiA1ErsM4ntP100CQ==
+"@patternfly/react-styles@5.0.0-prerelease.5", "@patternfly/react-styles@^5.0.0-prerelease.5":
+  version "5.0.0-prerelease.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-prerelease.5.tgz#cdd20855331fd1fde670c764cb3ec7faf3be93e4"
+  integrity sha512-1hMBVpW/LXuDOyfGhI7hhaBnUJn18wh2+Zbfj3Xh4J3jhI1iVr9XIudu/rjwheCKLcELid41IYWF43Pg6FmNSQ==
 
 "@patternfly/react-styles@^4.92.3", "@patternfly/react-styles@^4.92.6":
   version "4.92.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
   integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
-
-"@patternfly/react-styles@^5.0.0-prerelease.2", "@patternfly/react-styles@^5.0.0-prerelease.5":
-  version "5.0.0-prerelease.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.0.0-prerelease.5.tgz#cdd20855331fd1fde670c764cb3ec7faf3be93e4"
-  integrity sha512-1hMBVpW/LXuDOyfGhI7hhaBnUJn18wh2+Zbfj3Xh4J3jhI1iVr9XIudu/rjwheCKLcELid41IYWF43Pg6FmNSQ==
 
 "@patternfly/react-table@^5.0.0-prerelease.13":
   version "5.0.0-prerelease.13"
@@ -2682,19 +2660,19 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz#47c715721ad3dd315a523f352ba1a0de2b03f0bc"
   integrity sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==
 
-"@patternfly/react-tokens@^5.0.0-prerelease.2", "@patternfly/react-tokens@^5.0.0-prerelease.5":
+"@patternfly/react-tokens@^5.0.0-prerelease.5":
   version "5.0.0-prerelease.5"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.0.0-prerelease.5.tgz#5b44d55439f020878dde68d13941f2560beabe25"
   integrity sha512-36iQ7CuYh3OKf+TEZNSfU5Mpgi+aLJoFFA2V4YDaOL8+7RC8sFqh/dW3S9ThkjQrtc0fF7OK7mrPJzK+nQB9UQ==
 
-"@patternfly/react-topology@^5.0.0-alpha.2":
-  version "5.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-5.0.0-alpha.2.tgz#405091e6a9a17bd7e893f307e8bb82f4b974e3db"
-  integrity sha512-8cbEaJZhP0tfPOO1UMpS8PpMLtFMGQ7hIdySbf5lvpowa4ph9clf+8rMoq/uL3tQIRBcxMR2FIJjfK5vw0q9yg==
+"@patternfly/react-topology@5.0.0-prerelease.1":
+  version "5.0.0-prerelease.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-5.0.0-prerelease.1.tgz#bd04b473a2f74a7108de4abe513ec7008f4a9cf0"
+  integrity sha512-tnbYRCf8C3TuT5VFUWPFGazoC5Cbxvh09+UdvoWXHy5nRDaHk0C80UdZ1YSvUL5OD0tGbcYNmFYbBzlnyse4zg==
   dependencies:
-    "@patternfly/react-core" "5.0.0-prerelease.7"
-    "@patternfly/react-icons" "5.0.0-prerelease.3"
-    "@patternfly/react-styles" "5.0.0-prerelease.2"
+    "@patternfly/react-core" "^5.0.0-prerelease.13"
+    "@patternfly/react-icons" "^5.0.0-prerelease.7"
+    "@patternfly/react-styles" "^5.0.0-prerelease.5"
     "@types/d3" "^7.4.0"
     "@types/d3-force" "^1.2.1"
     "@types/dagre" "0.7.42"
@@ -2709,6 +2687,14 @@
     react-measure "^2.3.0"
     tslib "^2.0.0"
     webcola "3.4.0"
+
+"@patternfly/react-user-feedback@5.0.0-prerelease.1":
+  version "5.0.0-prerelease.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-user-feedback/-/react-user-feedback-5.0.0-prerelease.1.tgz#e084ab000eaba61f5b8fab93250b3cab3f9066b1"
+  integrity sha512-3mDlm4aQVEDaXkdQAvpp1fdEjdG2JBH6adhasL/he/l4szxYb6VqAOqB6fLyM1v4ChDmEAMThHtNArsnymIn7Q==
+  dependencies:
+    "@patternfly/react-core" "^5.0.0-prerelease.13"
+    "@patternfly/react-icons" "^5.0.0-prerelease.7"
 
 "@phenomnomnominal/tsquery@4.1.1":
   version "4.1.1"


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-org/issues/3631

-Adds extensions to the release notes and a blurb about extensions to the release highlights
-adds user feedback documentation
-fixes and updates all other extensions docs (including topology)
