### PR TITLE
fix: add charts stylesheet to docs site for dark theme charts

### DIFF
--- a/packages/documentation-site/patternfly-docs/patternfly-docs.css.js
+++ b/packages/documentation-site/patternfly-docs/patternfly-docs.css.js
@@ -20,3 +20,5 @@ import '@patternfly/react-log-viewer/src/LogViewer/css/log-viewer.css';
 import '@patternfly/react-user-feedback/src/Feedback/Feedback.css';
 // Patternfly chatbot
 import '@patternfly/chatbot/dist/css/main.css';
+// Charts
+import '@patternfly/patternfly/patternfly-charts.css';


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/4768

Imports the charts stylesheet which fixes dark theme charts styles on org