### PR TITLE
fix(TableOfContents): Adjust height on mobile

### DIFF
--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -39,7 +39,6 @@
 
 .ws-toc .pf-v6-c-jump-links__main {
   scrollbar-width: none;
-  margin-bottom: var(--jump-links-main-margin-bottom);
 }
 
 /* Hide TOC scrollbar Chrome, Safari & Opera */
@@ -71,4 +70,10 @@
 .ws-toc-item .pf-m-link {
   text-wrap: wrap;
   text-align: left;
+}
+
+@media (min-width: 1451px) {
+  .ws-toc .pf-v6-c-jump-links__main {
+    margin-bottom: var(--jump-links-main-margin-bottom);
+  }
 }


### PR DESCRIPTION
It looks like folks wanted to add more space to the table of contents so items weren't getting cut off, but that this was accidentally applied to mobile instead of the desktop view where it's relevant. Targeting the style there fixes both issues.

| Before | After |
|-|-|
|<img width="1060" height="138" alt="Screenshot 2025-07-21 at 3 29 33 PM" src="https://github.com/user-attachments/assets/438f059c-46ef-43ff-918d-2ed15511c904" />|<img width="1053" height="107" alt="Screenshot 2025-07-21 at 3 28 55 PM" src="https://github.com/user-attachments/assets/e9ea76e2-1d3c-4e7d-8ddf-7e7dd640f02e" />
