### PR TITLE
global vars - remove selector prop, show selector column

### DIFF
--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -80,10 +80,10 @@
     "webpack-merge": "5.8.0"
   },
   "peerDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.38",
-    "@patternfly/react-code-editor": "6.0.0-alpha.5",
-    "@patternfly/react-core": "6.0.0-alpha.5",
-    "@patternfly/react-table": "6.0.0-alpha.5",
+    "@patternfly/patternfly": "6.0.0-alpha.78",
+    "@patternfly/react-code-editor": "6.0.0-alpha.29",
+    "@patternfly/react-core": "6.0.0-alpha.29",
+    "@patternfly/react-table": "6.0.0-alpha.29",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   }

--- a/packages/documentation-framework/pages/global-css-variables.md
+++ b/packages/documentation-framework/pages/global-css-variables.md
@@ -102,8 +102,8 @@ Example:
 
 ## Global CSS variables
 
-<CSSVariables prefix="patternfly_variables" selector=":where(:root)" hideSelectorColumn />
+<CSSVariables prefix="patternfly_variables" />
 
 ## Chart CSS variables
 
-<CSSVariables prefix="patternfly_charts" hideSelectorColumn />
+<CSSVariables prefix="patternfly_charts" />

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -17,7 +17,7 @@
     "screenshots": "pf-docs-framework screenshots"
   },
   "dependencies": {
-    "@patternfly/documentation-framework": "6.0.0-alpha.8",
+    "@patternfly/documentation-framework": "6.0.0-alpha.10",
     "@patternfly/quickstarts": "5.1.0",
     "@patternfly/react-catalog-view-extension": "5.0.0",
     "@patternfly/react-console": "5.0.0",


### PR DESCRIPTION
Towards #3551 

Note: please leave any suggestions for additional enhancements/changes, I wasn't clear if this was all we need currently.

This PR:
- Bumps versions to latest alphas
- Removes the [`selector`](https://github.com/patternfly/patternfly-org/blob/v6/packages/documentation-framework/pages/global-css-variables.md?plain=1#L105) prop used in global-css-variables.md that was filtering to only show rules matching selector `:where(:root)`
  - it now shows all vars, but we could add in new selector `:root` to only show new vars (or leave as-is showing everything and wait until core cleanup?)
- Unhides the "selector" column from the global vars table
  - though all the new vars map to the `:root` selector, this column enables rows to be expanded (where applicable) to track the variable chain.
  - <img width="597" alt="Screenshot 2024-02-12 at 6 47 03 PM" src="https://github.com/patternfly/patternfly-org/assets/8651509/a8002255-84ce-4f4e-8ed3-ebb7f6b76154">
