### PR TITLE
fix(docs): Add file-saver dependency

### DIFF
--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -33,6 +33,7 @@
     "@patternfly/react-user-feedback": "6.2.0",
     "@patternfly/react-virtualized-extension": "6.1.0",
     "echarts": "^5.6.0",
+    "file-saver": "^2.0.5",
     "marked": "^15.0.7",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11384,6 +11384,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-saver@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "file-saver@npm:2.0.5"
+  checksum: 10c0/0a361f683786c34b2574aea53744cb70d0a6feb0fa5e3af00f2fcb6c9d40d3049cc1470e38c6c75df24219f247f6fb3076f86943958f580e62ee2ffe897af8b1
+  languageName: node
+  linkType: hard
+
 "file-selector@npm:^0.6.0":
   version: 0.6.0
   resolution: "file-selector@npm:0.6.0"
@@ -18144,6 +18151,7 @@ __metadata:
     "@patternfly/react-virtualized-extension": "npm:6.1.0"
     classnames: "npm:^2.2.5"
     echarts: "npm:^5.6.0"
+    file-saver: "npm:^2.0.5"
     fs-extra: "npm:^11.1.0"
     glob: "npm:^8.1.0"
     marked: "npm:^15.0.7"


### PR DESCRIPTION
ChatBot example for transcripts uses file-saver for file downloads. It works fine on extension Surge website. The actual website was throwing "Uncaught TypeError: saveAs is not a function" since file-saver was not a website dependency. Adding the dependency gets rid of the issue.