### PR TITLE
fix: update colors grid

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/colors-for-charts/colors-grid.js
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/colors-for-charts/colors-grid.js
@@ -5,19 +5,19 @@ import '@patternfly/patternfly/patternfly-charts.css';
 const colorFamilies = [
   'Blue',
   'Green',
-  'Cyan',
+  'Teal',
   'Purple',
-  'Gold',
+  'Yellow',
   'Orange',
-  'Red',
+  'Red Orange',
   'Black'
 ];
 
 const ColorEntry = ({color, idx, computedStyles}) => {
-  const varName = `--pf-v6-chart-color-${color.toLowerCase()}-${idx}00`;
+  const varName = `--pf-v6-chart-color-${color.replace(' ', '-').toLowerCase()}-${idx}00`;
   const varValue = computedStyles?.getPropertyValue
     ? computedStyles.getPropertyValue(varName).toUpperCase()
-    : ''; 
+    : '';
   return (
     <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter'}}>
       <FlexItem>
@@ -62,7 +62,7 @@ const ColorsGrid = () => {
       }
     }
   }
-  
+
   React.useEffect(() => {
     const getInitialRootStyles = () => typeof window !== "undefined" && window.getComputedStyle && getComputedStyle(document.documentElement);
     setComputedStyles(getInitialRootStyles);
@@ -72,7 +72,7 @@ const ColorsGrid = () => {
   }, []);
 
   return (
-    <Grid className="ws-colors-grid" hasGutter sm={12} md={6} lg={4}>
+    <Grid className="ws-colors-grid" hasGutter sm={12} md={6} lg={6}>
       {colorFamilies.map(color => (
         <ColorFamily color={color} computedStyles={computedStyles} key={color} />
       ))}


### PR DESCRIPTION
fixes #4444

before:
![image](https://github.com/user-attachments/assets/69bf67f6-7d41-44b5-aa35-ce606ea912c8)
![image](https://github.com/user-attachments/assets/00f7fd80-6db0-46e3-b399-a0531c7a31a7)

after:
![image](https://github.com/user-attachments/assets/fa2ac3dc-bb90-4abb-a423-3274f0f50793)
![image](https://github.com/user-attachments/assets/094b51e5-9b1b-4d52-8021-4a69ddfcb30c)

I had to change the grid size as "Red Orange" simply takes up too much space:
![image](https://github.com/user-attachments/assets/59aa8c8c-d6c5-49b6-99b1-250bcf5b9aff)
