### PR TITLE
docs(upgrade): Fix link to `card` component

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/get-started/upgrade.md
+++ b/packages/documentation-site/patternfly-docs/content/get-started/upgrade.md
@@ -27,7 +27,7 @@ Before you upgrade, familiarize yourself with these significant changes. While s
 ### Components
 
 1. [Chip](/components/chip): Replaced with [label](/components/label).
-1. [Tile](/components/tile): Replaced with [card](components/card).
+1. [Tile](/components/tile): Replaced with [card](/components/card).
 1. [Text](https://v5-archive.patternfly.org/components/text): Renamed to ["content"](/components/content).  
 1. [Expandable section](/components/expandable-section): Removed `isActive`.
 1. [Empty state](/components/empty-state): Refactored. 


### PR DESCRIPTION
Without the leading `/` the link is relative, thus:
- Doesn't work when clicked (but keeps adding to the URL); and
- Opens a non-existent page when opened in a new tab.

Btw, I gotta say from a first glance I already love the look & feel of PF6. Can't wait to upgrade the [tools repo of Apache KIE](https://github.com/apache/incubator-kie-tools) to it! We just finished upgrading to v5 🙏 