### PR TITLE
chore: move theme switcher to bottom/left

### DIFF
--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -72,8 +72,8 @@
 
 .ws-full-page-utils {
   position: fixed;
-  right: 0;
-  bottom: 0;
+  inset-inline-start: 0;
+  inset-block-end: 0;
   padding: var(--pf-t--global--spacer--lg);
   z-index: var(--pf-t--global--z-index--2xl);
 }


### PR DESCRIPTION
Moves the theme switcher to the bottom/left by default on full page examples. There is currently an override from chatbot that moves that menu to the bottom/left that shows up on org and can now be removed - https://github.com/patternfly/chatbot/pull/675