### PR TITLE
docs(design-foundations): Documents tabular font modifier.

### DIFF
--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -17,7 +17,7 @@
     "screenshots": "pf-docs-framework screenshots"
   },
   "dependencies": {
-    "@patternfly/documentation-framework": "6.0.0-alpha.94",
+    "@patternfly/documentation-framework": "6.0.0-alpha.95",
     "@patternfly/react-catalog-view-extension": "6.0.0-alpha.7",
     "@patternfly/react-console": "6.0.0-alpha.5",
     "@patternfly/react-docs": "7.0.0-alpha.113",

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/components/table/table.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/components/table/table.md
@@ -68,6 +68,11 @@ See [when to use compact vs. default spacing](#compact-vs-default-spacing) for m
 
 <img src="./img/compact-and-default-table.png"  alt="Compact and default table"  width="857"/>
 
+### Numeral styling
+
+If needed, we offer a font modifier `.pf-v6-m-tabular-nums` that applies tabular styling to numerals. [Learn more about tabular font styling.](/design-foundations/typography#tabular-font-styling)
+
+
 ### Table capabilities
 Every table can be extended with these functionalities:
 

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/content/numerics.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/content/numerics.md
@@ -3,6 +3,10 @@ id: Numerics
 section: UX writing
 ---
 
+## Font styling
+
+If needed, we offer a font modifier `.pf-v6-m-tabular-nums` that applies tabular styling to numerals. [Learn more about tabular font styling.](/design-foundations/typography#tabular-font-styling)
+
 ## Date and time formats
 
 All date and time formats should be localizable, not hard-coded. When building localizable date and time formats, development teams should share the same library by using resources like [date-fns](https://date-fns.org/) or [Day.js](https://day.js.org/).

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/typography/typography.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/typography/typography.md
@@ -20,7 +20,7 @@ You can place text content on a page using the content or title component:
 We use 3 fonts in PatternFly:
 - **Red Hat Display:** Used for larger text, such as headings.
 - **Red Hat Text:** Used for smaller text, subheadings, and body text. More readable for long-form text. 
-- **Red Hat Mono:** Used to format text as code.
+- **Red Hat Mono:** A tabular font used to format text as code. [Read more about our use of tabular font styling.](#tabular-font)
 
 [Download PatternFly's fonts from GitHub.](https://github.com/RedHatOfficial/RedHatFont)
 
@@ -80,6 +80,14 @@ All body text uses Red Hat Text.
 |<p style="font-size:16px">Aa</p>  | --pf-t--global--font--size--body--lg | 1rem (16px) | 1.5 | Use for larger body text, like in xl empty states.  |
 | <Content><Content component={ContentVariants.p}>Aa</Content></Content> | --pf-t--global--font--size--body--default | 0.875rem (14px) | 1.5 | Use for standard body text. |
 | <Content><Content component={ContentVariants.small}>Aa</Content></Content>  | --pf-t--global--font--size--body--sm | 0.75rem (12px) | 1.5 | User for smaller body text, like helper text. |
+
+## Tabular font styling 
+
+The primary fonts used in PatternFly (Red Hat Display and Red Hat Text) are proportional fonts, which typically offer better readability for standard blocks of text. When numerals are placed within long text bodies, as part of the text, it is best to use a proportional font. 
+
+Sometimes, numerals benefit from the use of a tabular font instead. **Tabular fonts** apply uniform width and spacing to helps maintain proper alignment of numbers. This can be particularly helpful when numbers are dynamically changing on screen, to prevent rough and jumpy movement. 
+
+Tabular font styling is used in a couple of PatternFly components, including slider and progress, but we also offer a modifier that allows you to apply tabular styling on your own: `.pf-v6-m-tabular-nums`, which sets `font-variant-numeric: tabular-nums;`
 
 ## Line height and spacing
 The line height of your text impacts how you should use [spacers](/design-foundations/spacers) in your design. 

--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/typography/typography.md
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/typography/typography.md
@@ -20,7 +20,7 @@ You can place text content on a page using the content or title component:
 We use 3 fonts in PatternFly:
 - **Red Hat Display:** Used for larger text, such as headings.
 - **Red Hat Text:** Used for smaller text, subheadings, and body text. More readable for long-form text. 
-- **Red Hat Mono:** A tabular font used to format text as code. [Read more about our use of tabular font styling.](#tabular-font)
+- **Red Hat Mono:** A tabular font used to format text as code. [Read more about our use of tabular font styling.](#tabular-font-styling)
 
 [Download PatternFly's fonts from GitHub.](https://github.com/RedHatOfficial/RedHatFont)
 


### PR DESCRIPTION
Replaces https://github.com/patternfly/patternfly-org/pull/4260 to fix the many build issues. 

---

The original issue mentions adding these details to the numerics page, but I added the bulk of the docs to our typography page instead, and linked to it from numerics (and also table). Can swap this around, though! But I thought it may make more sense for font-related details to live with the other typography info

Also, maybe this would benefit from an image to demonstrate the difference, but I'm struggling to understand what the actual styling difference is (slashed 0 or just a width change?). The "code" text style in Figma doesn't work for me, if that's the same idea