### PR TITLE
fix(documentation): remove excludes from codemod command

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/get-started/upgrade.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/upgrade.md
@@ -42,7 +42,7 @@ To run our codemods, complete the following steps:
 
 2. Make note of any issues that get flagged.
 
-3. Add the `–fix` flag to the end of your original command and run it again. 
+3. Add the `--fix` flag to the end of your original command and run it again. 
 
 4. Make note of the changes applied to your product's code base.
 

--- a/packages/documentation-site/patternfly-docs/content/get-started/upgrade.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/upgrade.md
@@ -37,7 +37,7 @@ To run our codemods, complete the following steps:
 1. Run the following command, adding in the path to your product's source code: 
 
     ```{
-    npx @patternfly/pf-codemods@latest <path to your source code> --exclude menu-search-rename,alert-remove-titleHeadingLevel,datetimepicker-warn-helperText,formgroup-remove-helpertextProps,formhelpertext-remove-props,alert-remove-titleHeadingLevel
+    npx @patternfly/pf-codemods@latest <path to your source code>
     ```
 
 2. Make note of any issues that get flagged.


### PR DESCRIPTION
these are all merged into pf now and don't need to be excluded

also `--fix` instead of `-fix`