### PR TITLE
chore(docs): Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The new v6 site can be built with:
 
 The static assets get copied to build/patternfly-org.
 
+If you see errors, make sure that the version of the `package.json` file in `packages/documentation-framework` matches the version of the `"@patternfly/documentation-framework"` dependency in the `package.json` file in `packages/documentation-site`.
+
 ### Deploy
 
 When you submit a PR, previews should be automatically generated for you and uploaded as PR comments. This takes between 5-10 minutes.
@@ -35,6 +37,16 @@ When you submit a PR, previews should be automatically generated for you and upl
 When the PR is merged to main, the site is first deployed to a [staging S3 bucket.](https://staging.patternfly.org)
 
 When PatternFly does a release (currently every 3 weeks) this bucket is copied to https://patternfly.org.
+
+### Update screenshots
+To update the screenshots (these are the images that you click on to see a full-page demo):
+
+- open a terminal and run `yarn build && yarn serve`
+- in another terminal, run `yarn screenshots`
+
+Make sure that the version of Chromium you are using is relatively recent. Version 112.0.5614.0 (Developer Build), for example, isn't compatible with the latest versions of PatternFly, and your screenshots will be off.
+
+Browse the screenshots to make sure that nothing seems super off. For V6, you can compare to [PatternFly React V6 staging](https://patternfly-react-v6.surge.sh/) and [PatternFly Core V6 staging](https://pf6.patternfly.org/) to verify. You may need to bump PatternFly-React and Core versions if things are only off in the patternfly-org workspace.
 
 ### Old submodules
 
@@ -45,3 +57,7 @@ You might have a dirty file tree with old submodules and folders lying around. Y
 ### Contribute to HTML/CSS
 
 To contribute to PatternFly's HTML/CSS core repo, refer to the [core contribution guide](https://github.com/patternfly/patternfly/blob/main/patternfly-docs/site/pages/contribution.md) and the related [guidelines](https://github.com/patternfly/patternfly/blob/main/patternfly-docs/site/pages/guidelines.md).  
+
+### pf-docs-framework documentation
+
+There is some historic documentation on pf-docs-framework at [packages/documentation-framework/README.md](packages/documentation-framework/README.md).

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:extensions": "EXTENSIONS_ONLY=true PRERELEASE=true yarn build:v6",
     "copy:v6": "rm -rf build/patternfly-org/site && mkdir -p build/patternfly-org && cp -r packages/documentation-site/public build/patternfly-org/site",
     "clean": "lerna run clean && rm -rf build",
-    "serve": "pf-docs-framework serve build/patternfly-org/site",
+    "serve": "npx pf-docs-framework serve build/patternfly-org/site",
     "test:v6": "yarn workspace patternfly-org test:a11y:ci",
     "screenshots": "node node_modules/puppeteer/install.js && yarn workspace patternfly-org screenshots",
     "start": "yarn start:v6",

--- a/packages/documentation-framework/README.md
+++ b/packages/documentation-framework/README.md
@@ -16,52 +16,14 @@ We publish this theme [on npm.](https://www.npmjs.com/package/@patternfly/docume
 
 2. Provide or install the following either as dependencies if you want to use them in your own project, or as devDependencies:
     ```
-    "@patternfly/patternfly": "^4.185.1",
-    "@patternfly/react-core": "^4.202.16",
-    "@patternfly/react-table": "^4.71.16",
-    "@patternfly/react-code-editor": "^4.43.16",
+    "@patternfly/patternfly": "6.0.0-alpha.205",
+    "@patternfly/react-core": "6.0.0-alpha.94",
+    "@patternfly/react-table": "6.0.0-alpha.95",
+    "@patternfly/react-code-editor": "6.0.0-alpha.94",
     ```
     `yarn add -D @patternfly/patternfly @patternfly/react-core @patternfly/react-table @patternfly/react-code-editor`
 
-### Resolutions
-
-This should not be needed, but if you encounter errors installing the above devDependencies, try adding one or more of these resolutions to your package.json file:
-```
-"resolutions": {
-  "@types/react": "^16.8.0",
-  "@types/react-dom": "^16.8.0",
-  "react": "16.8.0",
-  "react-dom": "16.8.0",
-  "chromedriver": "102.0.0",
-  "node-sass": "7.0.1",
-  "puppeteer": "14.3.0",
-  "sharp": "0.30.6"
-}
-```
-
 ## First time setup
-
-### Puppeteer
-
-Puppeteer is used to create screenshots, it requires chromium to be installed on your machine
-
-- install chromium using brew:
-
-  `brew install chromium`
-- check the chromium path, should point to /opt/homebrew/bin/chromium:
-
-  `which chromium`
-- export out the path:
-
-  export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
-  export PUPPETEER_EXECUTABLE_PATH=\`which chromium\`
-
-- So you don't have to retype this in the future, save to your shell rc file like .bashrc or .zshrc:
-
-  echo 'export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true' >> ~/.zshrc
-
-  echo 'export PUPPETEER_EXECUTABLE_PATH=\`which chromium\`' >> ~/.zshrc 
 
 ### Init documentation project
 
@@ -81,48 +43,15 @@ For individual CLI commands, you can also display more information by running `n
 
 ### Develop docs
 
-`yarn docs:develop`
-
-or
-
 `npx pf-docs-framework start`
 
 ### Build docs
-
-`yarn docs:build`
-
-or
 
 `npx pf-docs-framework build all --output public`
 
 > NOTE: If you have `sideEffects: false` in your package.json, that will prevent the CSS from loading in the documentation production build. Set it to true or remove it to enable the CSS from being loaded.
 
-### Generate screenshots
-
-You can generate screenshots against development or production builds.
-
-- Development:
-
-  Terminal 1:
-
-  `yarn docs:develop` or `npx pf-docs-framework start` (Take note of the port it started on, you can modify it in patternfly-docs.config)
-
-  Terminal 2:
-
-  `yarn docs:screenshots` or `npx pf-docs-framework screenshots --urlPrefix http://localhost:<PORT>`
-
-- Production:
-
-  Terminal 1:
-  
-  - `yarn docs:build` or `npx pf-docs-framework build all --output public`
-  - `yarn docs:serve` or `npx pf-docs-framework serve public --port 5000`
-
-  Terminal 2:
-
-  `yarn docs:screenshots` or `npx pf-docs-framework screenshots --urlPrefix http://localhost:5000`
-
-  ### Publish docs to patternfly.org
+### Publish docs to patternfly.org
 
   1. Include the `patternfly-docs/content` and `patternfly-docs/generated` folders as part of your npm published module
 


### PR DESCRIPTION
Added some info on how to generate screenshots and fix errors after discussion with PF team. Also removed old, out-of-date screenshots, etc. documentation in packages subfolder after discussion with PF team. I took out the Puppeteer, etc. section without discussing it because it doesn't seem to be required anymore. I was able to run this without installing Puppeteer separately.