### PR TITLE
chore: update copyright to range from 2014 through current year

### DIFF
--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -225,7 +225,7 @@ export const Footer = () => (
         </GridItem>
         <GridItem md={4} lg={3} xl={2}>
           <span className="ws-org-pfsite-site-copyright">
-            Copyright &copy; 2022 Red Hat, Inc.
+            Copyright &copy; 2014-{new Date().getFullYear()} Red Hat, Inc.
           </span>
         </GridItem>
         <GridItem md={4} lg={5} className="pf-v5-u-ml-xl-on-xl">


### PR DESCRIPTION
Closes #3702 

This PR updates the copyright dates in the footer.  Per research, copyright should include original publish date, or if content has been updated a range from original date through last published date.  As we will continually update docs site, the code has been updated to get the current year and range from 2014 (site creation) through the current year - this will avoid running into the same issue year after year.