### PR TITLE
fix(drag drop): add drag drop to 5.1 versions.json

### DIFF
--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -33,6 +33,7 @@
         "@patternfly/react-icons": "5.0.0",
         "@patternfly/react-styles": "5.0.0",
         "@patternfly/react-table": "5.0.0",
+        "@patternfly/react-drag-drop": "5.0.0-alpha.0",
         "@patternfly/react-tokens": "5.0.0",
         "@patternfly/react-catalog-view-extension": "5.0.0",
         "@patternfly/react-console": "5.0.0",

--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -34,7 +34,6 @@
         "@patternfly/react-icons": "5.0.0",
         "@patternfly/react-styles": "5.0.0",
         "@patternfly/react-table": "5.0.0",
-        "@patternfly/react-drag-drop": "5.0.0-alpha.0",
         "@patternfly/react-tokens": "5.0.0",
         "@patternfly/react-catalog-view-extension": "5.0.0",
         "@patternfly/react-console": "5.0.0",

--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -12,6 +12,7 @@
         "@patternfly/react-icons": "5.1.1",
         "@patternfly/react-styles": "5.1.1",
         "@patternfly/react-table": "5.1.1",
+        "@patternfly/react-drag-drop": "5.0.0-alpha.0",
         "@patternfly/react-tokens": "5.1.1",
         "@patternfly/react-catalog-view-extension": "5.0.0",
         "@patternfly/react-console": "5.0.0",


### PR DESCRIPTION
Not sure if I added the drag drop to a previous version or if another version was added between my PR and the merge but fixing the drag drop to be on the latest version again.