### PR TITLE
chore(a11y): updated a11y scorecard

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/developer-resources/a11y-scores.js
+++ b/packages/documentation-site/patternfly-docs/content/developer-resources/a11y-scores.js
@@ -2,21 +2,24 @@ import React from 'react';
 
 export const a11yScores = [
   {
-    'Nov 21, 2022': [
+    'April 23, 2024': [
       {
-        criteria: 'Preliminary accessibility report generated using axe-core based tooling.',
+        criteria:
+          'Preliminary accessibility report generated using axe-core based tooling.',
         status: '✅',
         notes: (
           <>
-            <a href="https://pf-a11y_5-16-22.surge.sh/">Initial report (May 16th, 2022)</a>
+            <a href="https://pf-a11y_5-16-22.surge.sh/">
+              Initial report (May 16th, 2022)
+            </a>
             <p>1066 violations found</p>
           </>
-        )
+        ),
       },
       {
         criteria: 'Manual keyboard and screen reader testing conducted.',
         status: '--',
-        notes: ''
+        notes: '',
       },
       {
         criteria: `Accessibility violations in product itemized and prioritized. Notes should indicate how violations 
@@ -24,54 +27,172 @@ export const a11yScores = [
         status: '✅',
         notes: (
           <>
-            <a href="https://github.com/patternfly/patternfly-org/issues/2920">patternfly/patternfly-org issue #2920</a>
-            <p>Will be updated once keyboard/screen reader testing conducted</p>
+            <a href="https://github.com/patternfly/patternfly-org/issues/3979">
+              patternfly/patternfly-org issue #3979
+            </a>
+            <p>Errors identified via generated report.</p>
           </>
-        )
+        ),
       },
       {
-        criteria: 'Critical and major accessibility violations identified in item #3 resolved (%).',
-        status: '96%',
+        criteria:
+          'Critical and major accessibility violations identified in item #3 resolved (%).',
+        status: '--',
         notes: (
           <>
-            <a href="http://pf-a11y_11-21-22.surge.sh">Latest generated report (Nov 21, 2022)</a>
-            <p>44 violations remaining</p>
+            <a href="http://pf-a11y_4-23-24.surge.sh">
+              Latest generated report (April 23, 2024)
+            </a>
+            <p>24 violations remaining</p>
           </>
-        )
+        ),
       },
       {
         criteria: `Automated accessibility checks added to pull request or equivalent code acceptance criteria.`,
         status: '--',
-        notes: ''
+        notes: '',
       },
       {
-        criteria: 'Manual keyboard and screen reader accessibility checks added to pull request or equivalent code acceptance criteria.',
+        criteria:
+          'Manual keyboard and screen reader accessibility checks added to pull request or equivalent code acceptance criteria.',
         status: '✅',
-        notes: `Accessibility devs identified and tagged on relevant PRs to manually review screen reader and keyboard interactions`
+        notes: `Accessibility devs identified and tagged on relevant PRs to manually review screen reader and keyboard interactions`,
       },
       {
-        criteria: <>CI/CD Process established to track accessibility violations/regressions. CI/CD process could be wired up to use <a href="https://www.deque.com/axe/">https://www.deque.com/axe/</a> or the patternfly-a11y tool (also built using axe)</>,
+        criteria: (
+          <>
+            CI/CD Process established to track accessibility
+            violations/regressions. CI/CD process could be wired up to use{' '}
+            <a href="https://www.deque.com/axe/">https://www.deque.com/axe/</a>{' '}
+            or the patternfly-a11y tool (also built using axe)
+          </>
+        ),
         status: '--',
-        notes: <>Report <a href="https://github.com/patternfly/patternfly-org/blob/main/packages/v4/patternfly-a11y.config.js">configuration</a> created, needs to be hooked into CI/CD</>
+        notes: (
+          <>
+            Report{' '}
+            <a href="https://github.com/patternfly/patternfly-org/blob/main/packages/v4/patternfly-a11y.config.js">
+              configuration
+            </a>{' '}
+            created, needs to be hooked into CI/CD
+          </>
+        ),
       },
       {
         criteria: `Website built with PatternFly React components. Could note alternate design systems/component 
         libraries along with reference to their accessibility docs.`,
         status: '✅',
-        notes: ''
+        notes: '',
+      },
+      {
+        criteria: 'PatternFly React is up to date with the latest release',
+        status: '✅',
+        notes: `Current versions:
+        "@patternfly/patternfly": "5.3.0",
+        "@patternfly/react-core": "5.3.0"`,
+      },
+      {
+        criteria: 'User testing conducted (Extra credit 🌟)',
+        status: '--',
+        notes: '',
+      },
+    ],
+  },
+  {
+    'Nov 21, 2022': [
+      {
+        criteria:
+          'Preliminary accessibility report generated using axe-core based tooling.',
+        status: '✅',
+        notes: (
+          <>
+            <a href="https://pf-a11y_5-16-22.surge.sh/">
+              Initial report (May 16th, 2022)
+            </a>
+            <p>1066 violations found</p>
+          </>
+        ),
+      },
+      {
+        criteria: 'Manual keyboard and screen reader testing conducted.',
+        status: '--',
+        notes: '',
+      },
+      {
+        criteria: `Accessibility violations in product itemized and prioritized. Notes should indicate how violations 
+        were identified - i.e. via generated report and/or manual testing.`,
+        status: '✅',
+        notes: (
+          <>
+            <a href="https://github.com/patternfly/patternfly-org/issues/2920">
+              patternfly/patternfly-org issue #2920
+            </a>
+            <p>Will be updated once keyboard/screen reader testing conducted</p>
+          </>
+        ),
+      },
+      {
+        criteria:
+          'Critical and major accessibility violations identified in item #3 resolved (%).',
+        status: '96%',
+        notes: (
+          <>
+            <a href="http://pf-a11y_11-21-22.surge.sh">
+              Latest generated report (Nov 21, 2022)
+            </a>
+            <p>44 violations remaining</p>
+          </>
+        ),
+      },
+      {
+        criteria: `Automated accessibility checks added to pull request or equivalent code acceptance criteria.`,
+        status: '--',
+        notes: '',
+      },
+      {
+        criteria:
+          'Manual keyboard and screen reader accessibility checks added to pull request or equivalent code acceptance criteria.',
+        status: '✅',
+        notes: `Accessibility devs identified and tagged on relevant PRs to manually review screen reader and keyboard interactions`,
+      },
+      {
+        criteria: (
+          <>
+            CI/CD Process established to track accessibility
+            violations/regressions. CI/CD process could be wired up to use{' '}
+            <a href="https://www.deque.com/axe/">https://www.deque.com/axe/</a>{' '}
+            or the patternfly-a11y tool (also built using axe)
+          </>
+        ),
+        status: '--',
+        notes: (
+          <>
+            Report{' '}
+            <a href="https://github.com/patternfly/patternfly-org/blob/main/packages/v4/patternfly-a11y.config.js">
+              configuration
+            </a>{' '}
+            created, needs to be hooked into CI/CD
+          </>
+        ),
+      },
+      {
+        criteria: `Website built with PatternFly React components. Could note alternate design systems/component 
+        libraries along with reference to their accessibility docs.`,
+        status: '✅',
+        notes: '',
       },
       {
         criteria: 'PatternFly React is up to date with the latest release',
         status: '✅',
         notes: `Current versions:
         "@patternfly/patternfly": ">=4.185.1",
-        "@patternfly/react-core": ">=4.202.16"`
+        "@patternfly/react-core": ">=4.202.16"`,
       },
       {
         criteria: 'User testing conducted (Extra credit 🌟)',
         status: '--',
-        notes: ''
-      }
-    ]
-  }
+        notes: '',
+      },
+    ],
+  },
 ];

