### PR TITLE
chore(deps): add `@patternfly/react-styles` as dependency

### DIFF
--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -76,6 +76,7 @@
     "@patternfly/patternfly": "5.3.1",
     "@patternfly/react-code-editor": "5.3.3",
     "@patternfly/react-core": "5.3.3",
+    "@patternfly/react-styles": "5.3.1",
     "@patternfly/react-table": "5.3.3",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Adds `@patternfly/react-styles` as peer dependency to the documentation framework. This package is referenced in code, but was never added to the dependencies, causing issues with package managers that hoist dependencies such as PNPM and Yarn.