### PR TITLE
fix(headings): copies heading link to clipboard

### DIFF
--- a/packages/documentation-framework/components/autoLinkHeader/autoLinkHeader.css
+++ b/packages/documentation-framework/components/autoLinkHeader/autoLinkHeader.css
@@ -7,8 +7,20 @@
   transform: translate(calc(-100% - var(--pf-t--global--spacer--xs)), -50%);
   opacity: 0;
   position: absolute;
+  display: flex;
   left: 0;
   top: 50%;
+  background: none;
+  border: none;
+  padding: 0;
+  tab-index: -1;
+}
+
+.ws-heading-anchor::before {
+  content: ''; 
+  position: absolute;
+  inset: 0;
+  margin: calc(var(--pf-t--global--spacer--sm) * -1);
 }
 
 .ws-heading-anchor-icon {

--- a/packages/documentation-framework/components/autoLinkHeader/autoLinkHeader.js
+++ b/packages/documentation-framework/components/autoLinkHeader/autoLinkHeader.js
@@ -1,7 +1,6 @@
-import React from 'react';
-import { Flex, FlexItem, Content } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Flex, FlexItem, Content, Tooltip, Button } from '@patternfly/react-core';
 import LinkIcon from '@patternfly/react-icons/dist/esm/icons/link-icon';
-import { Link } from '../link/link';
 import { slugger } from '../../helpers/slugger';
 import { css } from '@patternfly/react-styles';
 
@@ -13,6 +12,19 @@ export const AutoLinkHeader = ({
   className
 }) => {
   const slug = id || slugger(children);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const handleCopyUrl = (e) => {
+    e.preventDefault();
+    const url = `${window.location.origin}${window.location.pathname}#${slug}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setShowTooltip(true);
+      setTimeout(() => setShowTooltip(false), 2000); // Hide tooltip after 2 seconds
+      console.log('URL copied to clipboard:', url);
+    }).catch(err => {
+      console.error('Failed to copy URL:', err);
+    });
+  };
 
   return (
     <Flex alignItems={{ default: 'alignItemsCenter'}} spaceItems={{ default: "spaceItemsSm" }}>
@@ -24,9 +36,21 @@ export const AutoLinkHeader = ({
           tabIndex={-1}
           isEditorial
         >
-          <Link href={`#${slug}`} className="ws-heading-anchor" tabIndex="-1" aria-hidden>
-            <LinkIcon className="ws-heading-anchor-icon" style={{ verticalAlign: 'middle' }} />
-          </Link>
+          <Tooltip
+            content="Link copied to clipboard"
+            isVisible={showTooltip}
+            trigger="manual"
+          >
+            <button 
+              onClick={handleCopyUrl}
+              className="ws-heading-anchor" 
+              tabIndex="-1" 
+              aria-hidden
+              aria-label={`Copy link to ${children}`}
+            >
+              <LinkIcon className="ws-heading-anchor-icon" />
+            </button>
+          </Tooltip>
           {children}
         </Content>
       </FlexItem>


### PR DESCRIPTION
Fixes #4370 

This changes the link icon next to the headings to copy the link to the clipboard (and show a tooltip indicating this) rather than linking to the anchor.