### PR TITLE
chore: upgrade to Node.js v22.x (LTS) and enable Corepack

### DIFF
--- a/.github/workflows-src/partials/build.yml
+++ b/.github/workflows-src/partials/build.yml
@@ -1,14 +1,8 @@
-- uses: actions/setup-node@v1
+- uses: actions/setup-node@v4
   with:
-    node-version: "20"
-- uses: actions/cache@v2
-  id: yarn-cache
-  name: Load npm deps from cache
-  with:
-    path: "**/node_modules"
-    key: ${{ runner.os }}-yarn-14-${{ hashFiles('yarn.lock') }}
+    node-version: 22
+- run: corepack enable
 - run: yarn install --frozen-lockfile
-  if: steps.yarn-cache.outputs.cache-hit != 'true'
 # v5 build
 - uses: actions/cache@v2
   id: site-cache

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -16,17 +16,11 @@ jobs:
           git fetch origin pull/$GH_PR_NUM/head:tmp
           git checkout tmp
       # Injected by generate-workflows.js
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        name: Load  npm deps from cache
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-yarn-14-${{ hashFiles('yarn.lock') }}
+          node-version: 22
+      - run: corepack enable
       - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
       # build
       - uses: actions/cache@v2
         id: site-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,11 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN_REDALLEN }} # needs to be an admin token to get around branch protection
       # Injected by generate-workflows.js
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        name: Load npm deps from cache
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-yarn-14-${{ hashFiles('yarn.lock') }}
+          node-version: 22
+      - run: corepack enable
       - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
       # v6 build
       - uses: actions/cache@v2
         id: site-cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The PatternFly Org is the source for the official documentation for PatternFly.
 
 Development setup requires yarn. If you do not already have yarn installed on your system, see https://yarnpkg.com/en/.
 
-A Node version greater than 18.16.0 is also required.
+A Node version 22 or greater is also required.
 
 ### Live Reload Server
 


### PR DESCRIPTION
Upgrades the CI to use the latest LTS version of Node.js (v22). Also upgrades the `setup-node` action to the latest version (v4). And enables [Corepack](https://nodejs.org/api/corepack.html) (a pre-requisite for merging #4413).