### PR TITLE
fix(docs): updated width on table of contents

### DIFF
--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -48,7 +48,7 @@
 
 @media (min-width: 1451px) {
   .ws-toc {
-    width: 280px;
+    width: 260px;
     max-height: calc(100vh - 76px);
     overflow-y: auto;
     /* Hide TOC scrollbar IE, Edge & Firefox */


### PR DESCRIPTION
It looks like some of the widths changed since v5. This caused flex to stop wrapping the table of contents at the smaller viewports mentioned in https://github.com/patternfly/patternfly-org/issues/4178. The table of contents was still present, but just at the bottom of the screen since the order was 1 (the main content is ordered at 0). Dropping down to this width for the table of contents seems to allow wrapping as expected again.

Should fix https://github.com/patternfly/patternfly-org/issues/4178. I went through every page at 1451px and made sure this jump link width worked ok (main content width appears to be extremely variable). 