### PR TITLE
feat(templates): add templates package to versions.json

### DIFF
--- a/packages/documentation-framework/scripts/md/parseMD.js
+++ b/packages/documentation-framework/scripts/md/parseMD.js
@@ -105,6 +105,7 @@ function toReactComponent(mdFilePath, source, buildMode) {
         section: frontmatter.section || '',
         subsection: frontmatter.subsection || '',
         deprecated: frontmatter.deprecated || false,
+        template: frontmatter.template || false,
         beta: frontmatter.beta || false,
         demo: frontmatter.demo || false,
         newImplementationLink: frontmatter.newImplementationLink || false,
@@ -295,6 +296,7 @@ function sourceMDFile(file, source, buildMode) {
       ...(pageData.hideNavItem && { hideNavItem: pageData.hideNavItem }),
       ...(pageData.beta && { beta: pageData.beta }),
       ...(pageData.deprecated && { deprecated: pageData.deprecated }),
+      ...(pageData.template && { template: pageData.template }),
       ...(pageData.demo && { demo: pageData.demo }),
       ...(pageData.sortValue && { sortValue: pageData.sortValue }),
       ...(pageData.subsectionSortValue && { subsectionSortValue: pageData.subsectionSortValue })

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -23,6 +23,7 @@ const MDXChildTemplate = ({
     optIn,
     beta,
     deprecated,
+    template,
     newImplementationLink,
     functionDocumentation = []
   } = Component.getPageData();
@@ -82,6 +83,12 @@ const MDXChildTemplate = ({
             </React.Fragment>
           )}
           {' '}To learn more about the process, visit our <Link to="/get-started/about#major-release-cadence">about page</Link>.
+        </InlineAlert>
+      )}
+       {(template || source === 'react-template') && (
+        <InlineAlert title="Templates" variant="info">
+          {`This section showcases templates for the ${id} component. A template is a wrapped ${id} component use case that has built in logic with a streamlined API, and some limited customization.
+          For custom use cases that fall outside of a template's design, please use the ${id} component suite directly.`}
         </InlineAlert>
       )}
     </React.Fragment>

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -87,7 +87,7 @@ const MDXChildTemplate = ({
       )}
        {(template || source === 'react-template') && (
         <InlineAlert title="Templates" variant="info">
-          {`This page showcases templates for the ${id.toLowerCase()} component. A template consists of the component and additional logic supporting the use case, and has a streamlined API with some limited customization.`}
+          {`This page showcases templates for the ${id.toLowerCase()} component. A template combines a component with logic that supports a specific use case, with a streamlined API that offers additional, limited customization.`}
         </InlineAlert>
       )}
     </React.Fragment>

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -87,8 +87,7 @@ const MDXChildTemplate = ({
       )}
        {(template || source === 'react-template') && (
         <InlineAlert title="Templates" variant="info">
-          {`This section showcases templates for the ${id} component. A template is a wrapped ${id} component use case that has built in logic with a streamlined API, and some limited customization.
-          For custom use cases that fall outside of a template's design, please use the ${id} component suite directly.`}
+          {`This page showcases templates for the ${id.toLowerCase()} component. A template consists of the component and additional logic supporting the use case, and has a streamlined API with some limited customization.`}
         </InlineAlert>
       )}
     </React.Fragment>

--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -21,7 +21,8 @@
         "@patternfly/react-topology": "5.2.1",
         "@patternfly/react-user-feedback": "5.0.0",
         "@patternfly/react-virtualized-extension": "5.0.0",
-        "@patternfly/quickstarts": "5.0.0"
+        "@patternfly/quickstarts": "5.0.0",
+        "@patternfly/react-templates": "^1.0.0-alpha.0"
       }
     },
     {
@@ -45,7 +46,8 @@
         "@patternfly/react-topology": "5.2.1",
         "@patternfly/react-user-feedback": "5.0.0",
         "@patternfly/react-virtualized-extension": "5.0.0",
-        "@patternfly/quickstarts": "5.0.0"
+        "@patternfly/quickstarts": "5.0.0",
+        "@patternfly/react-templates": "^1.0.0-alpha.0"
       }
     },
     {

--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -69,7 +69,8 @@
         "@patternfly/react-topology": "5.2.1",
         "@patternfly/react-user-feedback": "5.0.0",
         "@patternfly/react-virtualized-extension": "5.0.0",
-        "@patternfly/quickstarts": "5.0.0"
+        "@patternfly/quickstarts": "5.0.0",
+        "@patternfly/react-templates": "^1.0.0-alpha.0"
       }
     },{
       "name": "5.1.0",


### PR DESCRIPTION
Closes #3898 

Adds the templates package to `versions.json` to allow the docs to build successfully. Currently version is set to `1.0.0-alpha.0` but may be changed depending on what number we want to start on (1 vs 5 to match other PF packages).