### PR TITLE
fix(footer): calendar link

### DIFF
--- a/packages/documentation-framework/components/footer/footer.js
+++ b/packages/documentation-framework/components/footer/footer.js
@@ -154,7 +154,7 @@ export const Footer = ({ isDarkTheme }) => (
                   <ListItem className="ws-org-pfsite-footer-menu-list-item">
                     <Link
                       className="ws-org-pfsite-footer-menu-link"
-                      to="https://github.com/patternfly/patternfly/blob/main/CODE_OF_CONDUCT.md"
+                      to="https://calendar.google.com/calendar/embed?src=patternflyteam%40gmail.com&ctz=America%2FNew_York"
                       aria-label="Join PatternFly meetings"
                     >
                       Calendar


### PR DESCRIPTION
Closes [#4383](https://github.com/patternfly/patternfly-org/issues/4383)