### PR TITLE
fix(styling): last link in jump links sidenav is now visible

### DIFF
--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -39,6 +39,7 @@
 
 .ws-toc .pf-v6-c-jump-links__main {
   scrollbar-width: none;
+  margin-bottom: var(--jump-links-main-margin-bottom);
 }
 
 /* Hide TOC scrollbar Chrome, Safari & Opera */

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.js
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.js
@@ -93,7 +93,9 @@ export const TableOfContents = ({ items }) => {
       isVertical
       scrollableSelector="#ws-page-main"
       className="ws-toc"
-      style={{ top: stickyNavHeight }}
+      style={{ top: stickyNavHeight,
+        '--jump-links-main-margin-bottom': `${stickyNavHeight}px`
+      }}
       offset={width > 1450 ? 108 + stickyNavHeight : 148 + stickyNavHeight}
       expandable={{ default: 'expandable', '2xl': 'nonExpandable' }}
     >


### PR DESCRIPTION
Created a new CSS variable to add the `margin-bottom:  45px` to `JumpLinks` component returned by `tableOfContents.js`, making the last jump links item visible regardless of the browser window dimensions. Closes #4579 