### PR TITLE
docs(release-highlights): Add more beta highlights.

### DIFF
--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -17,7 +17,7 @@
     "screenshots": "pf-docs-framework screenshots"
   },
   "dependencies": {
-    "@patternfly/documentation-framework": "6.0.0-alpha.94",
+    "@patternfly/documentation-framework": "6.0.0-alpha.95",
     "@patternfly/react-catalog-view-extension": "6.0.0-alpha.7",
     "@patternfly/react-console": "6.0.0-alpha.5",
     "@patternfly/react-docs": "7.0.0-alpha.113",

--- a/packages/documentation-site/patternfly-docs/content/get-started/release-highlights.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/release-highlights.md
@@ -25,7 +25,12 @@ We created a framework for micro animation CSS tokens, which will be used to ena
 ### Content updates 
 
 We made more improvements to our website docs, to ensure that they're accurate and inline with our new token system. A variety of pages and sections were updated, including: 
-- All [tokens](/tokens/about-tokens) pages
+- All tokens pages: 
+    - [About tokens](/tokens/about-tokens)
+    - [All PatternFly tokens](/tokens/all-patternfly-tokens)
+    - [Develop with tokens](/tokens/develop-with-tokens)
+    - [Design with tokens](/tokens/design-with-tokens)
+    - **Note:** Any @patternfly/react-tokens referencing global variables will need to be updated, since global variables have been replaced with tokens. Following our [token migration instructions](/tokens/develop-with-tokens#migrate-to-tokens) will help you determine the correct token to use. 
 - Our design foundations 
     - [Colors](/design-foundations/colors) 
     - [Icons](/design-foundations/icons) 
@@ -51,11 +56,19 @@ We also made updates to some of our component structure and naming conventions. 
 - Renamed the "text" component to ["content."](/components/content)
     - Added `<hr>` element support to the content component.
 - Refactored pagination to use menu toggle rather than options menu.
-- Restructured the mastehead component: 
+- Updated the `<ToolbarItem>` `variant` prop options: 
+    - Replaced "chip-group" with "label-group", to align with the deprecation of chip. 
+    - (Previously) Removed "bulk-select", "overflow-menu", and "search-filter" variants for `<ToolbarItem>`.
+- Restructured the masthead component: 
     - Renamed `<MastheadBrand>` to `<MastheadLogo>`
     - Renamed `<MastheadMain>` to `<MastheadBrand>`
     - Wrapped `<MastheadToggle>` and `<MastheadBrand>` in `<MastheadMain>`
     - Updated our documentation to align with the new structure.
+-  Restructured the empty state component:
+    - Made it less composable, in order to address styling issues.
+    - Updated `<EmptyStateHeader>` and `<EmptyStateIcon>` to be rendered internally within `<EmptyState>`. They should now only be customized using props. 
+    - Updated the content passed to the icon prop on `<EmptyState>` to be wrapped by `<EmptyStateIcon>` automatically.
+    - Made the `titleText` prop required.
 
 ### Extension updates
 


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-org/issues/4221 and replaces PR https://github.com/patternfly/patternfly-org/pull/4244, which had build errors I could not fix. 

Integrated the feedback comment as well