### PR TITLE
docs(breadcrumb): Move placement section of design guidelines to H2.

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/breadcrumb/breadcrumb.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/breadcrumb/breadcrumb.md
@@ -14,7 +14,7 @@ Use breadcrumbs in addition to your global navigation to display a user's locati
 * Never use breadcrumbs as a replacement for global navigation.
 * Breadcrumbs in PatternFly are intended to show the location of a page in the site hierarchy, and are **not intended to map the user's path through the application**.
 
-### Placement
+## Placement
 Breadcrumbs should be placed underneath the masthead, at the top of the page. There should be 16px of padding both between the breadcrumb and the masthead, and between the breadcrumbs and anything that comes below.
 
 <img src="./img/placement.png" alt="Placement of breadcrumbs and padding" width="825"/>


### PR DESCRIPTION
Closes #3725 