### PR TITLE
chore(docs): added ability to pass url filter term when generating screenshots

### DIFF
--- a/packages/documentation-framework/scripts/cli/cli.js
+++ b/packages/documentation-framework/scripts/cli/cli.js
@@ -46,6 +46,7 @@ program
   .command('screenshots')
   .option('-u, --urlPrefix <prefix>', 'where fullscreen pages are hosted', 'http://localhost:5000')
   .option('-a, --allRoutes', 'true if screenshots of all examples - not just full screen', false)
+  .option('-f --filterTerm <term>', 'search term to filter routes by', '')
   .description('updates screenshots for generated components')
   .action(options => {
     const { writeScreenshots } = require('../writeScreenshots');

--- a/packages/documentation-framework/scripts/writeScreenshots.js
+++ b/packages/documentation-framework/scripts/writeScreenshots.js
@@ -27,7 +27,7 @@ async function writeScreenshot({ page, data: { url, urlPrefix } }) {
   await sharp(buffer).toFile(outfile);
 }
 
-async function writeScreenshots({ urlPrefix, allRoutes }) {
+async function writeScreenshots({ urlPrefix, allRoutes, filterTerm }) {
   const cluster = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
     maxConcurrency: os.cpus().length,
@@ -43,7 +43,9 @@ async function writeScreenshots({ urlPrefix, allRoutes }) {
 
   // Add some pages to queue
   Object.entries(fullscreenRoutes)
-    .filter(([, { isFullscreenOnly }]) => allRoutes || isFullscreenOnly)
+    .filter(([url, { isFullscreenOnly }]) => allRoutes || (
+      isFullscreenOnly && (!filterTerm || url.includes(filterTerm.toLowerCase().split(' ').join('-')))
+    ))
     .forEach(([url,]) => cluster.queue({
       url: `${urlPrefix}${url}`,
       urlPrefix


### PR DESCRIPTION
Closes #3703 

This PR:
- updates the `screenshots` command (`yarn screenshots`) in `cli.js` to add an optional `filterTerm` flag (`--filterTerm` or `-f`) to filter URLs against before screenshots are generated
  - ex: `yarn screenshots --filterTerm extensions` or `yarn screenshots -f 'login page'`
- updates `writeScreenshots` to filter out URL matches against the passed `filterTerm`


One way to test - run locally and update `writeScreenshots` with the second `filter` shown below to console.log out the URLs to be written:
```
// Add some pages to queue
  Object.entries(fullscreenRoutes)
    .filter(([url, { isFullscreenOnly }]) => allRoutes || (
      isFullscreenOnly && (!filterTerm || url.includes(filterTerm.toLowerCase().split(' ').join('-')))
    ))
    .filter(([filteredUrl,]) => {
      console.log(filteredUrl);
      return true;
    })
    .forEach(([url,]) => cluster.queue({
      url: `${urlPrefix}${url}`,
      urlPrefix
    }));
```