### PR TITLE
fix(docs): hardcode Tile deprecation, fix console errors

### DIFF
--- a/packages/documentation-framework/components/cssVariables/cssVariables.js
+++ b/packages/documentation-framework/components/cssVariables/cssVariables.js
@@ -1,16 +1,9 @@
-import React from "react";
-import { List, ListItem, debounce } from "@patternfly/react-core";
-import {
-  Table,
-  Thead,
-  Th,
-  Tr,
-  Tbody,
-  Td
-} from "@patternfly/react-table";
-import { AutoLinkHeader } from "../autoLinkHeader/autoLinkHeader";
-import * as tokensModule from "@patternfly/react-tokens/dist/esm/componentIndex";
-import LevelUpAltIcon from "@patternfly/react-icons/dist/esm/icons/level-up-alt-icon";
+import React from 'react';
+import { List, ListItem, debounce } from '@patternfly/react-core';
+import { Table, Thead, Th, Tr, Tbody, Td } from '@patternfly/react-table';
+import { AutoLinkHeader } from '../autoLinkHeader/autoLinkHeader';
+import * as tokensModule from '@patternfly/react-tokens/dist/esm/componentIndex';
+import LevelUpAltIcon from '@patternfly/react-icons/dist/esm/icons/level-up-alt-icon';
 import { CSSSearch } from './cssSearch';
 
 const isColorRegex = /^(#|rgb)/;
@@ -19,27 +12,25 @@ const mappingAsList = (property, values) => (
   <List isPlain>
     <ListItem>{property}</ListItem>
     {values.map((entry) => (
-      <ListItem
-        icon={<LevelUpAltIcon className="rotate-90-deg" />}
-      >
+      <ListItem key={entry} icon={<LevelUpAltIcon className="rotate-90-deg" />}>
         {entry}
       </ListItem>
     ))}
   </List>
 );
 
-const flattenList = files => {
+const flattenList = (files) => {
   let list = [];
-  files.forEach(file => {
+  files.forEach((file) => {
     Object.entries(file).forEach(([selector, values]) => {
-      if(values !== undefined) {
+      if (values !== undefined) {
         Object.entries(values).forEach(([key, val]) => {
           list.push({
             selector,
             property: val.name,
             token: key,
             value: val.value,
-            values: val.values
+            values: val.values,
           });
         });
       }
@@ -51,15 +42,15 @@ const flattenList = files => {
 export class CSSVariables extends React.Component {
   constructor(props) {
     super(props);
-    const prefixToken = props.prefix.replace("pf-v6-", "").replace(/-+/g, "_");
+    const prefixToken = props.prefix.replace('pf-v6-', '').replace(/-+/g, '_');
     const applicableFiles = Object.entries(tokensModule)
       .filter(([key, val]) => prefixToken === key)
       .sort(([key1], [key2]) => key1.localeCompare(key2))
       .map(([key, val]) => {
         if (props.selector) {
           return {
-            [props.selector]: val[props.selector]
-          }
+            [props.selector]: val[props.selector],
+          };
         }
         return val;
       });
@@ -69,15 +60,15 @@ export class CSSVariables extends React.Component {
     this.state = {
       searchRE: '',
       rows: this.getFilteredRows(),
-      allRowsExpanded: true
+      allRowsExpanded: true,
     };
   }
 
   getFilteredRows = (searchRE) => {
     let filteredRows = [];
     let rowNumber = -1;
-    this.flatList.forEach(row => {
-      const { selector, property, token, value, values} = row;
+    this.flatList.forEach((row) => {
+      const { selector, property, token, value, values } = row;
       const passes =
         !searchRE ||
         searchRE.test(selector) ||
@@ -88,7 +79,7 @@ export class CSSVariables extends React.Component {
         const rowKey = `${selector}_${property}`;
         const isColor = isColorRegex.test(value);
         const cells = [
-          ...this.props.hideSelectorColumn ? [] : [selector],
+          ...(this.props.hideSelectorColumn ? [] : [selector]),
           property,
           <div key={rowKey}>
             <div
@@ -100,7 +91,10 @@ export class CSSVariables extends React.Component {
                   key={`${rowKey}_2`}
                   className="pf-v6-l-flex pf-m-column pf-m-align-self-center"
                 >
-                  <span className="circle" style={{ backgroundColor: `var(${property})`}}/>
+                  <span
+                    className="circle"
+                    style={{ backgroundColor: `var(${property})` }}
+                  />
                 </div>
               )}
               <div
@@ -110,20 +104,22 @@ export class CSSVariables extends React.Component {
                 {isColor && '(In light theme)'} {value}
               </div>
             </div>
-          </div>
+          </div>,
         ];
         filteredRows.push({
           isOpen: values ? false : undefined,
           cells,
-          details: values ? {
-            parent: rowNumber,
-            fullWidth: true,
-            data: mappingAsList(property, values)
-          } : undefined
+          details: values
+            ? {
+                parent: rowNumber,
+                fullWidth: true,
+                data: mappingAsList(property, values),
+              }
+            : undefined,
         });
         rowNumber += 1;
         if (values) {
-          rowNumber += 1
+          rowNumber += 1;
         }
       }
     });
@@ -136,28 +132,35 @@ export class CSSVariables extends React.Component {
     let newRows = Array.from(rows);
 
     if (collapseAll) {
-      newRows = newRows.map(r => (r.isOpen === undefined ? r : { ...r, isOpen }));
+      newRows = newRows.map((r) =>
+        r.isOpen === undefined ? r : { ...r, isOpen }
+      );
     } else {
       newRows[rowKey] = { ...newRows[rowKey], isOpen };
     }
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       rows: newRows,
-      ...(collapseAll && {allRowsExpanded: !prevState.allRowsExpanded})
+      ...(collapseAll && { allRowsExpanded: !prevState.allRowsExpanded }),
     }));
   };
 
-  getDebouncedFilteredRows = debounce(value => {
-    const searchRE = new RegExp(value, "i");
+  getDebouncedFilteredRows = debounce((value) => {
+    const searchRE = new RegExp(value, 'i');
     this.setState({
       searchRE,
-      rows: this.getFilteredRows(searchRE)
+      rows: this.getFilteredRows(searchRE),
     });
   }, 500);
 
   render() {
     return (
       <React.Fragment>
-        {this.props.autoLinkHeader && <AutoLinkHeader headingLevel="h3" className="pf-v6-u-mt-lg pf-v6-u-mb-md">{`Prefixed with '${this.props.prefix}'`}</AutoLinkHeader>}
+        {this.props.autoLinkHeader && (
+          <AutoLinkHeader
+            headingLevel="h3"
+            className="pf-v6-u-mt-lg pf-v6-u-mb-md"
+          >{`Prefixed with '${this.props.prefix}'`}</AutoLinkHeader>
+        )}
         <CSSSearch getDebouncedFilteredRows={this.getDebouncedFilteredRows} />
         <Table
           variant="compact"
@@ -183,11 +186,11 @@ export class CSSVariables extends React.Component {
                     expand={
                       row.details
                         ? {
-                          rowIndex,
-                          isExpanded: row.isOpen,
-                          onToggle: this.onCollapse,
-                          expandId: `css-vars-expandable-toggle-${this.props.prefix}`
-                        }
+                            rowIndex,
+                            isExpanded: row.isOpen,
+                            onToggle: this.onCollapse,
+                            expandId: `css-vars-expandable-toggle-${this.props.prefix}`,
+                          }
                         : undefined
                     }
                   />
@@ -198,19 +201,22 @@ export class CSSVariables extends React.Component {
                 {row.details ? (
                   <Tr isExpanded={row.isOpen}>
                     {!row.details.fullWidth ? <Td /> : null}
-                    <Td dataLabel="Selector" colSpan={5}>{row.details.data}</Td>
+                    <Td dataLabel="Selector" colSpan={5}>
+                      {row.details.data}
+                    </Td>
                   </Tr>
                 ) : null}
               </Tbody>
-            ))) : (
-              <Tbody>
-                {this.state.rows.map((row, rowIndex) => (
-                  <Tr key={rowIndex}>
-                    <Td dataLabel="Variable">{row.cells[0]}</Td>
-                    <Td dataLabel="Value">{row.cells[1]}</Td>
-                  </Tr>
-                ))}
-              </Tbody>
+            ))
+          ) : (
+            <Tbody>
+              {this.state.rows.map((row, rowIndex) => (
+                <Tr key={rowIndex}>
+                  <Td dataLabel="Variable">{row.cells[0]}</Td>
+                  <Td dataLabel="Value">{row.cells[1]}</Td>
+                </Tr>
+              ))}
+            </Tbody>
           )}
         </Table>
       </React.Fragment>

--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   Brand,
   Grid,
@@ -7,11 +7,11 @@ import {
   ListItem,
   PageSection,
   Content,
-} from "@patternfly/react-core";
-import { Link } from "@patternfly/documentation-framework/components";
-import { GithubIcon } from "@patternfly/react-icons";
-import redhatLogo from "./RHLogo.png";
-import redhatLogoDark from "./RHLogoDark.png";
+} from '@patternfly/react-core';
+import { Link } from '@patternfly/documentation-framework/components';
+import { GithubIcon } from '@patternfly/react-icons';
+import redhatLogo from './RHLogo.png';
+import redhatLogoDark from './RHLogoDark.png';
 
 export const Footer = ({ isDarkTheme }) => (
   <React.Fragment>
@@ -36,7 +36,7 @@ export const Footer = ({ isDarkTheme }) => (
               <p className="ws-org-pfsite-footer-menu-list-title">What's new</p>
               <nav aria-label="Quick Links">
                 <List isPlain className="ws-org-pfsite-footer-menu-list">
-                <ListItem className="ws-org-pfsite-footer-menu-list-item">
+                  <ListItem className="ws-org-pfsite-footer-menu-list-item">
                     <Link
                       className="ws-org-pfsite-footer-menu-link"
                       to="/get-started/upgrade"
@@ -83,7 +83,7 @@ export const Footer = ({ isDarkTheme }) => (
               <p className="ws-org-pfsite-footer-menu-list-title">Contribute</p>
               <nav aria-label="Contribute">
                 <List isPlain className="ws-org-pfsite-footer-menu-list">
-                <ListItem className="ws-org-pfsite-footer-menu-list-item">
+                  <ListItem className="ws-org-pfsite-footer-menu-list-item">
                     <Link
                       className="ws-org-pfsite-footer-menu-link"
                       to="/get-started/about-patternfly"
@@ -110,7 +110,7 @@ export const Footer = ({ isDarkTheme }) => (
                       Contribute
                     </Link>
                   </ListItem>
-                  </List>
+                </List>
               </nav>
             </GridItem>
             <GridItem
@@ -118,9 +118,7 @@ export const Footer = ({ isDarkTheme }) => (
               md={4}
               className="pf-v6-u-mt-lg pf-v6-u-mt-0-on-md pf-v6-u-ml-md pf-v6-u-ml-0-on-md"
             >
-              <p className="ws-org-pfsite-footer-menu-list-title">
-                Community
-              </p>
+              <p className="ws-org-pfsite-footer-menu-list-title">Community</p>
               <nav aria-label="Stay in touch">
                 <List isPlain className="ws-org-pfsite-footer-menu-list">
                   <ListItem className="ws-org-pfsite-footer-menu-list-item">
@@ -140,7 +138,7 @@ export const Footer = ({ isDarkTheme }) => (
                       target="top"
                       aria-label="Read the PatternFly blog"
                     >
-                     Blog
+                      Blog
                     </Link>
                   </ListItem>
                   <ListItem className="ws-org-pfsite-footer-menu-list-item">
@@ -171,7 +169,7 @@ export const Footer = ({ isDarkTheme }) => (
                     >
                       Discussions
                     </Link>
-                </ListItem>
+                  </ListItem>
                 </List>
               </nav>
             </GridItem>
@@ -268,9 +266,19 @@ export const Footer = ({ isDarkTheme }) => (
                 target="top"
                 aria-label="Link to PatternFly X page"
               >
-                <svg class="pf-v6-svg" viewBox="0 0 512 512" fill="currentColor" aria-hidden="true" role="img" width="1em" height="1em"><path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"></path></svg>
+                <svg
+                  className="pf-v6-svg"
+                  viewBox="0 0 512 512"
+                  fill="currentColor"
+                  aria-hidden="true"
+                  role="img"
+                  width="1em"
+                  height="1em"
+                >
+                  <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"></path>
+                </svg>
               </Link>
-               {/* Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.*/}
+              {/* Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.*/}
             </GridItem>
           </Grid>
         </GridItem>

--- a/packages/documentation-framework/components/sideNav/sideNav.js
+++ b/packages/documentation-framework/components/sideNav/sideNav.js
@@ -1,58 +1,88 @@
 import React from 'react';
 import { Link } from '../link/link';
-import { Label, Nav, NavList, NavExpandable, PageContextConsumer, capitalize, Flex, FlexItem } from '@patternfly/react-core';
+import {
+  Label,
+  Nav,
+  NavList,
+  NavExpandable,
+  PageContextConsumer,
+  capitalize,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { Location } from '@reach/router';
 import { makeSlug } from '../../helpers';
-import globalBreakpointXl from "@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl";
+import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl';
 import { trackEvent } from '../../helpers';
 
 const getIsActive = (location, section, subsection = null) => {
   const slug = makeSlug(null, section, null, null, subsection);
   return location.pathname.startsWith(slug);
-}
+};
 
 const defaultValue = 50;
 
 const NavItem = ({ text, href, isDeprecated, isBeta, isDemo }) => {
-  const isMobileView = window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
+  const isMobileView =
+    window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
   return (
     <PageContextConsumer key={href + text}>
-      {({onSidebarToggle, isSidebarOpen }) => (
-          <li key={href + text} className="pf-v6-c-nav__item" onClick={() => isMobileView && onSidebarToggle && onSidebarToggle()}>
-            <Link
-              to={href}
-              getProps={({ isCurrent, href, location }) => {
-                const { pathname } = location;
-                return {
-                  className: css(
-                    'pf-v6-c-nav__link',
-                    (isCurrent || pathname.startsWith(href + '/')) && 'pf-m-current'
-                  )
-                }}
-              }
-              tabIndex={isSidebarOpen ? undefined : -1}
-            >
-              <Flex spaceItems={{ default: 'spaceItemsSm'}}>
-                <FlexItem>{text}</FlexItem>
-                {(isBeta || isDemo || isDeprecated) && (
-                  <FlexItem>
-                    {isBeta && (<Label color="blue" isCompact>Beta</Label>)}
-                    {!isBeta && isDeprecated && (<Label color="grey" isCompact>Deprecated</Label>)}
-                    {!isBeta && !isDeprecated && isDemo && (<Label color="purple" isCompact>Demo</Label>)}
-                  </FlexItem>
-                )}
-              </Flex>
-
-
-            </Link>
-          </li>
+      {({ onSidebarToggle, isSidebarOpen }) => (
+        <li
+          key={href + text}
+          className="pf-v6-c-nav__item"
+          onClick={() => isMobileView && onSidebarToggle && onSidebarToggle()}
+        >
+          <Link
+            to={href}
+            getProps={({ isCurrent, href, location }) => {
+              const { pathname } = location;
+              return {
+                className: css(
+                  'pf-v6-c-nav__link',
+                  (isCurrent || pathname.startsWith(href + '/')) &&
+                    'pf-m-current'
+                ),
+              };
+            }}
+            tabIndex={isSidebarOpen ? undefined : -1}
+          >
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>{text}</FlexItem>
+              {(isBeta || isDemo || isDeprecated) && (
+                <FlexItem>
+                  {isBeta && (
+                    <Label color="blue" isCompact>
+                      Beta
+                    </Label>
+                  )}
+                  {!isBeta && isDeprecated && (
+                    <Label color="grey" isCompact>
+                      Deprecated
+                    </Label>
+                  )}
+                  {!isBeta && !isDeprecated && isDemo && (
+                    <Label color="purple" isCompact>
+                      Demo
+                    </Label>
+                  )}
+                </FlexItem>
+              )}
+            </Flex>
+          </Link>
+        </li>
       )}
     </PageContextConsumer>
-  )
+  );
 };
 
-const ExpandableNav = ({groupedRoutes, location, section, subsection = null}) => {
+const ExpandableNav = ({
+  groupedRoutes,
+  location,
+  section,
+  subsection = null,
+}) => {
   const isActive = getIsActive(location, section, subsection);
   const isSubsection = subsection;
   const routes = isSubsection
@@ -72,39 +102,97 @@ const ExpandableNav = ({groupedRoutes, location, section, subsection = null}) =>
         event.stopPropagation();
         // Don't trigger for bubbled events from NavItems
         if (!event.target.href) {
-          const isExpanded = event.currentTarget.classList.contains('pf-m-expanded');
+          const isExpanded =
+            event.currentTarget.classList.contains('pf-m-expanded');
           // 1 === expand section, 0 === collapse section
-          trackEvent('sidenav_section_click', 'click_event', analyticsName, isExpanded ? 0 : 1);
+          trackEvent(
+            'sidenav_section_click',
+            'click_event',
+            analyticsName,
+            isExpanded ? 0 : 1
+          );
         }
       }}
     >
       {Object.entries(routes || {})
-        .filter(([id, navObj]) => !Boolean(navObj.hideNavItem) && (Object.entries(navObj).length > 0))
-        .map(([id, { slug, isSubsection = false, sortValue = defaultValue, subsectionSortValue = defaultValue, sources }]) => ({ text: id, href: slug, isSubsection, sortValue: (isSubsection ? subsectionSortValue : sortValue), sources }))
-        .sort(({text: text1, sortValue: sortValue1}, {text: text2, sortValue: sortValue2}) => {
-          if (sortValue1 === sortValue2) {
-            return text1.localeCompare(text2);
+        .filter(
+          ([id, navObj]) =>
+            !Boolean(navObj.hideNavItem) && Object.entries(navObj).length > 0
+        )
+        .map(
+          ([
+            id,
+            {
+              slug,
+              isSubsection = false,
+              sortValue = defaultValue,
+              subsectionSortValue = defaultValue,
+              sources,
+            },
+          ]) => ({
+            text: id,
+            href: slug,
+            isSubsection,
+            sortValue: isSubsection ? subsectionSortValue : sortValue,
+            sources,
+          })
+        )
+        .sort(
+          (
+            { text: text1, sortValue: sortValue1 },
+            { text: text2, sortValue: sortValue2 }
+          ) => {
+            if (sortValue1 === sortValue2) {
+              return text1.localeCompare(text2);
+            }
+            return sortValue1 > sortValue2 ? 1 : -1;
           }
-          return sortValue1 > sortValue2 ? 1 : -1;
-        })
-        .map(navObj => navObj.isSubsection
-            ? ExpandableNav({groupedRoutes, location, section, subsection: navObj.text})
+        )
+        .map((navObj) => {
+          return navObj.isSubsection
+            ? ExpandableNav({
+                groupedRoutes,
+                location,
+                section,
+                subsection: navObj.text,
+              })
             : NavItem({
-              ...navObj,
-              isDeprecated: navObj.href?.includes('components') && navObj.sources.some(source => (
-                  source.source === "react-deprecated" || source.source === "html-deprecated")
-                && !navObj.sources.some(source => source.source === "react" || source.source === "html")
-              ),
-              isBeta: navObj.sources.some(source => source.beta && source.source !== 'react-next' && source.source !== 'react-templates'),
-              isDemo: navObj.sources.some(source => (
-                  source.source === "react-demos" || source.source === "html-demos")
-                && !navObj.sources.some(source => source.source === "react" || source.source === "html")
-              )
-            })
-        )}
+                ...navObj,
+                isDeprecated:
+                  navObj.href?.includes('components') &&
+                  navObj.sources.some(
+                    (source) =>
+                      (source.source === 'react-deprecated' ||
+                        source.source === 'html-deprecated') &&
+                      // TODO: remove hardcoded Tile when Core PR merges
+                      // https://github.com/patternfly/patternfly/pull/7178
+                      (source.id === 'Tile' ||
+                        !navObj.sources.some(
+                          (source) =>
+                            source.source === 'react' ||
+                            source.source === 'html'
+                        ))
+                  ),
+                isBeta: navObj.sources.some(
+                  (source) =>
+                    source.beta &&
+                    source.source !== 'react-next' &&
+                    source.source !== 'react-templates'
+                ),
+                isDemo: navObj.sources.some(
+                  (source) =>
+                    (source.source === 'react-demos' ||
+                      source.source === 'html-demos') &&
+                    !navObj.sources.some(
+                      (source) =>
+                        source.source === 'react' || source.source === 'html'
+                    )
+                ),
+              });
+        })}
     </NavExpandable>
   );
-}
+};
 
 export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
   React.useEffect(() => {
@@ -115,7 +203,8 @@ export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
     if (!overflowElement) {
       return;
     }
-    const activeElements = overflowElement.getElementsByClassName('pf-m-current');
+    const activeElements =
+      overflowElement.getElementsByClassName('pf-m-current');
     if (activeElements.length > 0) {
       const lastElement = activeElements[activeElements.length - 1];
       lastElement.scrollIntoView({ block: 'center' });
@@ -125,18 +214,22 @@ export const SideNav = ({ groupedRoutes = {}, navItems = [] }) => {
   return (
     <Nav aria-label="Side Nav" theme="light">
       <NavList className="ws-side-nav-list">
-        {navItems.map(({ section, text, href }) => section
-          ? (
+        {navItems.map(({ section, text, href }) =>
+          section ? (
             <Location key={section}>
-              {({ location }) => ExpandableNav({groupedRoutes, location, section})}
+              {({ location }) =>
+                ExpandableNav({ groupedRoutes, location, section })
+              }
             </Location>
-          )
-          : NavItem({
-              text: text || capitalize(href.replace(/\//g, '').replace(/-/g, ' ')),
-              href: href
+          ) : (
+            NavItem({
+              text:
+                text || capitalize(href.replace(/\//g, '').replace(/-/g, ' ')),
+              href: href,
             })
+          )
         )}
       </NavList>
     </Nav>
   );
-}
+};

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -1,21 +1,37 @@
 import React from 'react';
-import { PageSection, Title, Tooltip, PageSectionVariants, Button, BackToTop, Flex, FlexItem, PageGroup, Page, Content, Label, Stack, StackItem } from '@patternfly/react-core';
+import {
+  PageSection,
+  Title,
+  Tooltip,
+  PageSectionVariants,
+  Button,
+  BackToTop,
+  Flex,
+  FlexItem,
+  PageGroup,
+  Page,
+  Content,
+  Label,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Router, useLocation } from '@reach/router';
-import { CSSVariables, PropsTable, TableOfContents, Link, AutoLinkHeader, InlineAlert } from '../components';
+import {
+  CSSVariables,
+  PropsTable,
+  TableOfContents,
+  Link,
+  AutoLinkHeader,
+  InlineAlert,
+} from '../components';
 import { capitalize, getTitle, slugger, trackEvent } from '../helpers';
 import './mdx.css';
 import { convertToReactComponent } from '@patternfly/ast-helpers';
 import { FunctionsTable } from '../components/functionsTable/functionsTable';
 
-const MDXChildTemplate = ({
-  Component,
-  source,
-  toc = [],
-  index = 0,
-  id
-}) => {
+const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
   const {
     propComponents = [],
     sourceLink,
@@ -25,60 +41,107 @@ const MDXChildTemplate = ({
     deprecated,
     template,
     newImplementationLink,
-    functionDocumentation = []
+    functionDocumentation = [],
   } = Component.getPageData();
   const cssVarsTitle = cssPrefix.length > 0 && 'CSS variables';
   const propsTitle = propComponents.length > 0 && 'Props';
-  if (propsTitle && !toc.find(item => item.text === propsTitle)) {
+  if (propsTitle && !toc.find((item) => item.text === propsTitle)) {
     toc.push({ text: propsTitle });
-    toc.push(propComponents.map(propComponent => ({ text: propComponent.name })));
+    toc.push(
+      propComponents.map((propComponent) => ({ text: propComponent.name }))
+    );
   }
-  if (cssVarsTitle && !toc.find(item => item.text === cssVarsTitle)) {
+  if (cssVarsTitle && !toc.find((item) => item.text === cssVarsTitle)) {
     toc.push({ text: cssVarsTitle });
     if (cssPrefix.length > 1) {
-      toc.push(cssPrefix.map(cssPrefix => ({ text: `Prefixed with '${cssPrefix}'` })));
+      toc.push(
+        cssPrefix.map((cssPrefix) => ({ text: `Prefixed with '${cssPrefix}'` }))
+      );
     }
   }
   // We don't add `id`s in anchor-header.js for items where id === slugger(text)
   // in order to save ~10KB bandwidth.
   if (toc.length > 1) {
-    const ensureID = tocItem => {
+    const ensureID = (tocItem) => {
       if (Array.isArray(tocItem)) {
         tocItem.forEach(ensureID);
+      } else if (!tocItem.id) {
+        tocItem.id = slugger(tocItem.text);
       }
-      else if (!tocItem.id) {
-        tocItem.id = slugger(tocItem.text)
-      }
-    }
+    };
     ensureID(toc);
   }
 
-  const isComponentCodeDocs = ['react', 'react-demos', 'html', 'html-demos', 'react-templates'].includes(source);
+  const isComponentCodeDocs = [
+    'react',
+    'react-demos',
+    'html',
+    'html-demos',
+    'react-templates',
+  ].includes(source);
 
-  const InlineAlerts = (optIn || beta || deprecated || source === 'react-deprecated' || source === 'html-deprecated' || template || source === 'react-template') && (
+  const InlineAlerts = (optIn ||
+    beta ||
+    deprecated ||
+    source === 'react-deprecated' ||
+    source === 'html-deprecated' ||
+    // TODO: remove hardcoded Tile when Core PR merges
+    // https://github.com/patternfly/patternfly/pull/7178
+    id === 'Tile' ||
+    template ||
+    source === 'react-template') && (
     <StackItem>
-      {optIn && (
-        <InlineAlert title="Opt-in feature">
-          {optIn}
-        </InlineAlert>
-      )}
+      {optIn && <InlineAlert title="Opt-in feature">{optIn}</InlineAlert>}
       {beta && (
         <InlineAlert title="Beta feature">
-          This beta component is currently under review and is still open for further evolution. It is available for use in product. Beta components are considered for promotion on a quarterly basis. Please join in and give us your feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">Slack</a>. To learn more about the process, visit our <Link to="/get-started/about-patternfly#beta-components">about page</Link> or our <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">Beta components</a> page on GitHub.
+          This beta component is currently under review and is still open for
+          further evolution. It is available for use in product. Beta components
+          are considered for promotion on a quarterly basis. Please join in and
+          give us your feedback or submit any questions on the{' '}
+          <a href="https://forum.patternfly.org/">PatternFly forum</a> or via{' '}
+          <a
+            href="//slack.patternfly.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Slack
+          </a>
+          . To learn more about the process, visit our{' '}
+          <Link to="/get-started/about-patternfly#beta-components">
+            about page
+          </Link>{' '}
+          or our{' '}
+          <a href="https://github.com/patternfly/patternfly-org/tree/main/beta-component-promotion">
+            Beta components
+          </a>{' '}
+          page on GitHub.
         </InlineAlert>
       )}
-      {(deprecated || source === 'react-deprecated' || source === 'html-deprecated') && (
+      {(deprecated ||
+        source === 'react-deprecated' ||
+        source === 'html-deprecated' ||
+        // TODO: remove hardcoded Tile when Core PR merges
+        // https://github.com/patternfly/patternfly/pull/7178
+        id === 'Tile') && (
         <InlineAlert title="Deprecated feature" variant="warning">
-          This component implementation has been deprecated in favor of a newer solution, and is no longer being maintained or enhanced.
+          This component implementation has been deprecated in favor of a newer
+          solution, and is no longer being maintained or enhanced.
           {newImplementationLink && (
             <React.Fragment>
-              You can find the <Link to={newImplementationLink}>updated implementation here</Link>.
+              You can find the{' '}
+              <Link to={newImplementationLink}>
+                updated implementation here
+              </Link>
+              .
             </React.Fragment>
-          )}
-          {' '}To learn more about deprecated components, visit <Link to="/get-started/about-patternfly#deprecated-components">about PatternFly.</Link>
+          )}{' '}
+          To learn more about deprecated components, visit{' '}
+          <Link to="/get-started/about-patternfly#deprecated-components">
+            about PatternFly.
+          </Link>
         </InlineAlert>
       )}
-       {(template || source === 'react-template') && (
+      {(template || source === 'react-template') && (
         <InlineAlert title="Templates" variant="info">
           {`This page showcases templates for the ${id.toLowerCase()} component. A template combines a component with logic that supports a specific use case, with a streamlined API that offers additional, limited customization.`}
         </InlineAlert>
@@ -88,107 +151,164 @@ const MDXChildTemplate = ({
   // Create dynamic component for @reach/router
   const ChildComponent = () => (
     <div className={source !== 'landing-pages' ? 'pf-v6-l-flex' : ''}>
-      {toc.length > 1 && (
-        <TableOfContents items={toc} />
-      )}
-      <Stack hasGutter style={{...(source !== 'landing-pages' && {maxWidth: "825px"})}}>
+      {toc.length > 1 && <TableOfContents items={toc} />}
+      <Stack
+        hasGutter
+        style={{ ...(source !== 'landing-pages' && { maxWidth: '825px' }) }}
+      >
         {InlineAlerts}
-          <Component />
-          {functionDocumentation.length > 0 && (
-            <StackItem>
-              <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2" id="functions">
-                Functions
-              </AutoLinkHeader>
-              <FunctionsTable functionDescriptions={functionDocumentation}/>
-            </StackItem>
-          )}
-          {propsTitle && (
-            <StackItem>
-              <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2" id="props">
-                {propsTitle}
-              </AutoLinkHeader>
-              {propComponents.map(component => (
-                <PropsTable
-                  key={component.name}
-                  title={component.name}
-                  description={component.description}
-                  rows={component.props}
-                  allPropComponents={propComponents}
-                />
-              ))}
-            </StackItem>
-          )}
-          {cssPrefix.length > 0 && (
-            <StackItem>
-              <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2" id="css-variables">
-                {cssVarsTitle}
-              </AutoLinkHeader>
-              {cssPrefix.map((prefix, index) => (
-                <CSSVariables key={index} autoLinkHeader={cssPrefix.length > 1} prefix={prefix} />
-              ))}
-            </StackItem>
-          )}
-          {sourceLink && (
-            <StackItem>
-              <br />
-              <a href={sourceLink} target="_blank" onClick={() => trackEvent('view_source_click', 'click_event', source.toUpperCase())}>View source on GitHub</a>
-            </StackItem>
-          )}
+        <Component />
+        {functionDocumentation.length > 0 && (
+          <StackItem>
+            <AutoLinkHeader
+              headingLevel="h2"
+              className="pf-v6-c-content--h2"
+              id="functions"
+            >
+              Functions
+            </AutoLinkHeader>
+            <FunctionsTable functionDescriptions={functionDocumentation} />
+          </StackItem>
+        )}
+        {propsTitle && (
+          <StackItem>
+            <AutoLinkHeader
+              headingLevel="h2"
+              className="pf-v6-c-content--h2"
+              id="props"
+            >
+              {propsTitle}
+            </AutoLinkHeader>
+            {propComponents.map((component) => (
+              <PropsTable
+                key={component.name}
+                title={component.name}
+                description={component.description}
+                rows={component.props}
+                allPropComponents={propComponents}
+              />
+            ))}
+          </StackItem>
+        )}
+        {cssPrefix.length > 0 && (
+          <StackItem>
+            <AutoLinkHeader
+              headingLevel="h2"
+              className="pf-v6-c-content--h2"
+              id="css-variables"
+            >
+              {cssVarsTitle}
+            </AutoLinkHeader>
+            {cssPrefix.map((prefix, index) => (
+              <CSSVariables
+                key={index}
+                autoLinkHeader={cssPrefix.length > 1}
+                prefix={prefix}
+              />
+            ))}
+          </StackItem>
+        )}
+        {sourceLink && (
+          <StackItem>
+            <br />
+            <a
+              href={sourceLink}
+              target="_blank"
+              onClick={() =>
+                trackEvent(
+                  'view_source_click',
+                  'click_event',
+                  source.toUpperCase()
+                )
+              }
+            >
+              View source on GitHub
+            </a>
+          </StackItem>
+        )}
       </Stack>
     </div>
   );
   ChildComponent.displayName = `MDXChildTemplate${Component.displayName}`;
   return <ChildComponent key={source} path={source} default={index === 0} />;
-}
+};
 
 export const MDXTemplate = ({
   title,
   sources = [],
   path,
   id,
-  componentsData
+  componentsData,
 }) => {
-  const isDeprecated = sources.some(source => source.source === "react-deprecated" || source.source === "html-deprecated") && !sources.some(source => source.source === "react"  || source.source === "html");
-  const isBeta = sources.some(source => source.beta && source.source !== 'react-next' && source.source !== 'react-templates');
-  const isDemo = sources.some(source => source.source === "react-demos" || source.source === "html-demos") && !sources.some(source => source.source === "react" || source.source === "html");
+  const isDeprecated =
+    sources.some(
+      (source) =>
+        source.source === 'react-deprecated' ||
+        source.source === 'html-deprecated'
+    ) &&
+    !sources.some(
+      (source) => source.source === 'react' || source.source === 'html'
+    );
+  const isBeta = sources.some(
+    (source) =>
+      source.beta &&
+      source.source !== 'react-next' &&
+      source.source !== 'react-templates'
+  );
+  const isDemo =
+    sources.some(
+      (source) =>
+        source.source === 'react-demos' || source.source === 'html-demos'
+    ) &&
+    !sources.some(
+      (source) => source.source === 'react' || source.source === 'html'
+    );
   // Build obj mapping source names to text displayed on tabs
   const tabNames = sources.reduce((acc, curSrc) => {
     const { source, tabName } = curSrc;
     // use tabName for tab name if present, otherwise default to source
-    const tabLinkText = tabName || capitalize(source.replace('html', 'HTML').replace(/-/g, ' '));
+    const tabLinkText =
+      tabName || capitalize(source.replace('html', 'HTML').replace(/-/g, ' '));
     acc[source] = tabLinkText;
     return acc;
   }, {});
   const sourceKeys = Object.keys(tabNames);
   const isSinglePage = sourceKeys.length === 1;
 
-  let isDevResources, isComponent, isExtension, isChart, isPattern, isLayout, isUtility, isUpgrade;
+  let isDevResources,
+    isComponent,
+    isExtension,
+    isChart,
+    isPattern,
+    isLayout,
+    isUtility,
+    isUpgrade;
 
   const getSection = () => {
     return sources.some((source) => {
       switch (source.section) {
-        case "developer-resources":
+        case 'developer-resources':
           isDevResources = true;
           return;
-        case "components":
+        case 'components':
           isComponent = true;
           return;
-        case "extensions":
+        case 'extensions':
           isExtension = true;
           return;
-        case "charts":
+        case 'charts':
           isChart = true;
           return;
-        case "patterns":
+        case 'patterns':
           isPattern = true;
           return;
-        case "layouts":
+        case 'layouts':
           isLayout = true;
           return;
-        case "utilities":
+        case 'utilities':
           isUtility = true;
           return;
-        case "get-started":
+        case 'get-started':
           if (source.source.includes('upgrade')) {
             isUpgrade = true;
           }
@@ -199,7 +319,7 @@ export const MDXTemplate = ({
 
   // hide tab if it doesn't include the strings below
   const hideTabName = sourceKeys.some(
-    (e) => e.includes("pages") || e.includes("training")
+    (e) => e.includes('pages') || e.includes('training')
   );
   const { pathname } = useLocation();
   let activeSource = pathname.replace(/\/$/, '').split('/').pop();
@@ -225,34 +345,30 @@ export const MDXTemplate = ({
     getSection();
     if (isChart || isDevResources || isExtension) {
       if (isSinglePage) {
-        return "pf-m-light-100";
+        return 'pf-m-light-100';
       }
-      return "pf-m-light";
+      return 'pf-m-light';
     } else if (isUtility || isPattern || isLayout || isComponent || isUpgrade) {
-      return "pf-m-light";
+      return 'pf-m-light';
     }
-    return "pf-m-light-100";
+    return 'pf-m-light-100';
   };
 
-  const showTabs = (
-    (!isSinglePage && !hideTabName) ||
-    isComponent ||
-    isUtility ||
-    isPattern
-  );
+  const showTabs =
+    (!isSinglePage && !hideTabName) || isComponent || isUtility || isPattern;
 
   return (
     <React.Fragment>
       <PageGroup>
         <PageSection
           className={getClassName()}
-          variant={!isSinglePage ? PageSectionVariants.light : ""}
+          variant={!isSinglePage ? PageSectionVariants.light : ''}
           isWidthLimited
         >
           <Content isEditorial>
-            <Flex alignItems={{ default: 'alignItemsCenter'}}>
+            <Flex alignItems={{ default: 'alignItemsCenter' }}>
               <FlexItem>
-                <Title headingLevel='h1' size='4xl' id="ws-page-title">
+                <Title headingLevel="h1" size="4xl" id="ws-page-title">
                   {title}
                 </Title>
               </FlexItem>
@@ -288,11 +404,15 @@ export const MDXTemplate = ({
                 </Flex>
               </FlexItem>
             </Flex>
-            {isComponent && summary && (<SummaryComponent />)}
+            {isComponent && summary && <SummaryComponent />}
           </Content>
         </PageSection>
-        { showTabs && (
-          <PageSection id="ws-sticky-nav-tabs" stickyOnBreakpoint={{'default':'top'}} type="tabs">
+        {showTabs && (
+          <PageSection
+            id="ws-sticky-nav-tabs"
+            stickyOnBreakpoint={{ default: 'top' }}
+            type="tabs"
+          >
             <div className="pf-v6-c-tabs pf-m-page-insets pf-m-no-border-bottom">
               <ul className="pf-v6-c-tabs__list">
                 {sourceKeys.map((source, index) => (
@@ -303,9 +423,18 @@ export const MDXTemplate = ({
                       activeSource === source && 'pf-m-current'
                     )}
                     // Send clicked tab name for analytics
-                    onClick={() => trackEvent('tab_click', 'click_event', source.toUpperCase())}
+                    onClick={() =>
+                      trackEvent(
+                        'tab_click',
+                        'click_event',
+                        source.toUpperCase()
+                      )
+                    }
                   >
-                    <Link className="pf-v6-c-tabs__link" to={`${path}${index === 0 ? '' : '/' + source}`}>
+                    <Link
+                      className="pf-v6-c-tabs__link"
+                      to={`${path}${index === 0 ? '' : '/' + source}`}
+                    >
                       {tabNames[source]}
                     </Link>
                   </li>
@@ -315,7 +444,7 @@ export const MDXTemplate = ({
           </PageSection>
         )}
         <PageSection id="main-content" isFilled className="pf-m-light-100">
-          {isSinglePage && <MDXChildTemplate {...sources[0]} id={id}/>}
+          {isSinglePage && <MDXChildTemplate {...sources[0]} id={id} />}
           {!isSinglePage && (
             <Router className="pf-v6-u-h-100" primary={false}>
               {sources
@@ -327,8 +456,11 @@ export const MDXTemplate = ({
             </Router>
           )}
         </PageSection>
-        <BackToTop className="ws-back-to-top" scrollableSelector="#ws-page-main" />
+        <BackToTop
+          className="ws-back-to-top"
+          scrollableSelector="#ws-page-main"
+        />
       </PageGroup>
     </React.Fragment>
   );
-}
+};


### PR DESCRIPTION
Closes #4339 
Closes #4176 
Closes #4340 

FYI - Line changes linked due to additional prettier formatting changes.

This PR:
- Fixes console errors:
  - error thrown by missing `key` prop in CSSVariables table. (cssVariables.js [line 15](https://github.com/patternfly/patternfly-org/pull/4341/files#diff-364df80da54886753ca572b74c68a1a32893da16c7a4d9c76d762725ff51f228R15))
  - error thrown by use of `class` rather than `className` in the site footer. (footer.js [line 270](https://github.com/patternfly/patternfly-org/pull/4341/files#diff-4ffaf2430cb77de5fb6652969a79ce1202dca821889f6ae5358c8adc6ca33dc9R270))

- Hard-codes "Tile" to be deprecated:
  - Adds "deprecated" label to the Sidenav item (sideNav.js [line 169](https://github.com/patternfly/patternfly-org/pull/4341/files#diff-8e3c7674b90a7a160ac769d32b003a8c5ba29ee93599606701fd47312630fc0aR169))
    - _Explanation: sidenav label isn't added if either the React or Core examples aren't marked deprecated, this line bypasses that check specifically for the `Tile` component._
  - Adds inline alert to the top of each Tile docs page (mdx.js [line 125](https://github.com/patternfly/patternfly-org/pull/4341/files#diff-da135efaa2b01f501f1ac196874e6c6ae745345196f59a4581445639bf5384c4R125))
    - _Explanation: Inline deprecation alert is only added on Core page if examples exist in a `/deprecated/` directory, this bypasses that specifically for the `Tile` component._
  - Adds TODO comments to remove these hard-coded updates when [Core #7178](https://github.com/patternfly/patternfly/pull/7178) is merged. ([sideNav.js](https://github.com/patternfly/patternfly-org/pull/4341/files#diff-8e3c7674b90a7a160ac769d32b003a8c5ba29ee93599606701fd47312630fc0aR167-R168) && mdx.js)