### PR TITLE
feat(docs-framework): Add support for next subpaths in react-charts

### DIFF
--- a/packages/documentation-framework/scripts/md/typecheck.js
+++ b/packages/documentation-framework/scripts/md/typecheck.js
@@ -37,6 +37,7 @@ const reactStyles = globSync(path.join(reactStylesDir, 'css/**/*.d.ts'))
 const defaultImports = [
   'react',
   '@reach/router',
+  '@patternfly/react-charts/next',
   '@patternfly/react-core/next',
   '@patternfly/react-core/deprecated',
   '@patternfly/react-table/deprecated',

--- a/packages/documentation-framework/scripts/webpack/prerender.js
+++ b/packages/documentation-framework/scripts/webpack/prerender.js
@@ -31,7 +31,8 @@ async function prerender(url) {
     // For react-consoles
     createElementNS: () => ({
       download: {}
-    })
+    }),
+    documentElement: { style: {} }
   };
   global.self = {
     // For react-console


### PR DESCRIPTION
To enable https://github.com/patternfly/patternfly-react/pull/10854