### PR TITLE
fix: remove duplicate source names in full page demo URLs

### DIFF
--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -218,8 +218,17 @@ export const Example = ({
       ? getStaticParams(title, editorCode)
       : getReactParams(title, editorCode, scope, lang, relativeImports, relPath, sourceLink)
   );
-  const fullscreenLink =
-    loc.pathname.replace(/\/$/, '') + (loc.pathname.endsWith(source) ? '' : `/${source}`) + '/' + slugger(title);
+  const fullscreenLink = (() => {
+    const cleanPathname = loc.pathname.replace(/\/$/, '');
+    const sourcePath = `/${source}`;
+    
+    // Check if the source is already in the pathname to avoid duplication
+    if (cleanPathname.includes(sourcePath)) {
+      return `${cleanPathname}/${slugger(title)}`;
+    } else {
+      return `${cleanPathname}${sourcePath}/${slugger(title)}`;
+    }
+  })();
 
   const hasMetaText = isBeta || isDemo || isDeprecated || false;
   const tooltips = (

--- a/packages/documentation-framework/scripts/webpack/getHtmlWebpackPlugins.js
+++ b/packages/documentation-framework/scripts/webpack/getHtmlWebpackPlugins.js
@@ -36,7 +36,12 @@ async function getHtmlWebpackPlugins(options) {
       filename: 'sitemap.xml',
       templateParameters: {
         urls: Object.entries(routes)
-          .map(([path, { sources }]) => [path, ...(sources || []).slice(1).map((source) => source.slug)])
+          .map(([path, { sources }]) => [
+            path, 
+            ...(sources || []).slice(1)
+              .filter(source => source.slug !== path) // Filter out sources that would create duplicate routes
+              .map((source) => source.slug)
+          ])
           .flat()
       },
       inject: false,
@@ -54,8 +59,10 @@ async function getHtmlWebpackPlugins(options) {
     .concat(Object.entries(fullscreenRoutes))
     .map(([url, { sources = [], title, isFullscreen }]) => [
       [url, { title, isFullscreen }],
-      // Add pages for sources
-      ...sources.slice(1).map((source) => [source.slug, source])
+      // Add pages for sources, but filter out duplicates
+      ...sources.slice(1)
+        .filter(source => source.slug !== url) // Filter out sources that would create duplicate routes
+        .map((source) => [source.slug, source])
     ])
     .flat()
     .sort();


### PR DESCRIPTION
Closes: https://github.com/patternfly/patternfly-org/issues/4739