### PR TITLE
Fix narrow code editor width issue in Label component demos

### DIFF
--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -2,6 +2,16 @@
   --ws-code-editor--tooltip--MaxWidth: 16ch;
 }
 
+/* Fix for narrow code editor width issue #4777 */
+.ws-code-editor {
+  width: 100%;
+  max-width: none;
+}
+
+.ws-code-editor .pf-v6-c-code-editor {
+  width: 100%;
+}
+
 .ws-code-editor:not(.ws-example-code-expanded) > .pf-v6-c-code-editor__header::before {
   --pf-v6-c-code-editor__header--before--BorderBottomWidth: 0;
 }


### PR DESCRIPTION
## Summary
- Fixes narrow code editor width issue on Label component React demos page
- Ensures the `.ws-code-editor` element takes full width of its container
- Adds CSS rules to override any restrictive width constraints

## Changes
- Added CSS rules to set `width: 100%` and `max-width: none` for `.ws-code-editor`
- Added specific rule for nested `.pf-v6-c-code-editor` to ensure full width
- Applied changes to `packages/documentation-framework/components/example/example.css`

## Test plan
- [x] Build the project successfully (`yarn build`)
- [x] Verify CSS changes are applied to the documentation framework
- [ ] Manually test on Label component React demos page to confirm wider code editor
- [ ] Check that other component demo pages are not adversely affected

Fixes #4777

🤖 Generated with [Claude Code](https://claude.ai/code)