### PR TITLE
chore(): monaco-editor dependency

### DIFF
--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -43,6 +43,7 @@
     "mdast-util-to-hast": "9.1.1",
     "mdurl": "1.0.1",
     "mini-css-extract-plugin": "2.7.5",
+    "monaco-editor": "0.34.1",
     "null-loader": "4.0.1",
     "parse-entities": "2.0.0",
     "path-browserify": "1.0.1",


### PR DESCRIPTION
After bumping the docs framework version in react for the templates package, I'm running into an issue building the code-editor package. I think we do still need `monaco-editor` for it to build without manual dependency installation.