### PR TITLE
fix: enable HC switcher, add beta label

### DIFF
--- a/packages/documentation-framework/components/themeSelector/themeSelector.js
+++ b/packages/documentation-framework/components/themeSelector/themeSelector.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {
+  Content,
   Select,
   SelectGroup,
   SelectList,
@@ -11,8 +12,11 @@ import {
   ToggleGroupItem,
   Icon,
   Divider,
-  Label
+  Label,
+  Popover,
+  Button
 } from '@patternfly/react-core';
+import { HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useTheme, THEME_TYPES } from '../../hooks/useTheme';
 
 const SunIcon = (
@@ -47,8 +51,37 @@ const DesktopIcon = (
 );
 
 const HCGroupLabel = () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
   return (
-    <h2 className="pf-v6-c-menu__group-title">High contrast &nbsp;<Label color="blue" isCompact>Beta</Label></h2>
+    <h2 className="pf-v6-c-menu__group-title">
+      High contrast{' '}
+      <Popover
+        headerContent={"Under development"}
+        headerComponent="h3"
+        bodyContent={
+          "We are still working to add high contrast support across all PatternFly components and extensions. This beta allows you to preview our progress."
+        }
+        footerContent={
+          <Button icon={<ExternalLinkAltIcon />} component="a" isInline variant="link" href="https://medium.com/patternfly" target="_blank">
+            Learn more (replace with link to blog post)
+          </Button>
+        }
+        isVisible={isPopoverOpen}
+        shouldClose={() => setIsPopoverOpen(false)}
+        aria-label="More info about high contrast"
+        appendTo={() => document.body}
+      >
+        <Button
+          variant="plain"
+          hasNoPadding
+          icon={<HelpIcon />}
+          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+          aria-label="High contrast help"
+        />
+      </Popover>{' '}&nbsp;
+      <Label color="blue" isCompact>Beta</Label>
+    </h2>
   )
 };
 
@@ -116,7 +149,7 @@ export const ThemeSelector = ({ id }) => {
         preventOverflow: true
       }}
     >
-      <SelectGroup>
+      <SelectGroup label={'Color scheme'} labelHeadingLevel="h2">
         <SelectList aria-label="Light/Dark theme switcher">
           <SelectOption value={colorModes.SYSTEM} icon={DesktopIcon} description="Follow system preference">
             System

--- a/packages/documentation-framework/components/themeSelector/themeSelector.js
+++ b/packages/documentation-framework/components/themeSelector/themeSelector.js
@@ -10,7 +10,8 @@ import {
   ToggleGroup,
   ToggleGroupItem,
   Icon,
-  Divider
+  Divider,
+  Label
 } from '@patternfly/react-core';
 import { useTheme, THEME_TYPES } from '../../hooks/useTheme';
 
