### PR TITLE
feat(ver): update to final 5.4 pre-release versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "devDependencies": {
     "@patternfly/patternfly": "5.4.0-prerelease.8",
-    "@patternfly/react-code-editor": "5.4.0-prerelease.33",
-    "@patternfly/react-core": "5.4.0-prerelease.31",
-    "@patternfly/react-table": "5.4.0-prerelease.34",
+    "@patternfly/react-code-editor": "5.4.0-prerelease.35",
+    "@patternfly/react-core": "5.4.0-prerelease.33",
+    "@patternfly/react-table": "5.4.0-prerelease.37",
     "@octokit/rest": "^19.0.7",
     "glob": "^8.1.0",
     "lerna": "^6.4.1",

--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -74,10 +74,10 @@
   },
   "peerDependencies": {
     "@patternfly/patternfly": "5.4.0-prerelease.8",
-    "@patternfly/react-code-editor": "5.4.0-prerelease.33",
-    "@patternfly/react-core": "5.4.0-prerelease.31",
+    "@patternfly/react-code-editor": "5.4.0-prerelease.35",
+    "@patternfly/react-core": "5.4.0-prerelease.33",
     "@patternfly/react-styles": "5.4.0-prerelease.11",
-    "@patternfly/react-table": "5.4.0-prerelease.34",
+    "@patternfly/react-table": "5.4.0-prerelease.37",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   }

