### PR TITLE
fix(docs): update theme toggle icon colors

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, createContext } from "react";
+import React, { useEffect, useState, createContext } from 'react';
 import {
   Button,
   Page,
@@ -28,15 +28,15 @@ import {
   ToggleGroup,
   ToggleGroupItem,
   MastheadLogo,
-} from "@patternfly/react-core";
-import BarsIcon from "@patternfly/react-icons/dist/esm/icons/bars-icon";
-import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
-import MoonIcon from "@patternfly/react-icons/dist/esm/icons/moon-icon";
-import SunIcon from "@patternfly/react-icons/dist/esm/icons/sun-icon";
-import { SideNav, TopNav, GdprBanner } from "../../components";
-import staticVersions from "../../versions.json";
-import v5Logo from "../PF-HorizontalLogo-Reverse.svg";
-import { Footer } from "@patternfly/documentation-framework/components";
+} from '@patternfly/react-core';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
+import GithubIcon from '@patternfly/react-icons/dist/esm/icons/github-icon';
+import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
+import SunIcon from '@patternfly/react-icons/dist/esm/icons/sun-icon';
+import { SideNav, TopNav, GdprBanner } from '../../components';
+import staticVersions from '../../versions.json';
+import v5Logo from '../PF-HorizontalLogo-Reverse.svg';
+import { Footer } from '@patternfly/documentation-framework/components';
 
 export const RtlContext = createContext(false);
 
@@ -67,7 +67,7 @@ const HeaderTools = ({
     <DropdownItem
       itemId={version.name}
       key={version.name}
-      to={isLatest ? "/" : `/${version.name}`}
+      to={isLatest ? '/' : `/${version.name}`}
     >
       {`Current ${version.name}`}
     </DropdownItem>
@@ -84,8 +84,8 @@ const HeaderTools = ({
   const toggleDarkTheme = (_evt, selected) => {
     const darkThemeToggleClicked = !selected === isDarkTheme;
     document
-      .querySelector("html")
-      .classList.toggle("pf-v6-theme-dark", darkThemeToggleClicked);
+      .querySelector('html')
+      .classList.toggle('pf-v6-theme-dark', darkThemeToggleClicked);
     setIsDarkTheme(darkThemeToggleClicked);
   };
 
@@ -104,27 +104,19 @@ const HeaderTools = ({
             <TopNav navItems={topNavItems} />
           </ToolbarItem>
         )}
-        <ToolbarGroup align={{ default: "alignEnd" }}>
+        <ToolbarGroup align={{ default: 'alignEnd' }}>
           {hasDarkThemeSwitcher && (
             <ToolbarItem>
               <ToggleGroup aria-label="Dark theme toggle group">
                 <ToggleGroupItem
                   aria-label="light theme toggle"
-                  icon={
-                    <Icon size="md">
-                      <SunIcon />
-                    </Icon>
-                  }
+                  icon={<SunIcon />}
                   isSelected={!isDarkTheme}
                   onChange={toggleDarkTheme}
                 />
                 <ToggleGroupItem
                   aria-label="dark theme toggle"
-                  icon={
-                    <Icon size="md">
-                      <MoonIcon />
-                    </Icon>
-                  }
+                  icon={<MoonIcon />}
                   isSelected={isDarkTheme}
                   onChange={toggleDarkTheme}
                 />
@@ -135,7 +127,7 @@ const HeaderTools = ({
             <ToolbarItem>
               <Switch
                 id="ws-rtl-switch"
-                label={"RTL"}
+                label={'RTL'}
                 defaultChecked={isRTL}
                 onChange={() => setIsRTL((isRTL) => !isRTL)}
               />
@@ -268,7 +260,7 @@ export function attachDocSearch(algolia, inputSelector, timeout) {
         hint: false,
         appendTo: `.ws-global-search .pf-v6-c-text-input-group`,
       },
-      debug: process.env.NODE_ENV !== "production",
+      debug: process.env.NODE_ENV !== 'production',
       ...algolia,
     });
   } else {
@@ -295,11 +287,11 @@ export const SideNavLayout = ({
   const [isRTL, setIsRTL] = useState(false);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === 'undefined') {
       return;
     }
     if (hasVersionSwitcher && window.fetch) {
-      fetch("/versions.json").then((res) => {
+      fetch('/versions.json').then((res) => {
         if (res.ok) {
           res.json().then((json) => setVersions(json));
         }
@@ -327,7 +319,7 @@ export const SideNavLayout = ({
           {prnum ? (
             `PR #${prnum}`
           ) : (
-            <MastheadLogo href={prurl || "/"}>
+            <MastheadLogo href={prurl || '/'}>
               <svg height="40px" viewBox="0 0 679 158">
                 <title>PF-HorizontalLogo-Color</title>
                 <defs>


### PR DESCRIPTION
Closes #4174 

This PR updates the light/dark theme toggle at the top of the website to match the example implementation (passing the icon directly rather than wrapped in the <Icon> component) to fix the issue of the icon showing black on a blue background when the button is selected.