### PR TITLE
Update sectionGalleryToolbar.js

### DIFF
--- a/packages/documentation-framework/components/sectionGallery/sectionGalleryToolbar.js
+++ b/packages/documentation-framework/components/sectionGallery/sectionGalleryToolbar.js
@@ -60,8 +60,8 @@ export const SectionGalleryToolbar = ({
       </ToolbarGroup>
       <ToolbarItem
         variant="pagination"
-        spacer={{ default: 'spacerMd', md: 'spacerNone' }}
         style={{ '--pf-v6-c-toolbar__item--MinWidth': 'max-content' }}
+        className="pf-m-align-self-center"
       >
         <Content component={ContentVariants.small}>
           {galleryItems.length}


### PR DESCRIPTION
Closes #4181 

This PR center-aligns the toolbar text at the top of gallery pages such as All components.

<img width="615" alt="Screenshot 2024-08-09 at 4 53 13 PM" src="https://github.com/user-attachments/assets/b8fea796-3513-4450-9643-9e27415027cc">
