### PR TITLE
fix(docs): fix missing vars in global css vars table

### DIFF
--- a/packages/documentation-framework/pages/global-css-variables.md
+++ b/packages/documentation-framework/pages/global-css-variables.md
@@ -102,7 +102,7 @@ Example:
 
 ## Global CSS variables
 
-<CSSVariables prefix="patternfly_variables" selector=":root" hideSelectorColumn />
+<CSSVariables prefix="patternfly_variables" selector=":where(:root)" hideSelectorColumn />
 
 ## Chart CSS variables
 


### PR DESCRIPTION
Closes #3686 

This PR fixes the empty Global CSS Variables table by correcting the `selector` prop passed to the `CSSVariables` component from the `:root` selector previously used for global vars to the current `:where(:root)` selector. 