@@ -44,6 +45,12 @@ const DesktopIcon = (
     <path d="M23.94 16a1 1 0 0 1-.992-.876 6.957 6.957 0 0 0-6.069-6.062 1 1 0 1 1 .242-1.985 8.953 8.953 0 0 1 7.812 7.8A.999.999 0 0 1 23.94 16ZM16 5a1 1 0 0 1-1-1V1a1 1 0 1 1 2 0v3a1 1 0 0 1-1 1Zm0 27a1 1 0 0 1-1-1v-3a1 1 0 1 1 2 0v3a1 1 0 0 1-1 1ZM4 17H1a1 1 0 1 1 0-2h3a1 1 0 1 1 0 2Zm27 0h-3a1 1 0 1 1 0-2h3a1 1 0 1 1 0 2ZM5.394 27.606a1 1 0 0 1-.707-1.707l2.12-2.12a1 1 0 1 1 1.415 1.413L6.1 27.313a.997.997 0 0 1-.707.293ZM24.485 8.515a1 1 0 0 1-.707-1.707L25.9 4.686a1 1 0 1 1 1.415 1.415l-2.122 2.12a.997.997 0 0 1-.707.294Zm-16.97 0a.997.997 0 0 1-.707-.293L4.686 6.1a1 1 0 1 1 1.415-1.415l2.12 2.122a1 1 0 0 1-.706 1.707Zm19.091 19.091a.997.997 0 0 1-.707-.293l-2.12-2.12a1 1 0 1 1 1.413-1.415l2.122 2.121a1 1 0 0 1-.707 1.707ZM16 24.875c-4.894 0-8.875-3.981-8.875-8.875a8.879 8.879 0 0 1 5.227-8.088.876.876 0 0 1 1.153 1.163 6.945 6.945 0 0 0-.63 2.925A7.133 7.133 0 0 0 20 19.125a6.948 6.948 0 0 0 2.925-.63.876.876 0 0 1 1.163 1.154A8.88 8.88 0 0 1 16 24.875Zm-4.785-14.153A7.135 7.135 0 0 0 8.875 16 7.133 7.133 0 0 0 16 23.125a7.13 7.13 0 0 0 5.278-2.34c-.419.06-.845.09-1.278.09-4.894 0-8.875-3.981-8.875-8.875 0-.433.03-.86.09-1.278Z"></path>
   </svg>
 );
