### PR TITLE
fix(docs-framework): adjust back to top z-index

### DIFF
--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -308,7 +308,6 @@
   max-width: 832px;
 }
 
-/* Overlay the footer */
 .ws-back-to-top {
-  z-index: 2;
+  z-index: var(--pf-t--global--z-index--2xl);
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/4014

I think back to top should overlay everything, similar to skip-to-content. currently when it shows up when the jump links on the right are visible, the back to top button is visible, but clicking on it triggers a click on one of the jump links.