### PR TITLE
fix(links): fixed multiple broken linkes

### DIFF
--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -56,7 +56,7 @@ export const Footer = () => (
                   <li className="ws-org-pfsite-footer-menu-list-item">
                     <Link
                       className="ws-org-pfsite-footer-menu-link"
-                      to="/guidelines/colors"
+                      to="/design-foundations/colors"
                       aria-label="PatternFly 4 styles"
                     >
                       Styles

--- a/packages/documentation-framework/pages/404/index.js
+++ b/packages/documentation-framework/pages/404/index.js
@@ -100,7 +100,7 @@ const Page404 = () => {
           body="Check out PatternFly's design approach to icons, colors, and more."
           link={{
             text: 'View guidelines',
-            to: '/guidelines/colors'
+            to: '/design-foundations/colors'
           }}
         />
         <Card404

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/donut-chart/donut-chart.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/donut-chart/donut-chart.md
@@ -7,7 +7,7 @@ A **donut chart** represents relative amounts that must add up to 100%.
 ## Usage
 In donut charts, you can choose to use percentages or integer values to compare parts to the whole. When deciding which to use, consider the information that is most important to your user and what makes the most sense for your use case. For example, if a user knows they have 123 farm animals and they’re interested in knowing how many of those animals are cows, it probably makes more sense to use an integer value. If that same user is interested in knowing how much storage space they have left in their grain silo, a percentage might be better.
 
-Do not try to represent more than six categories in a donut chart. We recommend using the [colors for charts](/guidelines/colors-for-charts) guidelines to represent your data when thresholds are not present.
+Do not try to represent more than six categories in a donut chart. We recommend using the [colors for charts](/charts/colors-for-charts) guidelines to represent your data when thresholds are not present.
 
 The most common use cases for donut charts are:
 - Showing the relationship of a set of values to a whole.
@@ -18,7 +18,7 @@ If you need to compare one category to another, consider using a [bar chart](/ch
 ### Example
 <img src="./img/donut-chart.png" alt="Donut chart" width="501"/>
 
-1. **Segment fill:** We recommend using [colors for charts](/guidelines/colors-for-charts) for different items within the donut chart.
+1. **Segment fill:** We recommend using [colors for charts](/charts/colors-for-charts) for different items within the donut chart.
 2. **Segment padding:**  Always provide 3px of padding between segments.
 3. **Chart tooltip:** A tooltip will appear upon hover that states the name of the segment and corresponding value. For example, if the segment represents "Bugs," and the value being represented is 25, your chart tooltip would state, "Bugs: 25."
 4. **Label:** When a donut chart is contained within a dashboard card, a label defines what the chart represents. The label may also represent the total value of the data set. If this optional representation is chosen, it should follow the format of **[total numeric value] + [data set label]** (example: "100 Issues"). The total numeric value should be rounded to two decimal places or less (14 characters max) and should be styled using 24px font in standard text color. The data set label cannot contain more than 24 characters and should be styled using 14px font in secondary text color. Center them within the donut and style as shown. If the label exceeds the max character count, place it outside of the donut and leave the center empty.

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/donut-utilization-chart/donut-utilization-chart.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/donut-utilization-chart/donut-utilization-chart.md
@@ -13,7 +13,7 @@ A **donut utlization chart** is a donut chart used specifically to show utilizat
 <img src="./img/donut-utilization-2.png" alt="Donut utilization 2" width="404"/>
 
 1. **Unused segment fill:** The unused area of the donut chart will always remain at #EDEDED.
-2. **Used segment fill:** We recommend using #0066cc for the used area of the donut chart. See [colors for charts](/guidelines/colors-for-charts) for other recommended color options.
+2. **Used segment fill:** We recommend using #0066cc for the used area of the donut chart. See [colors for charts](/charts/colors-for-charts) for other recommended color options.
 3. **Utilization label:** Both percentages and whole numbers can be used to represent the utilization.
 4. **Chart tooltip:** Since this is a utilization donut chart, the tooltip will display the percentage of data utilized. Chart tooltips only appear on hover over the utilization segment of the chart. We recommend stating the segment name and the utilization value being captured. For example, if the user is tracking GBps utilization, the chart tooltip would state "GBps utilization: 75%."
 

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/line-chart/line-chart.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/line-chart/line-chart.md
@@ -12,4 +12,4 @@ Multiple lines on the same chart allow the user to visualize relationships betwe
 ### Example
 <img src="./img/line-chart.png" alt="Line chart" />
 
-Line charts can optionally represent data points as dots on the line. If so, the same interaction that occurs when hovering over one in an [area chart](/charts/area-chart) will occur in line charts. For line colors, we recommend consulting [colors for charts](/guidelines/colors-for-charts).
+Line charts can optionally represent data points as dots on the line. If so, the same interaction that occurs when hovering over one in an [area chart](/charts/area-chart) will occur in line charts. For line colors, we recommend consulting [colors for charts](/charts/colors-for-charts).

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/pie-chart/pie-chart.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/pie-chart/pie-chart.md
@@ -12,5 +12,5 @@ A pie chart may be the wrong choice when you need to compare categories to one a
 ### Example
 <img src="./img/pie-chart.png" alt="Pie chart" width="428"/>
 
-1. **Pie chart fill:** We recommend fill colors based on the [colors for charts](/guidelines/colors-for-charts).
+1. **Pie chart fill:** We recommend fill colors based on the [colors for charts](/charts/colors-for-charts).
 2. **Legend:** Each variable on the legend should report their current value.

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/stacked-chart/stacked-chart.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/charts/stacked-chart/stacked-chart.md
@@ -14,4 +14,4 @@ An advantageous feature of stacked bar charts is the ability to reorder the stac
 
 <img src="./img/vertical-stacked-bar-chart.png" alt="Vertical stacked bar chart" width="663"/>
 
-The first series name is represented by the topmost stacked bar, and the last series name is represented by the bottommost stacked bar. For recommendations on series colors, see [colors for charts](/guidelines/colors-for-charts).
+The first series name is represented by the topmost stacked bar, and the last series name is represented by the bottommost stacked bar. For recommendations on series colors, see [colors for charts](/charts/colors-for-charts).

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/form/forms.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/form/forms.md
@@ -282,7 +282,7 @@ Learn more about writing error messages in the [content](#content-considerations
 Forms may be placed in several contexts including on a page, in a wizard, or in a modal. Your chosen form placement may impact specific spacing considerations, but general form spacing requirements apply across these contexts.
 
 ### General spacing
-Always add 24px of spacing underneath each form input. If a form input includes helper text, this 24px spacing should start below the helper text. Spacing between data inputs like checkboxes and radio buttons should also be 24px when on the same line or stacked on one another. For more spacing information, consult the [PatternFly spacer guidelines](/guidelines/spacers#considering-line-height-and-padding).
+Always add 24px of spacing underneath each form input. If a form input includes helper text, this 24px spacing should start below the helper text. Spacing between data inputs like checkboxes and radio buttons should also be 24px when on the same line or stacked on one another. For more spacing information, consult the [PatternFly spacer guidelines](/design-foundations/spacers#considering-line-height-and-padding).
 
 <img src="./img/form-spacing.png" alt="Basic form example with spacers to demonstrate how elements should be spaced within it" width="460"/>
 

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/progress/progress.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/progress/progress.md
@@ -56,7 +56,7 @@ A red progress bar represents a process that has failed. Accompany a failed prog
 
 ### Complete or success
 
-A green progress bar represents the successful completion of a process. Accompany a complete progress bar with a [green check-circle icon](/guidelines/icons/#all-icons) to demonstrate that the process has finished with no errors.
+A green progress bar represents the successful completion of a process. Accompany a complete progress bar with a [green check-circle icon](/design-foundations/icons/#all-icons) to demonstrate that the process has finished with no errors.
 
 <img src="./img/progress-bar-complete.png" alt="An example of a progress bar in a complete or successful state, with a green track, optional check-circle icon, and a title that indicates its status: 'Validated account credentials.'" width="560" />
 

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/search-input/search-input.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/search-input/search-input.md
@@ -31,9 +31,9 @@ Another way to use search input is as a find function. This would mean that the 
 
 3. **Optional navigation:** The navigation feature allows the user to navigate 1-by-1 through the matched results. It will correspond to the count that is within the badge.
 
-4. **Match highlight:** All matches will be highlighted using `gold-50`from the [PatternFly color palette](/guidelines/colors#color-palette).
+4. **Match highlight:** All matches will be highlighted using `gold-50`from the [PatternFly color palette](/design-foundations/colors#color-palette).
 
-5. **Current highlight:** The active match will be highlighted with `gold-100` from the [PatternFly color palette](/guidelines/colors#color-palette). In this case, since the user is on match 2 of 5, “Node” in “Node 2” is highlighted.
+5. **Current highlight:** The active match will be highlighted with `gold-100` from the [PatternFly color palette](/design-foundations/colors#color-palette). In this case, since the user is on match 2 of 5, “Node” in “Node 2” is highlighted.
 
 ### Advanced search
 The [advanced search variant](/components/search-input#advanced) is intended for more advanced search use cases across multiple attribute-value pairs. It allows users to enter complex search queries from the keyboard or to fill out a search form. Use this component for search or filter queries that involve many attributes and when you want to give the user the option to use a form to complete the search criteria.

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/table/table.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/table/table.md
@@ -116,9 +116,9 @@ Sorting by columns is possible for any table variation. Enabling the component w
 
 <img src="./img/sortable-data-table.png"  alt="Sortable table"  width="1161"/>
 
-1. **Sortable column:** When a column is sortable, the sort icon will appear to the right of the column header in a [light grey](/guidelines/colors#typography-and-iconography-colors) color. Sorting will not become active until the user selects the column header. This triggers the arrow to point upwards and the content to be sorted in ascending order.
-3. **Hovered sort:** When a column is sortable, the sort icon will appear to the right of the column header. Upon hover, the  icon will change to a [darker grey](/guidelines/colors#typography-and-iconography-colors) indicating that the icon is actionable.
-2. **Sorted column:** When a column is being sorted by, the column header will turn [blue](/guidelines/colors#typography-and-iconography-colors) and the sort icon will represent the direction of the sort. Subsequent clicks on the sortable column header will toggle the direction of the sort.
+1. **Sortable column:** When a column is sortable, the sort icon will appear to the right of the column header in a [light grey](/design-foundations/colors#typography-and-iconography-colors) color. Sorting will not become active until the user selects the column header. This triggers the arrow to point upwards and the content to be sorted in ascending order.
+3. **Hovered sort:** When a column is sortable, the sort icon will appear to the right of the column header. Upon hover, the  icon will change to a [darker grey](/design-foundations/colors#typography-and-iconography-colors) indicating that the icon is actionable.
+2. **Sorted column:** When a column is being sorted by, the column header will turn [blue](/design-foundations/colors#typography-and-iconography-colors) and the sort icon will represent the direction of the sort. Subsequent clicks on the sortable column header will toggle the direction of the sort.
 
 #### When to use
 The default sort order for a table should support the primary use case for the application. All columns in a table do not require sort functionality. That is, you can disable the header sort function on some columns and enable it on others.

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/text/text.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/text/text.md
@@ -5,4 +5,4 @@ section: components
 
 ## Usage
 
-Text can be used anywhere in your designs and can take on different formats. Read [PatternFly’s typography page](/guidelines/typography) for more guidelines on how to use text in your UIs, and the different styles available.
+Text can be used anywhere in your designs and can take on different formats. Read [PatternFly’s typography page](/design-foundations/typography) for more guidelines on how to use text in your UIs, and the different styles available.

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/content/writing-design-documentation.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/content/writing-design-documentation.md
@@ -34,7 +34,7 @@ Additional sub-sections to include:
 #### When to use X variation vs. when to use Y variation
 
 ### Spacing (H2)
-Introduce spacing requirements for components and their content. For more information regarding proper spacing, refer to our [spacing guidelines.](https://www.patternfly.org/v4/guidelines/spacers/)
+Introduce spacing requirements for components and their content. For more information regarding proper spacing, refer to our [spacing guidelines.](https://www.patternfly.org/design-foundations/spacers/)
 
 ### Content considerations (H2)
 Showcase the different content that could be included within your component. Here is where you can also give additional tips and tricks the user may want to know. Content guidance includes:

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/icons/icons.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/icons/icons.md
@@ -90,7 +90,7 @@ If you're a developer, check out our [getting started](/get-started/develop#usin
 <Divider className="ws-icons-divider" />
 
 ## Icon colors
-Visit our [colors page](/guidelines/colors) to learn more about icon colors.
+Visit our [colors page](/design-foundations/colors) to learn more about icon colors.
 
 <Divider className="ws-icons-divider" />
 


### PR DESCRIPTION
just looked for any url pointing to `/guidelines/...` which doesn't exist anymore. Updated to `/design-foundations/...` or `/charts/...`

closes #3681 