### PR TITLE
docs(icons): Adds more guidance for removal and deletion.

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/icons/icons.js
+++ b/packages/documentation-site/patternfly-docs/content/design-guidelines/styles/icons/icons.js
@@ -531,14 +531,14 @@ export const iconsData = [
     "Name": "fa-minus",
     "React_name": "MinusIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to remove an item",
+    "Contextual_usage": "Indicates the ability to remove an item (such as a table row), decrease (in number input controls), or minimize",
   },
   {
     "Style": "fas",
     "Name": "fa-minus-circle",
     "React_name": "MinusCircleIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to remove an item (alt concept)",
+    "Contextual_usage": "Alternative option that indicates the ability to remove an item (such as a table row), decrease (in number input controls), or minimize",
   },
   {
     "Style": "fas",
@@ -770,7 +770,7 @@ export const iconsData = [
     "Name": "fa-trash",
     "React_name": "TrashIcon",
     "Type": "Action",
-    "Contextual_usage": "Indicates the ability to delete",
+    "Contextual_usage": "Indicates the ability to delete an item/element or remove an uploaded file",
   },
   {
     "Style": "fas",


### PR DESCRIPTION
Closes #4659 

This is a small update to address the issue -- I think this is a good solution to cover the additional use cases without removing guidance that products are likely already following

but more work could come in follow-up issues if we want:
- Adding icons within the UX writing terminology table
- Adding a new doc to Patterns to document general removal and deletion patterns/scenarios