### PR TITLE
fix(homepage): remove is full height

### DIFF
--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -164,7 +164,6 @@ const HeaderTools = ({
                 isOpen={isDropdownOpen}
                 toggle={(toggleRef) => (
                   <MenuToggle
-                    isFullHeight
                     ref={toggleRef}
                     onClick={() => setDropdownOpen(!isDropdownOpen)}
                     isExpanded={isDropdownOpen}


### PR DESCRIPTION
The isFullHeight menu toggle adds extra padding to the version dropdown. 