### PR TITLE
fix(docs): wrap text on ToC jumplinks

### DIFF
--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -67,3 +67,7 @@
   }
 }
 
+.ws-toc-item .pf-m-link {
+  text-wrap: wrap;
+  text-align: left;
+}


### PR DESCRIPTION
Closes #4184 

This PR adds text wrapping to table of contents jumplinks to avoid them running off the screen horizontally, and left-aligns text as it defaults to center-justified when wrapping.