### PR TITLE
fix(examples): let the page wrapper grow more than TOC

### DIFF
--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -26,4 +26,5 @@ p.pf-v6-c-content--p.ws-p {
 
 .ws-example-page-wrapper {
   max-width: min(100%, 825px);
+  flex-grow: 2;
 }


### PR DESCRIPTION
Fixes #4777 

If there was not enough wide content, the TOC would grow but the content area did not. This gives the content area `flex-grow:2` so that it grows up to its max-width, prioritized over the TOC.