--- a/packages/documentation-site/patternfly-docs/content/developer-resources/a11y-scores.js
+++ b/packages/documentation-site/patternfly-docs/content/developer-resources/a11y-scores.js
@@ -5,14 +5,14 @@ export const a11yScores = [
     'April 23, 2024': [
       {
         criteria:
-          'Preliminary accessibility report generated using axe-core based tooling.',
+          'Accessibility report generated using axe-core based tooling.',
         status: '✅',
         notes: (
           <>
-            <a href="https://pf-a11y_5-16-22.surge.sh/">
-              Initial report (May 16th, 2022)
+            <a href="http://pf-a11y_4-23-24.surge.sh/">
+              Q2 2024 report (April 23, 2024)
             </a>
-            <p>1066 violations found</p>
+            <p>24 violations found</p>
           </>
         ),
       },
@@ -38,14 +38,7 @@ export const a11yScores = [
         criteria:
           'Critical and major accessibility violations identified in item #3 resolved (%).',
         status: '--',
-        notes: (
-          <>
-            <a href="http://pf-a11y_4-23-24.surge.sh">
-              Latest generated report (April 23, 2024)
-            </a>
-            <p>24 violations remaining</p>
-          </>
-        ),
+        notes: <p>24 violations remaining</p>,
       },
       {
         criteria: `Automated accessibility checks added to pull request or equivalent code acceptance criteria.`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,10 +2810,10 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@remix-run/router@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.8.0.tgz#e848d2f669f601544df15ce2a313955e4bf0bafc"
-  integrity sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==
+"@remix-run/router@1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.16.0.tgz#0e10181e5fec1434eb071a9bc4bdaac843f16dcc"
+  integrity sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==
 
 "@spice-project/spice-html5@^0.2.1":
   version "0.2.1"
@@ -2821,9 +2821,9 @@
   integrity sha512-NY86i+x/0ldKK89enXghsXCzWwfb5DQ91hQFu9hbyLcAfCVn+ZKoYsw7xUWX6/HQBRrdu/4F1id7SdOwNqpG9g==
 
 "@testim/chrome-version@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.2.tgz#092005c5b77bd3bb6576a4677110a11485e11864"
-  integrity sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"
+  integrity sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -3804,9 +3804,9 @@ aws4@^1.8.0:
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
 axe-core@^4.4.1:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.2.tgz#dcf7fb6dea866166c3eab33d68208afe4d5f670c"
-  integrity sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.9.0.tgz#b18971494551ab39d4ff5f7d4c6411bd20cc7c2a"
+  integrity sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==
 
 axios@^0.18.1:
   version "0.18.1"
@@ -4382,9 +4382,9 @@ ci-info@^2.0.0:
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 classnames@^2.2.5:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 clean-css@^5.2.2:
   version "5.3.2"
@@ -6298,10 +6298,15 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.4, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+follow-redirects@^1.14.4:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -7651,9 +7656,9 @@ is-wsl@^2.2.0:
     is-docker "^2.0.0"
 
 is2@^2.0.6:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.7.tgz#d084e10cab3bd45d6c9dfde7a48599fcbb93fcac"
-  integrity sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.9.tgz#ff63b441f90de343fa8fac2125ee170da8e8240d"
+  integrity sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==
   dependencies:
     deep-is "^0.1.3"
     ip-regex "^4.1.0"
@@ -10066,9 +10071,9 @@ puppeteer@19.11.1:
     puppeteer-core "19.11.1"
 
 puppeteer@^14.2.0:
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-14.3.0.tgz#0099cabf97767461aca02486313e84fcfc776af6"
-  integrity sha512-pDtg1+vyw1UPIhUjh2/VW1HUdQnaZJHfMacrJciR3AVm+PBiqdCEcFeFb3UJ/CDEQlHOClm3/WFa7IjY25zIGg==
+  version "14.4.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-14.4.1.tgz#6c7437a65f7ba98ef8ad7c2b0f1cf808e91617bb"
+  integrity sha512-+H0Gm84aXUvSLdSiDROtLlOofftClgw2TdceMvvCU9UvMryappoeS3+eOLfKvoy4sm8B8MWnYmPhWxVFudAOFQ==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"
@@ -10228,19 +10233,19 @@ react-measure@^2.3.0:
     resize-observer-polyfill "^1.5.0"
 
 react-router-dom@^6.3.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.15.0.tgz#6da7db61e56797266fbbef0d5e324d6ac443ee40"
-  integrity sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.23.0.tgz#8b80ad92ad28f4dc38972e92d84b4c208150545a"
+  integrity sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==
   dependencies:
-    "@remix-run/router" "1.8.0"
-    react-router "6.15.0"
+    "@remix-run/router" "1.16.0"
+    react-router "6.23.0"
 
-react-router@6.15.0, react-router@^6.3.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.15.0.tgz#bf2cb5a4a7ed57f074d4ea88db0d95033f39cac8"
-  integrity sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==
+react-router@6.23.0, react-router@^6.3.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.23.0.tgz#2f2d7492c66a6bdf760be4c6bdf9e1d672fa154b"
+  integrity sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==
   dependencies:
-    "@remix-run/router" "1.8.0"
+    "@remix-run/router" "1.16.0"
 
 react-ssr-prepass@1.5.0:
   version "1.5.0"
@@ -10796,10 +10801,10 @@ sass-graph@^4.0.1:
     scss-tokenizer "^0.4.3"
     yargs "^17.2.1"
 
-sax@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+sax@^1.2.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
+  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
 
 scheduler@^0.23.0:
   version "0.23.0"
@@ -12855,14 +12860,14 @@ xdg-basedir@^3.0.0:
 xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmldoc@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.1.2.tgz#6666e029fe25470d599cd30e23ff0d1ed50466d7"
-  integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.3.0.tgz#7823225b096c74036347c9ec5924d06b6a3cebab"
+  integrity sha512-y7IRWW6PvEnYQZNZFMRLNJw+p3pezM4nKYPfr15g4OOW9i8VpeydycFuipE2297OvZnh3jSb2pxOt9QpkZUVng==
   dependencies:
-    sax "^1.2.1"
+    sax "^1.2.4"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Closes #3744 

This PR updates the a11y scorecard with a new report link from 4/23/24 and links to a new epic (#3979) with 24 new bugs.