### PR TITLE
feat(docs): fix for missing props tables

### DIFF
--- a/packages/documentation-framework/templates/patternfly-docs/patternfly-docs.source.js
+++ b/packages/documentation-framework/templates/patternfly-docs/patternfly-docs.source.js
@@ -1,16 +1,16 @@
-const path = require('path');
+const path = require("path");
 
 module.exports = (sourceMD, sourceProps) => {
   /** Parse source content for props so that we can display them. You must source props before sourcing the markdown
   files, otherwise the props table won't be rendered.
   */
-  const propsIgnore = ['**/*.test.tsx', '**/examples/*.tsx'];
-  const extensionPath = path.join(__dirname, '../src');
-  sourceProps(path.join(extensionPath, '/**/*.tsx'), propsIgnore);
+  const propsIgnore = ["/**/*.test.tsx", "/**/examples/*.tsx"];
+  const extensionPath = path.join(__dirname, "../src");
+  sourceProps(path.join(extensionPath, "/**/*.tsx"), propsIgnore);
 
-  // Parse md files 
-  const contentBase = path.join(__dirname, './content');
-  sourceMD(path.join(contentBase, 'extensions/**/*.md'), 'extensions');
+  // Parse md files
+  const contentBase = path.join(__dirname, "./content");
+  sourceMD(path.join(contentBase, "extensions/**/*.md"), "extensions");
 
   /**
     If you want to parse content from node_modules instead of providing a relative/absolute path, 
@@ -23,4 +23,4 @@ module.exports = (sourceMD, sourceProps) => {
     sourceMD(path.join(extensionPath, '../patternfly-docs/**\/demos/*.md'), 'react-demos');
     sourceMD(path.join(extensionPath, '../patternfly-docs/**\/design-guidelines/*.md'), 'design-guidelines');
   */
-}
+};

--- a/packages/documentation-site/patternfly-docs/patternfly-docs.source.js
+++ b/packages/documentation-site/patternfly-docs/patternfly-docs.source.js
@@ -6,7 +6,12 @@ module.exports = (sourceMD, sourceProps, sourceFunctionDocs) => {
 
   // Content md
   const contentBase = path.join(__dirname, "../patternfly-docs/content");
-  const reactPropsIgnore = ["**/*.test.tsx", "**/examples/*.tsx"];
+  const reactPropsIgnore = [
+    "/**/examples/**",
+    "/**/__mocks__/**",
+    "/**/__tests__/**",
+    "/**/*.test.tsx",
+  ];
   sourceMD(path.join(contentBase, "extensions/**/*.md"), "extensions");
   if (!(process.env.EXTENSIONS_ONLY === "true")) {
     sourceMD(path.join(contentBase, "contribute/**/*.md"), "pages-contribute");


### PR DESCRIPTION
Closes #3894.

The newer `__mocks__` directory in react was overriding existing props tables data with an empty array when it went to build the docs out, and the existing functionality for ignoring sets of files for the props data gathering wasn't actually working at all. This PR fixes the syntax for the ignore path matching, and adds mocks to the list.

Components that were affected: `Menu`, `MenuList`, `MenuItem`, `MenuContent`, `MenuGroup`, `Button`, `HelperText`