### PR TITLE
fix: clean up h2 and dark theme switcher styles

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.css
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.css
@@ -36,3 +36,9 @@
 .ws-masthead .pf-v5-c-toolbar__item  {
   min-width: 0;
 }
+
+.ws-masthead .pf-v5-c-switch {
+  align-items: center;
+  --pf-v5-c-switch__input--not-checked__label--Color: var(--pf-v5-global--Color--100);
+  --pf-v5-c-switch__input--checked__label--Color: var(--pf-v5-global--Color--100);
+}

--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -191,8 +191,7 @@
   margin-bottom: var(--pf-v5-c-content--h2--MarginBottom);
   font-size: var(--pf-v5-c-content--h2--FontSize);
   font-weight: var(--pf-v5-c-content--h2--FontWeight);
-  line-height: var(--pf-v5-c-content--h2--LineHeight); }
-  .ws-h2:not(:first-child) {
+  line-height: var(--pf-v5-c-content--h2--LineHeight);
     margin-top: var(--pf-v5-c-content--h2--MarginTop); }
 .ws-h3 {
   margin-bottom: var(--pf-v5-c-content--h3--MarginBottom);


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-org/issues/3629
Closes https://github.com/patternfly/patternfly-org/issues/3668

The dark theme switcher is being fixed with CSS overrides - likely we will want to actually address these issues on the core side in general.

I've also asked design whether the switch component was the right choice. I'll update this with their response when I get it.