### PR TITLE
fix(docs-framework): Stop 'undefined' being included in classnames

### DIFF
--- a/packages/documentation-framework/scripts/md/styled-tags.js
+++ b/packages/documentation-framework/scripts/md/styled-tags.js
@@ -23,12 +23,13 @@ const styledMdTags = [
 function styledTags() {
   return tree => {
     visit(tree, 'element', node => {
+      node.properties.className = node.properties.className || '';
+      
       if (contentStyledMdTags.includes(node.tagName)) {
         node.properties.className += `pf-v6-c-content--${node.tagName}`;
       }
 
       if (styledMdTags.includes(node.tagName)) {
-        node.properties.className = node.properties.className || '';
         node.properties.className += node.properties.className ? ' ' : '';
         node.properties.className += `ws-${node.tagName} `;
         // Match pf-v6-c-table implementation

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -17,7 +17,7 @@
     "screenshots": "pf-docs-framework screenshots"
   },
   "dependencies": {
-    "@patternfly/documentation-framework": "6.0.0-alpha.34",
+    "@patternfly/documentation-framework": "6.0.0-alpha.36",
     "@patternfly/quickstarts": "^5.1.0",
     "@patternfly/react-catalog-view-extension": "5.0.0",
     "@patternfly/react-console": "5.0.0",


### PR DESCRIPTION
Closes #4037 