### PR TITLE
fix(docs): gallery cards fill row height

### DIFF
--- a/packages/documentation-framework/components/sectionGallery/sectionGallery.css
+++ b/packages/documentation-framework/components/sectionGallery/sectionGallery.css
@@ -9,6 +9,11 @@
   color: inherit;
 }
 
+/* Ensure cards within a row stretch vertically to fill row height */
+.ws-section-gallery .pf-v6-c-card {
+  height: 100%;
+}
+
 /* Limit width for data list view only */
 .ws-section-gallery .pf-v6-c-data-list {
   max-width: var(--pf-t--global--breakpoint--lg);


### PR DESCRIPTION
Closes #4179 

This PR adds `height: 100%` to the section gallery pages (ex: All components) so that all cards within a row stretch vertically to match the height of the tallest card in the row.