### PR TITLE
chore(deps): Temporarily allow for React 19 peer dependency

### DIFF
--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -76,7 +76,7 @@
     "@patternfly/react-code-editor": "^6.2.2",
     "@patternfly/react-core": "^6.2.2",
     "@patternfly/react-table": "^6.2.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2611,8 +2611,8 @@ __metadata:
     "@patternfly/react-code-editor": ^6.2.2
     "@patternfly/react-core": ^6.2.2
     "@patternfly/react-table": ^6.2.2
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   bin:
     pf-docs-framework: scripts/cli/cli.js
   languageName: unknown


### PR DESCRIPTION
Extensions which import PatternFly seem to have problems pulling in React 19 due to the docs framework - trying this to see if it helps.

I tried dropping the docs framework within the extension, but we have code-editor, core, etc. as dependencies. It seems to ship as part of the dependency according to this install trail, so that doesn't help all that much. I verified that 6.2.2, etc. should have 19 support.

```
ralpert@ralpert-mac virtual-assistant % npm install        
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^17 || ^18" from @patternfly/react-code-editor@6.2.2
npm warn node_modules/@patternfly/react-code-editor
npm warn   peer @patternfly/react-code-editor@"^6.2.2" from @patternfly/documentation-framework@6.9.7
npm warn   node_modules/@patternfly/documentation-framework
npm warn   1 more (@patternfly/chatbot)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^17 || ^18" from @patternfly/react-core@6.2.2
npm warn node_modules/@patternfly/react-core
npm warn   peer @patternfly/react-core@"^6.2.2" from @patternfly/documentation-framework@6.9.7
npm warn   node_modules/@patternfly/documentation-framework
npm warn   3 more (@patternfly/react-code-editor, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^17 || ^18" from @patternfly/react-icons@6.2.2
npm warn node_modules/@patternfly/react-icons
npm warn   dev @patternfly/react-icons@"6.2.2" from the root project
npm warn   4 more (@patternfly/react-code-editor, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^17 || ^18" from @patternfly/react-icons@6.2.2
npm warn node_modules/@patternfly/react-icons
npm warn   dev @patternfly/react-icons@"6.2.2" from the root project
npm warn   4 more (@patternfly/react-code-editor, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^17 || ^18" from @patternfly/react-table@6.2.2
npm warn node_modules/@patternfly/react-table
npm warn   dev @patternfly/react-table@"6.2.2" from the root project
npm warn   2 more (@patternfly/documentation-framework, @patternfly/chatbot)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^17 || ^18" from @patternfly/react-table@6.2.2
npm warn node_modules/@patternfly/react-table
npm warn   dev @patternfly/react-table@"6.2.2" from the root project
npm warn   2 more (@patternfly/documentation-framework, @patternfly/chatbot)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react@18.2.0
npm warn node_modules/react
npm warn   dev react@"^19" from the root project
npm warn   30 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^18.2.0" from react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react-dom@"^17 || ^18" from @patternfly/react-code-editor@6.2.2
npm warn node_modules/@patternfly/react-code-editor
npm warn   peer @patternfly/react-code-editor@"^6.2.2" from @patternfly/documentation-framework@6.9.7
npm warn   node_modules/@patternfly/documentation-framework
npm warn   1 more (@patternfly/chatbot)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react-dom@"^17 || ^18" from @patternfly/react-table@6.2.2
npm warn node_modules/@patternfly/react-table
npm warn   dev @patternfly/react-table@"6.2.2" from the root project
npm warn   2 more (@patternfly/documentation-framework, @patternfly/chatbot)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @patternfly/chatbot-root@0.0.0
npm warn Found: react-dom@18.2.0
npm warn node_modules/react-dom
npm warn   dev react-dom@"^19" from the root project
npm warn   9 more (@monaco-editor/react, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react-dom@"^17 || ^18" from @patternfly/react-table@6.2.2
npm warn node_modules/@patternfly/react-table
npm warn   dev @patternfly/react-table@"6.2.2" from the root project
npm warn   2 more (@patternfly/documentation-framework, @patternfly/chatbot)
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: @patternfly/chatbot-root@0.0.0
npm error Found: react@19.1.0
npm error node_modules/react
npm error   dev react@"^19" from the root project
npm error   peer react@"^17 || ^18 || ^19" from @patternfly/chatbot@1.0.0
npm error   packages/module
npm error     @patternfly/chatbot@1.0.0
npm error     node_modules/@patternfly/chatbot
npm error       workspace packages/module from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^17 || ^18" from @patternfly/react-icons@6.2.2
npm error node_modules/@patternfly/react-icons
npm error   dev @patternfly/react-icons@"6.2.2" from the root project
npm error   @patternfly/react-icons@"6.2.2" from @patternfly/chatbot@1.0.0
npm error   packages/module
npm error     @patternfly/chatbot@1.0.0
npm error     node_modules/@patternfly/chatbot
npm error       workspace packages/module from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/ralpert/.npm/_logs/2025-04-24T15_38_30_332Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/ralpert/.npm/_logs/2025-04-24T15_38_30_332Z-debug-0.log

```