### PR TITLE
moved GDPR banner to after page content

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -270,9 +270,6 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
   return (
     <React.Fragment>
       <RtlContext.Provider value={ isRTL }>
-        <div id="ws-page-banners">
-          {hasGdprBanner && <GdprBanner />}
-        </div>
         <Page
           id="ws-page"
           mainContainerId="ws-page-main"
@@ -284,6 +281,9 @@ export const SideNavLayout = ({ children, groupedRoutes, navOpen: navOpenProp })
         >
           {children}
         </Page>
+        <div id="ws-page-banners">
+          {hasGdprBanner && <GdprBanner />}
+        </div>
       </RtlContext.Provider>
     </React.Fragment>
   );


### PR DESCRIPTION
Closes #3621 

Research of common practices did show GDPR/cookie banners loading after page content in DOM order.  This PR moves the banner to after the page content.