### PR TITLE
fix(documentation-framework): updated page logo size, props

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -235,9 +235,7 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
       <MastheadMain>
         <MastheadBrand href={prurl || '/'}>
           {prnum ? `PR #${prnum}` : (
-            <Brand src={v5Logo} alt="PatternFly" heights={{ default: '40px' }} widths={{ default: '180px', '2xl': '220px' }}>
-              <source srcSet={v5Logo} />
-            </Brand>
+            <Brand src={v5Logo} alt="PatternFly" heights={{ default: '36px' }} />
           )}
         </MastheadBrand>
       </MastheadMain>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/3643

Relies upon https://github.com/patternfly/patternfly-react/pull/9342 being merged, which will allow for custom widths/heights to be passed when `<Brand>` has no children.