### PR TITLE
fix: clean up toc/JumpLinks styling

### DIFF
--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -1,12 +1,13 @@
 .ws-toc {
   align-self: flex-start;
   position: sticky;
-  width: calc(100% + var(--pf-v6-c-page__main-section--PaddingLeft) + var(--pf-v6-c-page__main-section--PaddingRight));
+  width: calc(100% + var(--pf-v6-c-page__main-section--PaddingInlineStart) + var(--pf-v6-c-page__main-section--PaddingInlineEnd));
+  background-color: var(--pf-t--global--background--color--secondary--default);
   z-index: 201;
   margin-block-start: calc(var(--pf-v6-c-page__main-section--PaddingTop) * -1);
   margin-block-end: var(--pf-t--global--spacer--md);
-  margin-inline-start: calc(var(--pf-v6-c-page__main-section--PaddingLeft) * -1);
-  margin-inline-end: calc(var(--pf-v6-c-page__main-section--PaddingRight) * -2);
+  margin-inline-start: calc(var(--pf-v6-c-page__main-section--PaddingInlineStart) * -1);
+  margin-inline-end: calc(var(--pf-v6-c-page__main-section--PaddingInlineEnd) * -2);
   padding-block-start: var(--pf-t--global--spacer--md);
   padding-block-end: var(--pf-t--global--spacer--md);
   padding-inline-start: var(--pf-t--global--spacer--md);
@@ -28,7 +29,6 @@
   .ws-toc .pf-v6-c-jump-links__header {
     position: sticky;
     top: 0;
-    background-color: var(--pf-t--global--background--color--secondary--default);
     z-index: 2;
   }
 }

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -64,19 +64,3 @@
   }
 }
 
-/* .ws-toc-link { */
-.ws-toc-item .pf-v6-c-jump-links__link {
-  position: relative;
-  display: block;
-  color: var(--pf-v6-global--Color--300);
-  font-size: var(--pf-t--global--font--size--body--sm);
-  margin: -4px 0;
-}
-
-.ws-toc-sublist > .ws-toc-item:first-child .pf-v6-c-jump-links__link {
-  margin-top: 0;
-}
-
-.ws-toc-item.pf-m-current .pf-v6-c-jump-links__link::before {
-  z-index: 1;
-}

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -2,7 +2,6 @@
   align-self: flex-start;
   position: sticky;
   width: calc(100% + var(--pf-v6-c-page__main-section--PaddingLeft) + var(--pf-v6-c-page__main-section--PaddingRight));
-  background-color: var(--pf-t--global--background--color--200);
   z-index: 201;
   margin-block-start: calc(var(--pf-v6-c-page__main-section--PaddingTop) * -1);
   margin-block-end: var(--pf-t--global--spacer--md);

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -2,8 +2,8 @@
   align-self: flex-start;
   position: sticky;
   width: calc(100% + var(--pf-v6-c-page__main-section--PaddingLeft) + var(--pf-v6-c-page__main-section--PaddingRight));
-  background-color: var(--pf-t--global--background--color--primary--default);
-  z-index: 501;
+  background-color: var(--pf-t--global--background--color--200);
+  z-index: var(--pf-t--global--z-index--sm);
   margin-block-start: calc(var(--pf-v6-c-page__main-section--PaddingTop) * -1);
   margin-block-end: var(--pf-t--global--spacer--md);
   margin-inline-start: calc(var(--pf-v6-c-page__main-section--PaddingLeft) * -1);
@@ -12,23 +12,24 @@
   padding-block-end: var(--pf-t--global--spacer--md);
   padding-inline-start: var(--pf-t--global--spacer--md);
   padding-inline-end: 0;
-/*   box-shadow: var(--pf-v6-global--BoxShadow--lg-bottom); */
+  box-shadow: var(--pf-t--global--box-shadow--lg--bottom);
 }
 
 .ws-toc.pf-m-expanded {
-/*   box-shadow: var(--pf-v6-global--BoxShadow--sm-bottom) */
+  box-shadow: var(--pf-t--global--box-shadow--sm--bottom)
 }
 
 /* Mobile jumplinks */
 @media (max-width: 1450px) {
   .ws-toc.pf-m-expanded .pf-v6-c-jump-links__main {
     max-height: 65vh;
+    overflow-y:scroll;
   }
 
   .ws-toc .pf-v6-c-jump-links__header {
     position: sticky;
     top: 0;
-    background-color: var(--pf-t--global--background--color--primary--default);
+    background-color: var(--pf-t--global--background--color--200);
     z-index: 2;
   }
 }
@@ -67,8 +68,8 @@
 .ws-toc-item .pf-v6-c-jump-links__link {
   position: relative;
   display: block;
-/*   color: var(--ws-toc-link--Color, var(--pf-v6-global--Color--300)); */
-/*   font-size: var(--pf-v6-global--FontSize--sm); */
+  color: var(--pf-v6-global--Color--300);
+  font-size: var(--pf-t--global--font--size--body--sm);
   margin: -4px 0;
 }
 

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -3,7 +3,7 @@
   position: sticky;
   width: calc(100% + var(--pf-v6-c-page__main-section--PaddingLeft) + var(--pf-v6-c-page__main-section--PaddingRight));
   background-color: var(--pf-t--global--background--color--200);
-  z-index: var(--pf-t--global--z-index--sm);
+  z-index: 201;
   margin-block-start: calc(var(--pf-v6-c-page__main-section--PaddingTop) * -1);
   margin-block-end: var(--pf-t--global--spacer--md);
   margin-inline-start: calc(var(--pf-v6-c-page__main-section--PaddingLeft) * -1);
@@ -23,13 +23,13 @@
 @media (max-width: 1450px) {
   .ws-toc.pf-m-expanded .pf-v6-c-jump-links__main {
     max-height: 65vh;
-    overflow-y:scroll;
+    overflow-y:auto;
   }
 
   .ws-toc .pf-v6-c-jump-links__header {
     position: sticky;
     top: 0;
-    background-color: var(--pf-t--global--background--color--200);
+    background-color: var(--pf-t--global--background--color--secondary--default);
     z-index: 2;
   }
 }

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -17,7 +17,7 @@
     "screenshots": "pf-docs-framework screenshots"
   },
   "dependencies": {
-    "@patternfly/documentation-framework": "6.0.0-alpha.51",
+    "@patternfly/documentation-framework": "6.0.0-alpha.52",
     "@patternfly/react-catalog-view-extension": "6.0.0-alpha.4",
     "@patternfly/react-console": "6.0.0-alpha.1",
     "@patternfly/react-docs": "7.0.0-alpha.75",


### PR DESCRIPTION
Closes: https://github.com/patternfly/patternfly-org/issues/4064

I cannot figure out how to get the mobile jumplinks/table of contents to scroll properly.
I tried to do overflow-y: scroll on the `.ws-toc.pf-m-expanded .pf-v6-c-jump-links__main` but it is clipping the toggle arrow. Very open to suggestions.