### PR TITLE
fix: export valid SVGs in all icons page

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/icons/IconsTable.js
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/icons/IconsTable.js
@@ -47,7 +47,7 @@ export const IconsTable = () => {
   });
 
   const onDownloadSvg = (currentTarget, name) => {
-    const domNode = currentTarget.children[0].cloneNode(true);
+    const domNode = currentTarget.querySelector("svg").cloneNode(true);
     domNode.setAttribute("xmlns", "http://www.w3.org/2000/svg");
     domNode.setAttribute("width", "100%");
     domNode.setAttribute("height", "100%");


### PR DESCRIPTION
fixes #4449 

before:
```xml
<?xml version="1.0" standalone="no"?>
<span class="pf-v6-c-button__text" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><svg class="pf-v6-svg" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true" role="img" width="1em" height="1em" color=""><path d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"></path></svg></span>
```


after:
```xml
<?xml version="1.0" standalone="no"?>
<svg class="pf-v6-svg" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true" role="img" width="100%" height="100%" color="" xmlns="http://www.w3.org/2000/svg"><path d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"></path></svg>
```