--- a/packages/documentation-framework/versions.json
+++ b/packages/documentation-framework/versions.json
@@ -7,22 +7,22 @@
       "versions": {
         "@patternfly/patternfly": "5.4.0-prerelease.8",
         "@patternfly/react-charts": "7.4.0-prerelease.17",
-        "@patternfly/react-code-editor": "5.4.0-prerelease.33",
-        "@patternfly/react-core": "5.4.0-prerelease.31",
+        "@patternfly/react-code-editor": "5.4.0-prerelease.35",
+        "@patternfly/react-core": "5.4.0-prerelease.33",
         "@patternfly/react-icons": "5.4.0-prerelease.10",
         "@patternfly/react-styles": "5.4.0-prerelease.11",
-        "@patternfly/react-table": "5.4.0-prerelease.34",
-        "@patternfly/react-drag-drop": "5.4.0-prerelease.32",
+        "@patternfly/react-table": "5.4.0-prerelease.37",
+        "@patternfly/react-drag-drop": "5.4.0-prerelease.34",
         "@patternfly/react-tokens": "5.4.0-prerelease.10",
         "@patternfly/react-catalog-view-extension": "5.0.0",
         "@patternfly/react-component-groups": "5.1.0",
         "@patternfly/react-console": "5.1.0-prerelease.2",
         "@patternfly/react-log-viewer": "5.2.0-prerelease.2",
-        "@patternfly/react-topology": "5.4.0-prerelease.10",
+        "@patternfly/react-topology": "5.4.0-prerelease.13",
         "@patternfly/react-user-feedback": "5.0.0",
         "@patternfly/react-virtualized-extension": "5.0.0",
         "@patternfly/quickstarts": "5.4.0-prerelease.4",
-        "@patternfly/react-templates": "1.1.0-prerelease.35"
+        "@patternfly/react-templates": "1.1.0-prerelease.40"
       }
     },
     {

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -17,13 +17,13 @@
     "screenshots": "pf-docs-framework screenshots"
   },
   "dependencies": {
-    "@patternfly/documentation-framework": "^5.18.0",
+    "@patternfly/documentation-framework": "^5.20.1",
     "@patternfly/quickstarts": "5.4.0-prerelease.4",
     "@patternfly/react-catalog-view-extension": "5.0.0",
     "@patternfly/react-console": "5.1.0-prerelease.2",
-    "@patternfly/react-docs": "6.4.0-prerelease.48",
+    "@patternfly/react-docs": "6.4.0-prerelease.54",
     "@patternfly/react-log-viewer": "5.2.0-prerelease.2",
-    "@patternfly/react-topology": "5.4.0-prerelease.10",
+    "@patternfly/react-topology": "5.4.0-prerelease.13",
     "@patternfly/react-user-feedback": "5.0.0",
     "@patternfly/react-component-groups": "5.2.0",
     "@patternfly/react-virtualized-extension": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,13 +2548,13 @@
     victory-voronoi-container "^37.0.2"
     victory-zoom-container "^37.0.2"
 
-"@patternfly/react-code-editor@5.4.0-prerelease.33", "@patternfly/react-code-editor@^5.4.0-prerelease.33":
-  version "5.4.0-prerelease.33"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-5.4.0-prerelease.33.tgz#5c7d6c8d6cc40413194fafdc0a8d7568aa3c8389"
-  integrity sha512-KwWsGbECOHCFn55O5X+KbjQdkmGD0XlKIl+r/rsXN4+AMdyPHzK3KC4xessjFXQ8qtqQ/ieGLTtTRgjCT/1B1A==
+"@patternfly/react-code-editor@5.4.0-prerelease.35", "@patternfly/react-code-editor@^5.4.0-prerelease.35":
+  version "5.4.0-prerelease.35"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-code-editor/-/react-code-editor-5.4.0-prerelease.35.tgz#037db000761aeda39eae9dc014c99731cc5f771c"
+  integrity sha512-vtxhZc1jb9CVLywtiPzhVPHvHdXacp8+2eVauzc1pxH3VhwI7T56JR048g9aMqN7EFgKUystJTAlrO+ArmhHJw==
   dependencies:
     "@monaco-editor/react" "^4.6.0"
-    "@patternfly/react-core" "^5.4.0-prerelease.31"
+    "@patternfly/react-core" "^5.4.0-prerelease.33"
     "@patternfly/react-icons" "^5.4.0-prerelease.10"
     "@patternfly/react-styles" "^5.4.0-prerelease.11"
     react-dropzone "14.2.3"
@@ -2584,10 +2584,10 @@
     xterm "^4.8.1"
     xterm-addon-fit "^0.2.1"
 
-"@patternfly/react-core@5.4.0-prerelease.31", "@patternfly/react-core@^5.4.0-prerelease.31":
-  version "5.4.0-prerelease.31"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.4.0-prerelease.31.tgz#73a39aed2cc97b6bd9bf0222fad2b23831b27ae3"
-  integrity sha512-ge1P/bfiDyLcWaW1puygMFIrN9N99N0pI3l9p45+X9qUg6pEVhTKNeIMjaiP6fHSklYDSjb/3OWcSBg02tCYiQ==
+"@patternfly/react-core@5.4.0-prerelease.33", "@patternfly/react-core@^5.4.0-prerelease.33":
+  version "5.4.0-prerelease.33"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.4.0-prerelease.33.tgz#95d544b9aa7081ef4b3dfd69733f4f8f6f5e8a11"
+  integrity sha512-Px51Rn8POE0Z+8/dOmM6nnfpXbk9V5pNkmKF2rl56xYv+SRqxvDSKjNvMOLUPlqqLiPovOXI7C/jiD9tNWpFgA==
   dependencies:
     "@patternfly/react-icons" "^5.4.0-prerelease.10"
     "@patternfly/react-styles" "^5.4.0-prerelease.11"
@@ -2620,31 +2620,31 @@
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
 
-"@patternfly/react-docs@6.4.0-prerelease.48":
-  version "6.4.0-prerelease.48"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-6.4.0-prerelease.48.tgz#799539f7105e54b4ebf71974430bc90d99fb76bb"
-  integrity sha512-8UsGg+8Le/SxVxFrKNpuRyjcMh/4os08MgEd7PK0+L4z21JOmcDbe0oHgV6a9XkpijaDZsaqeXRDj1exDA0NPg==
+"@patternfly/react-docs@6.4.0-prerelease.54":
+  version "6.4.0-prerelease.54"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-docs/-/react-docs-6.4.0-prerelease.54.tgz#f7caae3e8521c7b096a0dbff03afbddcdd19ffd8"
+  integrity sha512-y34FC1NfvkckMwmwTKHg41ac8EThwYiE7qNLZPM46zTq7blrYuqdnyJzX0f3Rm9hm1GeLKD9EuWcImTyv0v5Iw==
   dependencies:
     "@patternfly/patternfly" "5.4.0-prerelease.8"
     "@patternfly/react-charts" "^7.4.0-prerelease.17"
-    "@patternfly/react-code-editor" "^5.4.0-prerelease.33"
-    "@patternfly/react-core" "^5.4.0-prerelease.31"
-    "@patternfly/react-drag-drop" "^5.4.0-prerelease.32"
+    "@patternfly/react-code-editor" "^5.4.0-prerelease.35"
+    "@patternfly/react-core" "^5.4.0-prerelease.33"
+    "@patternfly/react-drag-drop" "^5.4.0-prerelease.34"
     "@patternfly/react-icons" "^5.4.0-prerelease.10"
     "@patternfly/react-styles" "^5.4.0-prerelease.11"
-    "@patternfly/react-table" "^5.4.0-prerelease.34"
-    "@patternfly/react-templates" "^1.1.0-prerelease.35"
+    "@patternfly/react-table" "^5.4.0-prerelease.37"
+    "@patternfly/react-templates" "^1.1.0-prerelease.40"
     "@patternfly/react-tokens" "^5.4.0-prerelease.10"
 
-"@patternfly/react-drag-drop@^5.4.0-prerelease.32":
-  version "5.4.0-prerelease.32"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-drag-drop/-/react-drag-drop-5.4.0-prerelease.32.tgz#e7faf7477539674188d3de6f7e1d20ef03169981"
-  integrity sha512-t8JMRia1D+xrii8TrSnTTLiYx27GMGA3LKwZBgeeEEO4s+HVB5Pns95oDCdEpEnH60Jr6O5QxQMzwaqWH6q/ow==
+"@patternfly/react-drag-drop@^5.4.0-prerelease.34":
+  version "5.4.0-prerelease.34"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-drag-drop/-/react-drag-drop-5.4.0-prerelease.34.tgz#a0b619a185c322f20fccccb31e736283297b7f7d"
+  integrity sha512-VxUc8kzSg6TBgwi2v1MkS6uPQ47IAJRxqjsRiRr/b0frG6lfPRPZoRo/h4cGJFC4h/PXwtC1TxiQYpjffFygfw==
   dependencies:
     "@dnd-kit/core" "^6.1.0"
     "@dnd-kit/modifiers" "^6.0.1"
     "@dnd-kit/sortable" "^7.0.2"
-    "@patternfly/react-core" "^5.4.0-prerelease.31"
+    "@patternfly/react-core" "^5.4.0-prerelease.33"
     "@patternfly/react-icons" "^5.4.0-prerelease.10"
     "@patternfly/react-styles" "^5.4.0-prerelease.11"
     resize-observer-polyfill "^1.5.1"
@@ -2689,12 +2689,12 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.4.0-prerelease.11.tgz#87e4bf443d431a18bfb8c02d22f97fe18e7f0b52"
   integrity sha512-l463dA2LM6vx2D4zxCOtNINTSamNSRDsVWK/DCGCF2aMBpnrHh9iBqjz2J+t0EOEQHNdbV5hIuPDH5J0vUZgsw==
 
-"@patternfly/react-table@5.4.0-prerelease.34", "@patternfly/react-table@^5.4.0-prerelease.34":
-  version "5.4.0-prerelease.34"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.4.0-prerelease.34.tgz#0c6162d2c9ee6b9c61f17b831469c798b6eaa794"
-  integrity sha512-Wtywz/tctG5POapUpRRWcVh36lV6bkuoy2OLe8KdFysm2nngU/Snnj7zpfwvkX5bNStV60igEV7K0GAwtWWbkQ==
+"@patternfly/react-table@5.4.0-prerelease.37", "@patternfly/react-table@^5.4.0-prerelease.37":
+  version "5.4.0-prerelease.37"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.4.0-prerelease.37.tgz#34b4d52fbccadbaf5f597233c3ae38b844b0aa2f"
+  integrity sha512-KXcMe5tjfvDtLSc0IzBVIQ38VFedFT8L6g1umP/2rmfGOTJQ5ThRWoJmOS91z0f3vrgpF0mhVAVejK6fEtRgXw==
   dependencies:
-    "@patternfly/react-core" "^5.4.0-prerelease.31"
+    "@patternfly/react-core" "^5.4.0-prerelease.33"
     "@patternfly/react-icons" "^5.4.0-prerelease.10"
     "@patternfly/react-styles" "^5.4.0-prerelease.11"
     "@patternfly/react-tokens" "^5.4.0-prerelease.10"
@@ -2713,12 +2713,12 @@
     lodash "^4.17.19"
     tslib "^2.5.0"
 
-"@patternfly/react-templates@^1.1.0-prerelease.35":
-  version "1.1.0-prerelease.35"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-templates/-/react-templates-1.1.0-prerelease.35.tgz#dc9f70f859293b63f928c4204c96a4d6e3ee795c"
-  integrity sha512-JcKoobbKneMriLvzp5pKflbAI0+dLrDWAIU1roKsFDAiYEt70sYuXDmBi1Y9m+4xHsMwVzFhyZ46+dHVh61hJw==
+"@patternfly/react-templates@^1.1.0-prerelease.40":
+  version "1.1.0-prerelease.40"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-templates/-/react-templates-1.1.0-prerelease.40.tgz#89ab33cc8890cdb2233d5fbd74c5f4b4f8fa45b6"
+  integrity sha512-lz0txytCqj1eEw1d9lpLZ1HgJXQaJZjkmVKTxQDkY3JdvtdVcXBmzSi2mhfLEhnsA+2veAOh9IxT7VimhxXM9A==
   dependencies:
-    "@patternfly/react-core" "^5.4.0-prerelease.31"
+    "@patternfly/react-core" "^5.4.0-prerelease.33"
     "@patternfly/react-icons" "^5.4.0-prerelease.10"
     "@patternfly/react-styles" "^5.4.0-prerelease.11"
     "@patternfly/react-tokens" "^5.4.0-prerelease.10"
@@ -2739,10 +2739,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.4.0-prerelease.10.tgz#fdb31ffab8d769dc8fb78b87b60ac342d0b63d23"
   integrity sha512-uDMF2mujs+1Kwao3VgLUJWRUCn7DSSfmv46zkJD7UX9WT5ZpW1QoX9LWBuf8NAj1tRkIcnZsGPFYiG5/eDQQtw==
 
-"@patternfly/react-topology@5.4.0-prerelease.10":
-  version "5.4.0-prerelease.10"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-5.4.0-prerelease.10.tgz#c6f941ef89bb3e998c405a9abe01aca65f18bacc"
-  integrity sha512-7hTc6Pe5Z1qd54VyONHyANshtJigd9AEWos6y+ekW4QjgUEF+kJ134x7hW7jlNcLLHcrBF3RClCA4Kja8sqVzQ==
+"@patternfly/react-topology@5.4.0-prerelease.13":
+  version "5.4.0-prerelease.13"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-5.4.0-prerelease.13.tgz#cbad32920edb8fa761fc0b29d0b470c507be9416"
+  integrity sha512-MRH4ySUwIsTRn99iAk4IA3O02sRp/2kMTVK0XOLbWV2UP6xqaBMzOtAYFJK1Et4NXrYv7I5eQv5WkEOHX7rn9w==
   dependencies:
     "@dagrejs/dagre" "1.1.2"
     "@patternfly/react-core" "^5.1.1"


### PR DESCRIPTION
```
"@patternfly/patternfly": "5.4.0-prerelease.8",
"@patternfly/react-charts": "7.4.0-prerelease.17",
"@patternfly/react-code-editor": "5.4.0-prerelease.35",
"@patternfly/react-core": "5.4.0-prerelease.33",
"@patternfly/react-drag-drop": "5.4.0-prerelease.34",
"@patternfly/react-icons": "5.4.0-prerelease.10",
"@patternfly/react-styles": "5.4.0-prerelease.11",
"@patternfly/react-table": "5.4.0-prerelease.37",
"@patternfly/react-templates": "1.1.0-prerelease.40",
"@patternfly/react-tokens": "5.4.0-prerelease.10",
“@patternfly/react-topology”: "5.4.0-prerelease.13"
“@patternfly/react-console”: "5.1.0-prerelease.2",
“@patternlfy/react-log-viewer”: "5.2.0-prerelease.2",
“@patternfly/quickstarts”: "5.4.0-prerelease.4"
```