### PR TITLE
chore(actions): update github actions to add issues to project board

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,13 +1,12 @@
-name: Add relevant issues to extensions project board
+name: Add new issues to project board
 
 on:
   issues:
     types:
-      - labeled
+      - opened
 
 jobs:
   add-to-extensions:
-    if: github.event.label.name == 'extension'
     name: Add issue to extensions board
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Updates our github action workflow to add new issues to the project board, not just with an extensions label