### PR TITLE
fix(TOC): fixes toc showing incorrectly at exactly 1450px

### DIFF
--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -46,7 +46,7 @@
   display: none;
 }
 
-@media (min-width: 1451px) {
+@media (min-width: 1450px) {
   .ws-toc {
     width: 260px;
     max-height: calc(100vh - 76px);


### PR DESCRIPTION
Fixes #4747 

This fixes the small blip where the menu shows incorrectly at exactly 1450px. 

One known problem: if the TOC is expanded when in the dropdown (mobile) mode, then the `.pf-m-expanded` class will be added. If the window is resized to be larger than 1450px, the TOC will be displayed vertically - however, that class is never removed. So the next time the user resizes the window to be smaller than 1450px, the expanded class is still there and the menu will show as expanded.