+
+const HCGroupLabel = () => {
+  return (
+    <h2 className="pf-v6-c-menu__group-title">High contrast &nbsp;<Label color="blue" isCompact>Beta</Label></h2>
+  )
+};
 
 export const ThemeSelector = ({ id }) => {
   const { mode: themeMode, setMode: setThemeMode, modes: colorModes } = useTheme(THEME_TYPES.COLOR);
@@ -124,7 +131,7 @@ export const ThemeSelector = ({ id }) => {
       </SelectGroup>
       {process.env.hasHighContrastSwitcher && (<>
       <Divider />
-      <SelectGroup label="High Contrast">
+      <SelectGroup label={HCGroupLabel}>
         <MenuSearch>
           <MenuSearchInput>
             <ToggleGroup aria-label="High contrast theme switcher">

--- a/packages/documentation-framework/components/themeSelector/themeSelector.js
+++ b/packages/documentation-framework/components/themeSelector/themeSelector.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import {
-  Content,
   Select,
   SelectGroup,
   SelectList,

--- a/packages/documentation-framework/components/themeSelector/themeSelector.js
+++ b/packages/documentation-framework/components/themeSelector/themeSelector.js
@@ -72,7 +72,7 @@ const HighContrastGroupLabel = () => {
         }
         footerContent={
           <Button icon={<ExternalLinkAltIcon />} component="a" isInline variant="link" href="/design-foundations/theming" target="_blank">
-            Learn more (replace with link to blog post)
+            Learn more
           </Button>
         }
         aria-label="More info about high contrast"

--- a/packages/documentation-framework/components/themeSelector/themeSelector.js
+++ b/packages/documentation-framework/components/themeSelector/themeSelector.js
@@ -71,7 +71,7 @@ const HighContrastGroupLabel = () => {
           "We are still working to add high contrast support across all PatternFly components and extensions. This beta allows you to preview our progress."
         }
         footerContent={
-          <Button icon={<ExternalLinkAltIcon />} component="a" isInline variant="link" href="https://medium.com/patternfly" target="_blank">
+          <Button icon={<ExternalLinkAltIcon />} component="a" isInline variant="link" href="/design-foundations/theming" target="_blank">
             Learn more (replace with link to blog post)
           </Button>
         }

--- a/packages/documentation-framework/components/themeSelector/themeSelector.js
+++ b/packages/documentation-framework/components/themeSelector/themeSelector.js
@@ -50,15 +50,24 @@ const DesktopIcon = (
   </svg>
 );
 
-const HCGroupLabel = () => {
+const ColorSchemeGroupLabel = () => {
+  return (
+    <div className="pf-v6-c-menu__group-title" id="theme-selector-color-scheme-title">
+      Color scheme
+    </div>
+  );
+};
+
+const HighContrastGroupLabel = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   return (
-    <h2 className="pf-v6-c-menu__group-title">
+    <div className="pf-v6-c-menu__group-title">
       High contrast{' '}
       <Popover
+        onClick={(e) => e.stopPropagation()}
         headerContent={"Under development"}
-        headerComponent="h3"
+        headerComponent="h1"
         bodyContent={
           "We are still working to add high contrast support across all PatternFly components and extensions. This beta allows you to preview our progress."
         }
@@ -67,8 +76,6 @@ const HCGroupLabel = () => {
             Learn more (replace with link to blog post)
           </Button>
         }
-        isVisible={isPopoverOpen}
-        shouldClose={() => setIsPopoverOpen(false)}
         aria-label="More info about high contrast"
         appendTo={() => document.body}
       >
@@ -76,12 +83,11 @@ const HCGroupLabel = () => {
           variant="plain"
           hasNoPadding
           icon={<HelpIcon />}
-          onClick={() => setIsPopoverOpen(!isPopoverOpen)}
           aria-label="High contrast help"
         />
       </Popover>{' '}&nbsp;
       <Label color="blue" isCompact>Beta</Label>
-    </h2>
+    </div>
   )
 };
 
@@ -149,8 +155,8 @@ export const ThemeSelector = ({ id }) => {
         preventOverflow: true
       }}
     >
-      <SelectGroup label={'Color scheme'} labelHeadingLevel="h2">
-        <SelectList aria-label="Light/Dark theme switcher">
+      <SelectGroup label={ColorSchemeGroupLabel}>
+        <SelectList aria-labelledby="theme-selector-color-scheme-title">
           <SelectOption value={colorModes.SYSTEM} icon={DesktopIcon} description="Follow system preference">
             System
           </SelectOption>
@@ -164,7 +170,7 @@ export const ThemeSelector = ({ id }) => {
       </SelectGroup>
       {process.env.hasHighContrastSwitcher && (<>
       <Divider />
-      <SelectGroup label={HCGroupLabel}>
+      <SelectGroup label={HighContrastGroupLabel}>
         <MenuSearch>
           <MenuSearchInput>
             <ToggleGroup aria-label="High contrast theme switcher">

--- a/packages/documentation-site/patternfly-docs/patternfly-docs.config.js
+++ b/packages/documentation-site/patternfly-docs/patternfly-docs.config.js
@@ -31,7 +31,7 @@ if (process.env.EXTENSIONS_ONLY === 'true') {
     hasDesignGuidelines: true,
     hasThemeSwitcher: true,
     hasFeedbackButton: true,
-    hasHighContrastSwitcher: false,
+    hasHighContrastSwitcher: true,
     componentsData,
     sideNavItems: [
       { section: 'get-started' },


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/4765
fixes https://github.com/patternfly/patternfly-org/issues/4759

Questions:
* Is there a way I can pass this text + component to `<SelectGroup label="...">` and have it generate the menu title element/classes so I don't have to hard code it? According to the [<MenuGroup> code](https://github.com/patternfly/patternfly-react/blob/7a5d71d36e67a772c9c4990f80597d1ea602fa88/packages/react-core/src/components/Menu/MenuGroup.tsx#L33-L39), I assumed if I pass a function, it would  include the function within `<Wrapper />` but it doesn't appear to.
* I'm not sure what heading level to use - `<h2>` seemed appropriate considering it's a top-level heading for the page, not necessarily related to the content (cc @thatblindgeye)
* Should we add a label for the dark theme stuff? This is what it might look like (cc @lboehling) 
    <img width="272" height="387" alt="Screenshot 2025-09-02 at 8 11 06 PM" src="https://github.com/user-attachments/assets/d02dccaa-3075-4c0a-9f63-8939aff1f27e" />
