### PR TITLE
chore: Updated to release to staging for aws instead of v6 staging.

### DIFF
--- a/.github/upload-staging.sh
+++ b/.github/upload-staging.sh
@@ -1,13 +1,13 @@
-aws s3 rm --recursive s3://patternfly-org-v6
+aws s3 rm --recursive s3://patternfly-org-staging
 # TODO: Proper S3 meta tags for redirects
-aws s3 sync build/patternfly-org/site s3://patternfly-org-v6 --exclude "*" \
+aws s3 sync build/patternfly-org/site s3://patternfly-org-staging --exclude "*" \
     --include "*.html" \
     --include "*.json" \
     --exclude "static/**/*.json" \
     --include "sw.js" \
     --cache-control "public, max-age=0, must-revalidate"
 
-aws s3 sync build/patternfly-org/site s3://patternfly-org-v6 --include "*" \
+aws s3 sync build/patternfly-org/site s3://patternfly-org-staging --include "*" \
     --exclude "*.html" \
     --exclude "*.json" \
     --include "static/**/*.json" \

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you see errors, make sure that the version of the `package.json` file in `pac
 
 When you submit a PR, previews should be automatically generated for you and uploaded as PR comments. This takes between 5-10 minutes.
 
-When the PR is merged to main, the site is first deployed to a [staging S3 bucket.](https://staging-v6.patternfly.org)
+When the PR is merged to main, the site is first deployed to a [staging S3 bucket.](https://staging.patternfly.org)
 
 When PatternFly does a release (currently every 3 weeks) this bucket is copied to https://patternfly.org.
 
@@ -46,7 +46,7 @@ To update the screenshots (these are the images that you click on to see a full-
 
 Make sure that the version of Chromium you are using is relatively recent. Version 112.0.5614.0 (Developer Build), for example, isn't compatible with the latest versions of PatternFly, and your screenshots will be off.
 
-Browse the screenshots to make sure that nothing seems super off. For V6, you can compare to [PatternFly React V6 staging](https://patternfly-react-v6.surge.sh/) and [PatternFly Core V6 staging](https://pf6.patternfly.org/) to verify. You may need to bump PatternFly-React and Core versions if things are only off in the patternfly-org workspace.
+Browse the screenshots to make sure that nothing seems super off. You can compare to [PatternFly React staging](https://patternfly-react.surge.sh/) and [PatternFly Core staging](https://pf.patternfly.org/) to verify. You may need to bump PatternFly-React and Core versions if things are only off in the patternfly-org workspace.
 
 ### Old submodules
 

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
     "packages/documentation-site"
   ],
   "version": "independent",
-  "allowBranch": ["main", "v4", "v6"]
+  "allowBranch": ["main", "v4", "v5"]
 }

--- a/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
+++ b/packages/documentation-framework/layouts/sideNavLayout/sideNavLayout.js
@@ -200,7 +200,7 @@ const HeaderTools = ({
                       key="PatternFly 6"
                       className="ws-patternfly-versions"
                       isExternalLink
-                      to="https://staging-v6.patternfly.org/"
+                      to="https://staging.patternfly.org/"
                       itemId="patternfly-6"
                     >
                       PatternFly 6


### PR DESCRIPTION
Updated to push to staging instead of v6 staging for patternfly org.