### PR TITLE
chore(packaging): remove astro build from overall build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "yarn workspace site dev",
     "develop:extensions": "EXTENSIONS_ONLY=true PRERELEASE=true yarn develop",
     "build:analyze": "yarn workspace patternfly-org build:analyze && yarn copy",
-    "build": "yarn workspace patternfly-org build && yarn workspace site build && yarn copy",
+    "build": "yarn workspace patternfly-org build && yarn copy",
     "build:extensions": "EXTENSIONS_ONLY=true PRERELEASE=true yarn build",
     "build:doc-core": "yarn workspace site build",
     "build:ts": "yarn workspace patternfly-org build:ts",


### PR DESCRIPTION
Currently there is a bug that occurs when doing the docs framework build after having done a build of the astro app, until I can fix this we should just remove the astro build from the overall build