### PR TITLE
feat: allow full-page example utils to change position

### DIFF
--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -73,36 +73,45 @@
 .ws-full-page-utils {
   position: fixed;
   inset-block-end: 0;
-  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg);
+  padding: var(--pf-t--global--spacer--xl);
   z-index: var(--pf-t--global--z-index--2xl);
 }
 
-.ws-full-page-utils.pf-m-top-right {
-  top: 0;
-  right: 0;
+.ws-full-page-utils-position-btn {
+  --ws-full-page-utils-btn--inset: var(--pf-t--global--spacer--xs);
+  position: absolute;
+}
+
+:is(.ws-full-page-utils, .ws-full-page-utils-position-btn).pf-m-top-right {
+  top: var(--ws-full-page-utils-btn--inset, 0);
+  right: var(--ws-full-page-utils-btn--inset, 0);
   bottom: auto;
   left: auto;
 }
 
-.ws-full-page-utils.pf-m-bottom-right {
+:is(.ws-full-page-utils, .ws-full-page-utils-position-btn).pf-m-bottom-right {
   top: auto;
-  right: 0;
-  bottom: 0;
+  right: var(--ws-full-page-utils-btn--inset, 0);
+  bottom: var(--ws-full-page-utils-btn--inset, 0);
   left: auto;
 }
 
-.ws-full-page-utils.pf-m-bottom-left {
+:is(.ws-full-page-utils, .ws-full-page-utils-position-btn).pf-m-bottom-left {
   top: auto;
   right: auto;
-  bottom: 0;
-  left: 0;
+  bottom: var(--ws-full-page-utils-btn--inset, 0);
+  left: var(--ws-full-page-utils-btn--inset, 0);
 }
 
-.ws-full-page-utils.pf-m-top-left {
-  top: 0;
+:is(.ws-full-page-utils, .ws-full-page-utils-position-btn).pf-m-top-left {
+  top: var(--ws-full-page-utils-btn--inset, 0);
   right: auto;
   bottom: auto;
-  left: 0;
+  left: var(--ws-full-page-utils-btn--inset, 0);
+}
+
+.ws-full-page-utils-position-btn.pf-m-clicked {
+  --pf-v6-c-button__icon--Color: var(--pf-t--global--text--color--regular);
 }
 
 .ws-full-page-utils::before {
@@ -112,8 +121,4 @@
   background-color: var(--pf-t--global--background--color--floating--default);
   opacity: 0.8;
   box-shadow: var(--pf-t--global--box-shadow--sm);
-}
-
-.ws-full-page-utils .pf-v6-c-button.pf-m-no-padding.pf-m-clicked {
-  --pf-v6-c-button__icon--Color: var(--pf-t--global--text--color--regular);
 }

--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -72,10 +72,37 @@
 
 .ws-full-page-utils {
   position: fixed;
-  inset-inline-start: 0;
   inset-block-end: 0;
   padding: var(--pf-t--global--spacer--lg);
   z-index: var(--pf-t--global--z-index--2xl);
+}
+
+.ws-full-page-utils.pf-m-top-right {
+  top: 0;
+  right: 0;
+  bottom: auto;
+  left: auto;
+}
+
+.ws-full-page-utils.pf-m-bottom-right {
+  top: auto;
+  right: 0;
+  bottom: 0;
+  left: auto;
+}
+
+.ws-full-page-utils.pf-m-bottom-left {
+  top: auto;
+  right: auto;
+  bottom: 0;
+  left: 0;
+}
+
+.ws-full-page-utils.pf-m-top-left {
+  top: 0;
+  right: auto;
+  bottom: auto;
+  left: 0;
 }
 
 .ws-full-page-utils::before {
@@ -85,4 +112,8 @@
   background-color: var(--pf-t--global--background--color--floating--default);
   opacity: 0.8;
   box-shadow: var(--pf-t--global--box-shadow--sm);
+}
+
+.ws-full-page-utils .pf-v6-c-button.pf-m-no-padding.pf-m-clicked {
+  --pf-v6-c-button__icon--Color: var(--pf-t--global--text--color--regular);
 }

--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -73,7 +73,7 @@
 .ws-full-page-utils {
   position: fixed;
   inset-block-end: 0;
-  padding: var(--pf-t--global--spacer--lg);
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--lg);
   z-index: var(--pf-t--global--z-index--2xl);
 }
 

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -33,15 +33,15 @@ import { convertToReactComponent } from '@patternfly/ast-helpers';
 import missingThumbnail from './missing-thumbnail.jpg';
 import { RtlContext } from '../../layouts';
 import { ThemeSelector } from '../themeSelector/themeSelector';
-// import RhUiArrowCircleDownRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-right-icon';
-// import RhUiArrowCircleDownLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-left-icon';
-// import RhUiArrowCircleTopRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-top-right-icon';
-// import RhUiArrowCircleTopLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-top-left-icon';
 
-const RhUiArrowCircleUpRightIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1847" role="img" width="1em" height="1em"><title id="icon-title-1847">RhUiArrowCircleUpRightIcon</title><path d="M22 11.5V20a1 1 0 1 1-2 0v-6.586l-8.243 8.243a.997.997 0 0 1-1.414 0 .999.999 0 0 1 0-1.414L18.586 12H12a1 1 0 1 1 0-2h8.5c.827 0 1.5.673 1.5 1.5Zm9 4.5c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
-const RhUiArrowCircleDownRightIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1837" role="img" width="1em" height="1em"><title id="icon-title-1837">RhUiArrowCircleDownRightIcon</title><path d="M22 12v8.5c0 .827-.673 1.5-1.5 1.5H12a1 1 0 1 1 0-2h6.586l-8.243-8.243a.999.999 0 1 1 1.414-1.414L20 18.586V12a1 1 0 1 1 2 0Zm9 4c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
-const RhUiArrowCircleDownLeftIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1835" role="img" width="1em" height="1em"><title id="icon-title-1835">RhUiArrowCircleDownLeftIcon</title><path d="M21.657 10.343a.999.999 0 0 1 0 1.414L13.414 20H20a1 1 0 1 1 0 2h-8.5c-.827 0-1.5-.673-1.5-1.5V12a1 1 0 1 1 2 0v6.586l8.243-8.243a.999.999 0 0 1 1.414 0ZM31 16c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
-const RhUiArrowCircleUpLeftIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1845" role="img" width="1em" height="1em"><title id="icon-title-1845">RhUiArrowCircleUpLeftIcon</title><path d="M21.657 20.243a.999.999 0 1 1-1.414 1.414L12 13.414V20a1 1 0 1 1-2 0v-8.5c0-.827.673-1.5 1.5-1.5H20a1 1 0 1 1 0 2h-6.586l8.243 8.243ZM31 16c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
+import RhUiArrowCircleDownRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-right-icon';
+import RhUiArrowCircleDownLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-left-icon';
+import RhUiArrowCircleUpRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-up-right-icon';
+import RhUiArrowCircleUpLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-up-left-icon';
+import RhUiArrowCircleDownRightFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-right-fill-icon';
+import RhUiArrowCircleDownLeftFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-left-fill-icon';
+import RhUiArrowCircleUpRightFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-up-right-fill-icon';
+import RhUiArrowCircleUpLeftFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-up-left-fill-icon';
 
 const errorComponent = (err) => <pre>{err.toString()}</pre>;
 
@@ -214,7 +214,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-top-left'}
                 onClick={() => setFullPageUtilsPosition('pf-m-top-left')}
                 aria-label="Position utilities top left"
-                icon={RhUiArrowCircleUpLeftIcon}
+                icon={fullPageUtilsPosition === 'pf-m-top-left' ? RhUiArrowCircleUpLeftFillIcon : RhUiArrowCircleUpLeftIcon}
               />
               <Button
                 variant="plain"
@@ -223,7 +223,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-bottom-left'}
                 onClick={() => setFullPageUtilsPosition('pf-m-bottom-left')}
                 aria-label="Position utilities bottom left"
-                icon={RhUiArrowCircleDownLeftIcon}
+                icon={fullPageUtilsPosition === 'pf-m-bottom-left' ? RhUiArrowCircleDownLeftFillIcon : RhUiArrowCircleDownLeftIcon}
               />
               <Button
                 variant="plain"
@@ -232,7 +232,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-bottom-right'}
                 onClick={() => setFullPageUtilsPosition('pf-m-bottom-right')}
                 aria-label="Position utilities bottom right"
-                icon={RhUiArrowCircleDownRightIcon}
+                icon={fullPageUtilsPosition === 'pf-m-bottom-right' ? RhUiArrowCircleDownRightFillIcon : RhUiArrowCircleDownRightIcon}
               />
               <Button
                 variant="plain"
@@ -241,7 +241,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-top-right'}
                 onClick={() => setFullPageUtilsPosition('pf-m-top-right')}
                 aria-label="Position utilities top right"
-                icon={RhUiArrowCircleUpRightIcon}
+                icon={fullPageUtilsPosition === 'pf-m-top-right' ? RhUiArrowCircleUpRightFillIcon : RhUiArrowCircleUpRightIcon}
               />
             </Flex>
             {hasThemeSwitcher && <ThemeSelector id="ws-example-theme-select" />}

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -33,6 +33,15 @@ import { convertToReactComponent } from '@patternfly/ast-helpers';
 import missingThumbnail from './missing-thumbnail.jpg';
 import { RtlContext } from '../../layouts';
 import { ThemeSelector } from '../themeSelector/themeSelector';
+// import RhUiArrowCircleDownRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-right-icon';
+// import RhUiArrowCircleDownLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-down-left-icon';
+// import RhUiArrowCircleTopRightIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-top-right-icon';
+// import RhUiArrowCircleTopLeftIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-arrow-circle-top-left-icon';
+
+const RhUiArrowCircleUpRightIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1847" role="img" width="1em" height="1em"><title id="icon-title-1847">RhUiArrowCircleUpRightIcon</title><path d="M22 11.5V20a1 1 0 1 1-2 0v-6.586l-8.243 8.243a.997.997 0 0 1-1.414 0 .999.999 0 0 1 0-1.414L18.586 12H12a1 1 0 1 1 0-2h8.5c.827 0 1.5.673 1.5 1.5Zm9 4.5c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
+const RhUiArrowCircleDownRightIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1837" role="img" width="1em" height="1em"><title id="icon-title-1837">RhUiArrowCircleDownRightIcon</title><path d="M22 12v8.5c0 .827-.673 1.5-1.5 1.5H12a1 1 0 1 1 0-2h6.586l-8.243-8.243a.999.999 0 1 1 1.414-1.414L20 18.586V12a1 1 0 1 1 2 0Zm9 4c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
+const RhUiArrowCircleDownLeftIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1835" role="img" width="1em" height="1em"><title id="icon-title-1835">RhUiArrowCircleDownLeftIcon</title><path d="M21.657 10.343a.999.999 0 0 1 0 1.414L13.414 20H20a1 1 0 1 1 0 2h-8.5c-.827 0-1.5-.673-1.5-1.5V12a1 1 0 1 1 2 0v6.586l8.243-8.243a.999.999 0 0 1 1.414 0ZM31 16c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
+const RhUiArrowCircleUpLeftIcon = <svg class="pf-v6-svg" viewBox="0 0 32 32" fill="currentColor" aria-labelledby="icon-title-1845" role="img" width="1em" height="1em"><title id="icon-title-1845">RhUiArrowCircleUpLeftIcon</title><path d="M21.657 20.243a.999.999 0 1 1-1.414 1.414L12 13.414V20a1 1 0 1 1-2 0v-8.5c0-.827.673-1.5 1.5-1.5H20a1 1 0 1 1 0 2h-6.586l8.243 8.243ZM31 16c0 8.271-6.729 15-15 15S1 24.271 1 16 7.729 1 16 1s15 6.729 15 15Zm-2 0c0-7.168-5.832-13-13-13S3 8.832 3 16s5.832 13 13 13 13-5.832 13-13Z"></path></svg>;
 
 const errorComponent = (err) => <pre>{err.toString()}</pre>;
 
@@ -137,6 +146,7 @@ export const Example = ({
   }
 
   const [editorCode, setEditorCode] = React.useState(code);
+  const [fullPageUtilsPosition, setFullPageUtilsPosition] = React.useState('pf-m-bottom-right');
   const loc = useLocation();
   const isRTL = useContext(RtlContext);
   const scope = {
@@ -194,8 +204,46 @@ export const Example = ({
           <Flex
             direction={{ default: 'column' }}
             gap={{ default: 'gapMd' }}
-            className="ws-full-page-utils pf-v6-m-dir-ltr"
+            className={css('ws-full-page-utils', 'pf-v6-m-dir-ltr', fullPageUtilsPosition)}
           >
+            <Flex justifyContent={{ default: 'justifyContentCenter' }} gap={{ default: 'gapXs' }}>
+            <Button
+                variant="plain"
+                size="sm"
+                hasNoPadding
+                isClicked={fullPageUtilsPosition === 'pf-m-top-left'}
+                onClick={() => setFullPageUtilsPosition('pf-m-top-left')}
+                aria-label="Position utilities top left"
+                icon={RhUiArrowCircleUpLeftIcon}
+              />
+              <Button
+                variant="plain"
+                size="sm"
+                hasNoPadding
+                isClicked={fullPageUtilsPosition === 'pf-m-bottom-left'}
+                onClick={() => setFullPageUtilsPosition('pf-m-bottom-left')}
+                aria-label="Position utilities bottom left"
+                icon={RhUiArrowCircleDownLeftIcon}
+              />
+              <Button
+                variant="plain"
+                size="sm"
+                hasNoPadding
+                isClicked={fullPageUtilsPosition === 'pf-m-bottom-right'}
+                onClick={() => setFullPageUtilsPosition('pf-m-bottom-right')}
+                aria-label="Position utilities bottom right"
+                icon={RhUiArrowCircleDownRightIcon}
+              />
+              <Button
+                variant="plain"
+                size="sm"
+                hasNoPadding
+                isClicked={fullPageUtilsPosition === 'pf-m-top-right'}
+                onClick={() => setFullPageUtilsPosition('pf-m-top-right')}
+                aria-label="Position utilities top right"
+                icon={RhUiArrowCircleUpRightIcon}
+              />
+            </Flex>
             {hasThemeSwitcher && <ThemeSelector id="ws-example-theme-select" />}
             {hasRTLSwitcher && (
               <Switch

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -203,7 +203,7 @@ export const Example = ({
         {(hasThemeSwitcher || hasRTLSwitcher) && (
           <Flex
             direction={{ default: 'column' }}
-            gap={{ default: 'gapMd' }}
+            gap={{ default: 'gapSm' }}
             className={css('ws-full-page-utils', 'pf-v6-m-dir-ltr', fullPageUtilsPosition)}
           >
             <Flex justifyContent={{ default: 'justifyContentCenter' }} gap={{ default: 'gapXs' }}>
@@ -214,7 +214,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-top-left'}
                 onClick={() => setFullPageUtilsPosition('pf-m-top-left')}
                 aria-label="Position utilities top left"
-                icon={fullPageUtilsPosition === 'pf-m-top-left' ? RhUiArrowCircleUpLeftFillIcon : RhUiArrowCircleUpLeftIcon}
+                icon={fullPageUtilsPosition === 'pf-m-top-left' ? <RhUiArrowCircleUpLeftFillIcon /> : <RhUiArrowCircleUpLeftIcon />}
               />
               <Button
                 variant="plain"
@@ -223,7 +223,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-bottom-left'}
                 onClick={() => setFullPageUtilsPosition('pf-m-bottom-left')}
                 aria-label="Position utilities bottom left"
-                icon={fullPageUtilsPosition === 'pf-m-bottom-left' ? RhUiArrowCircleDownLeftFillIcon : RhUiArrowCircleDownLeftIcon}
+                icon={fullPageUtilsPosition === 'pf-m-bottom-left' ? <RhUiArrowCircleDownLeftFillIcon /> : <RhUiArrowCircleDownLeftIcon />}
               />
               <Button
                 variant="plain"
@@ -232,7 +232,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-bottom-right'}
                 onClick={() => setFullPageUtilsPosition('pf-m-bottom-right')}
                 aria-label="Position utilities bottom right"
-                icon={fullPageUtilsPosition === 'pf-m-bottom-right' ? RhUiArrowCircleDownRightFillIcon : RhUiArrowCircleDownRightIcon}
+                icon={fullPageUtilsPosition === 'pf-m-bottom-right' ? <RhUiArrowCircleDownRightFillIcon /> : <RhUiArrowCircleDownRightIcon />}
               />
               <Button
                 variant="plain"
@@ -241,7 +241,7 @@ export const Example = ({
                 isClicked={fullPageUtilsPosition === 'pf-m-top-right'}
                 onClick={() => setFullPageUtilsPosition('pf-m-top-right')}
                 aria-label="Position utilities top right"
-                icon={fullPageUtilsPosition === 'pf-m-top-right' ? RhUiArrowCircleUpRightFillIcon : RhUiArrowCircleUpRightIcon}
+                icon={fullPageUtilsPosition === 'pf-m-top-right' ? <RhUiArrowCircleUpRightFillIcon /> : <RhUiArrowCircleUpRightIcon />}
               />
             </Flex>
             {hasThemeSwitcher && <ThemeSelector id="ws-example-theme-select" />}

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -209,11 +209,42 @@ export const Example = ({
   const previewId = getExampleId(source, section[0], id, title);
   const className = getExampleClassName(source, section[0], id);
 
+  // Four corner position button props
+  const fullPageUtilsPositionProps = {
+    topLeft: {
+      className: 'pf-m-top-left',
+      label: 'Move to the top left corner',
+      tooltipPosition: 'bottom-start',
+      icon: <RhUiArrowCircleUpLeftIcon />,
+      iconClicked: <RhUiArrowCircleUpLeftFillIcon />
+    },
+    topRight: {
+      className: 'pf-m-top-right',
+      label: 'Move to the top right corner',
+      tooltipPosition: 'bottom-end',
+      icon: <RhUiArrowCircleUpRightIcon />,
+      iconClicked: <RhUiArrowCircleUpRightFillIcon />
+    },
+    bottomLeft: {
+      className: 'pf-m-bottom-left',
+      label: 'Move to the bottom left corner',
+      tooltipPosition: 'top-start',
+      icon: <RhUiArrowCircleDownLeftIcon />,
+      iconClicked: <RhUiArrowCircleDownLeftFillIcon />
+    },
+    bottomRight: {
+      className: 'pf-m-bottom-right',
+      label: 'Move to the bottom right corner',
+      tooltipPosition: 'top-end',
+      icon: <RhUiArrowCircleDownRightIcon />,
+      iconClicked: <RhUiArrowCircleDownRightFillIcon />
+    }
+  };
+
   if (isFullscreenPreview) {
-    const tooltipPosition =
-      fullPageUtilsPosition === 'pf-m-bottom-left' ? 'top-start' :
-      fullPageUtilsPosition === 'pf-m-bottom-right' ? 'top-end' :
-      fullPageUtilsPosition === 'pf-m-top-left' ? 'bottom-start' : 'bottom-end';
+    const activeFullPageUtilsTooltipPosition = Object.values(fullPageUtilsPositionProps).find(
+      (props) => props.className === fullPageUtilsPosition
+    )?.tooltipPosition;
 
     return (
       <div id={previewId} className={css(className, 'pf-v6-u-h-100')}>
@@ -224,68 +255,6 @@ export const Example = ({
             gap={{ default: 'gapSm' }}
             className={css('ws-full-page-utils', 'pf-v6-m-dir-ltr', fullPageUtilsPosition)}
           >
-            <Flex justifyContent={{ default: 'justifyContentCenter' }} gap={{ default: 'gapXs' }}>
-              <Tooltip
-                content={'Move to the top left corner'}
-                position={tooltipPosition}
-                enableFlip={false}
-              >
-                <Button
-                  variant="plain"
-                  size="sm"
-                  hasNoPadding
-                  isClicked={fullPageUtilsPosition === 'pf-m-top-left'}
-                  onClick={() => setFullPageUtilsPosition('pf-m-top-left')}
-                  aria-label="Position utilities top left"
-                  icon={fullPageUtilsPosition === 'pf-m-top-left' ? <RhUiArrowCircleUpLeftFillIcon /> : <RhUiArrowCircleUpLeftIcon />}
-                />
-              </Tooltip>
-              <Tooltip
-                content={'Move to the bottom left corner'}
-                position={tooltipPosition}
-                enableFlip={false}
-              >
-                <Button
-                  variant="plain"
-                  size="sm"
-                  hasNoPadding
-                  isClicked={fullPageUtilsPosition === 'pf-m-bottom-left'}
-                  onClick={() => setFullPageUtilsPosition('pf-m-bottom-left')}
-                  aria-label="Position utilities bottom left"
-                  icon={fullPageUtilsPosition === 'pf-m-bottom-left' ? <RhUiArrowCircleDownLeftFillIcon /> : <RhUiArrowCircleDownLeftIcon />}
-                />
-              </Tooltip>
-              <Tooltip
-                content={'Move to the bottom right corner'}
-                position={tooltipPosition}
-                enableFlip={false}
-              >
-                <Button
-                  variant="plain"
-                  size="sm"
-                  hasNoPadding
-                  isClicked={fullPageUtilsPosition === 'pf-m-bottom-right'}
-                  onClick={() => setFullPageUtilsPosition('pf-m-bottom-right')}
-                  aria-label="Position utilities bottom right"
-                  icon={fullPageUtilsPosition === 'pf-m-bottom-right' ? <RhUiArrowCircleDownRightFillIcon /> : <RhUiArrowCircleDownRightIcon />}
-                />
-              </Tooltip>
-              <Tooltip
-                content={'Move to the top right corner'}
-                position={tooltipPosition}
-                enableFlip={false}
-              >
-                <Button
-                  variant="plain"
-                  size="sm"
-                  hasNoPadding
-                  isClicked={fullPageUtilsPosition === 'pf-m-top-right'}
-                  onClick={() => setFullPageUtilsPosition('pf-m-top-right')}
-                  aria-label="Position utilities top right"
-                  icon={fullPageUtilsPosition === 'pf-m-top-right' ? <RhUiArrowCircleUpRightFillIcon /> : <RhUiArrowCircleUpRightIcon />}
-                />
-              </Tooltip>
-            </Flex>
             {hasThemeSwitcher && <ThemeSelector id="ws-example-theme-select" />}
             {hasRTLSwitcher && (
               <Switch
@@ -299,6 +268,27 @@ export const Example = ({
                 }}
               />
             )}
+            {/* Four corner position buttons */}
+            {Object.entries(fullPageUtilsPositionProps).map(([key, utilsProps]) => (
+              <Tooltip
+                key={key}
+                content={utilsProps.label}
+                position={activeFullPageUtilsTooltipPosition || utilsProps.tooltipPosition}
+                enableFlip={false}
+                aria-none
+                aria-life="off"
+              >
+                <Button
+                  variant="plain"
+                  size="sm"
+                  className={css('ws-full-page-utils-position-btn', utilsProps.className)}
+                  isClicked={fullPageUtilsPosition === utilsProps.className}
+                  onClick={() => setFullPageUtilsPosition(utilsProps.className)}
+                  aria-label={`${utilsProps.label}${fullPageUtilsPosition === utilsProps.className ? ', selected' : ''}`}
+                  icon={fullPageUtilsPosition === utilsProps.className ? utilsProps.iconClicked : utilsProps.icon}
+                />
+              </Tooltip>
+            ))}
           </Flex>
         )}
       </div>

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -275,8 +275,8 @@ export const Example = ({
                 content={utilsProps.label}
                 position={activeFullPageUtilsTooltipPosition || utilsProps.tooltipPosition}
                 enableFlip={false}
-                aria-none
-                aria-life="off"
+                aria="none"
+                aria-live="off"
               >
                 <Button
                   variant="plain"

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -209,6 +209,11 @@ export const Example = ({
   const className = getExampleClassName(source, section[0], id);
 
   if (isFullscreenPreview) {
+    const tooltipPosition =
+      fullPageUtilsPosition === 'pf-m-bottom-left' ? 'top-start' :
+      fullPageUtilsPosition === 'pf-m-bottom-right' ? 'top-end' :
+      fullPageUtilsPosition === 'pf-m-top-left' ? 'bottom-start' : 'bottom-end';
+
     return (
       <div id={previewId} className={css(className, 'pf-v6-u-h-100')}>
         {livePreview}
@@ -219,42 +224,66 @@ export const Example = ({
             className={css('ws-full-page-utils', 'pf-v6-m-dir-ltr', fullPageUtilsPosition)}
           >
             <Flex justifyContent={{ default: 'justifyContentCenter' }} gap={{ default: 'gapXs' }}>
-            <Button
-                variant="plain"
-                size="sm"
-                hasNoPadding
-                isClicked={fullPageUtilsPosition === 'pf-m-top-left'}
-                onClick={() => setFullPageUtilsPosition('pf-m-top-left')}
-                aria-label="Position utilities top left"
-                icon={fullPageUtilsPosition === 'pf-m-top-left' ? <RhUiArrowCircleUpLeftFillIcon /> : <RhUiArrowCircleUpLeftIcon />}
-              />
-              <Button
-                variant="plain"
-                size="sm"
-                hasNoPadding
-                isClicked={fullPageUtilsPosition === 'pf-m-bottom-left'}
-                onClick={() => setFullPageUtilsPosition('pf-m-bottom-left')}
-                aria-label="Position utilities bottom left"
-                icon={fullPageUtilsPosition === 'pf-m-bottom-left' ? <RhUiArrowCircleDownLeftFillIcon /> : <RhUiArrowCircleDownLeftIcon />}
-              />
-              <Button
-                variant="plain"
-                size="sm"
-                hasNoPadding
-                isClicked={fullPageUtilsPosition === 'pf-m-bottom-right'}
-                onClick={() => setFullPageUtilsPosition('pf-m-bottom-right')}
-                aria-label="Position utilities bottom right"
-                icon={fullPageUtilsPosition === 'pf-m-bottom-right' ? <RhUiArrowCircleDownRightFillIcon /> : <RhUiArrowCircleDownRightIcon />}
-              />
-              <Button
-                variant="plain"
-                size="sm"
-                hasNoPadding
-                isClicked={fullPageUtilsPosition === 'pf-m-top-right'}
-                onClick={() => setFullPageUtilsPosition('pf-m-top-right')}
-                aria-label="Position utilities top right"
-                icon={fullPageUtilsPosition === 'pf-m-top-right' ? <RhUiArrowCircleUpRightFillIcon /> : <RhUiArrowCircleUpRightIcon />}
-              />
+              <Tooltip
+                content={'Move to the top left corner'}
+                position={tooltipPosition}
+                enableFlip={false}
+              >
+                <Button
+                  variant="plain"
+                  size="sm"
+                  hasNoPadding
+                  isClicked={fullPageUtilsPosition === 'pf-m-top-left'}
+                  onClick={() => setFullPageUtilsPosition('pf-m-top-left')}
+                  aria-label="Position utilities top left"
+                  icon={fullPageUtilsPosition === 'pf-m-top-left' ? <RhUiArrowCircleUpLeftFillIcon /> : <RhUiArrowCircleUpLeftIcon />}
+                />
+              </Tooltip>
+              <Tooltip
+                content={'Move to the bottom left corner'}
+                position={tooltipPosition}
+                enableFlip={false}
+              >
+                <Button
+                  variant="plain"
+                  size="sm"
+                  hasNoPadding
+                  isClicked={fullPageUtilsPosition === 'pf-m-bottom-left'}
+                  onClick={() => setFullPageUtilsPosition('pf-m-bottom-left')}
+                  aria-label="Position utilities bottom left"
+                  icon={fullPageUtilsPosition === 'pf-m-bottom-left' ? <RhUiArrowCircleDownLeftFillIcon /> : <RhUiArrowCircleDownLeftIcon />}
+                />
+              </Tooltip>
+              <Tooltip
+                content={'Move to the bottom right corner'}
+                position={tooltipPosition}
+                enableFlip={false}
+              >
+                <Button
+                  variant="plain"
+                  size="sm"
+                  hasNoPadding
+                  isClicked={fullPageUtilsPosition === 'pf-m-bottom-right'}
+                  onClick={() => setFullPageUtilsPosition('pf-m-bottom-right')}
+                  aria-label="Position utilities bottom right"
+                  icon={fullPageUtilsPosition === 'pf-m-bottom-right' ? <RhUiArrowCircleDownRightFillIcon /> : <RhUiArrowCircleDownRightIcon />}
+                />
+              </Tooltip>
+              <Tooltip
+                content={'Move to the top right corner'}
+                position={tooltipPosition}
+                enableFlip={false}
+              >
+                <Button
+                  variant="plain"
+                  size="sm"
+                  hasNoPadding
+                  isClicked={fullPageUtilsPosition === 'pf-m-top-right'}
+                  onClick={() => setFullPageUtilsPosition('pf-m-top-right')}
+                  aria-label="Position utilities top right"
+                  icon={fullPageUtilsPosition === 'pf-m-top-right' ? <RhUiArrowCircleUpRightFillIcon /> : <RhUiArrowCircleUpRightIcon />}
+                />
+              </Tooltip>
             </Flex>
             {hasThemeSwitcher && <ThemeSelector id="ws-example-theme-select" />}
             {hasRTLSwitcher && (

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -146,9 +146,21 @@ export const Example = ({
   }
 
   const [editorCode, setEditorCode] = React.useState(code);
-  const [fullPageUtilsPosition, setFullPageUtilsPosition] = React.useState('pf-m-bottom-right');
+  const [fullPageUtilsPosition, setFullPageUtilsPosition] = React.useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('fullPageUtilsPosition') || 'pf-m-bottom-left';
+    }
+    return 'pf-m-bottom-left';
+  });
   const loc = useLocation();
   const isRTL = useContext(RtlContext);
+
+  // Save fullPageUtilsPosition to localStorage when it changes
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('fullPageUtilsPosition', fullPageUtilsPosition);
+    }
+  }, [fullPageUtilsPosition]);
   const scope = {
     ...liveContext,
     // These 2 are in the bundle anyways for the site since we dogfood

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -146,8 +146,9 @@ export const Example = ({
   }
 
   const [editorCode, setEditorCode] = React.useState(code);
+  const isBrowser = typeof window !== 'undefined' && window.localStorage;
   const [fullPageUtilsPosition, setFullPageUtilsPosition] = React.useState(() => {
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       return localStorage.getItem('fullPageUtilsPosition') || 'pf-m-bottom-left';
     }
     return 'pf-m-bottom-left';
@@ -157,7 +158,7 @@ export const Example = ({
 
   // Save fullPageUtilsPosition to localStorage when it changes
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       localStorage.setItem('fullPageUtilsPosition', fullPageUtilsPosition);
     }
   }, [fullPageUtilsPosition]);

--- a/packages/documentation-framework/package.json
+++ b/packages/documentation-framework/package.json
@@ -71,6 +71,7 @@
     "@patternfly/patternfly": "^6.5.0-prerelease.33",
     "@patternfly/react-code-editor": "^6.5.0-prerelease.26",
     "@patternfly/react-core": "^6.5.0-prerelease.24",
+    "@patternfly/react-icons": "^6.5.0-prerelease.11",
     "@patternfly/react-table": "^6.5.0-prerelease.24",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/documentation-site/package.json
+++ b/packages/documentation-site/package.json
@@ -28,6 +28,7 @@
     "@patternfly/react-console": "6.1.0",
     "@patternfly/react-data-view": "6.4.0-prerelease.8",
     "@patternfly/react-docs": "7.5.0-prerelease.26",
+    "@patternfly/react-icons": "6.5.0-prerelease.11",
     "@patternfly/react-log-viewer": "6.3.0",
     "@patternfly/react-topology": "6.5.0-prerelease.3",
     "@patternfly/react-user-feedback": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4792,6 +4792,7 @@ __metadata:
     "@patternfly/patternfly": ^6.5.0-prerelease.33
     "@patternfly/react-code-editor": ^6.5.0-prerelease.26
     "@patternfly/react-core": ^6.5.0-prerelease.24
+    "@patternfly/react-icons": ^6.5.0-prerelease.11
     "@patternfly/react-table": ^6.5.0-prerelease.24
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -5142,6 +5143,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-icons@npm:6.5.0-prerelease.11, @patternfly/react-icons@npm:^6.5.0-prerelease.11":
+  version: 6.5.0-prerelease.11
+  resolution: "@patternfly/react-icons@npm:6.5.0-prerelease.11"
+  peerDependencies:
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10c0/d0d91d9e011747dde34a0d3521cd92d58ff29281f6fb1e442c72cf0ea1ca8b3a69e270497e0644ffa499601484394bc9fdf12b070f8568114a7fcfed0428a8c8
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-icons@npm:^6.0.0, @patternfly/react-icons@npm:^6.0.0-prerelease.7, @patternfly/react-icons@npm:^6.3.1":
   version: 6.3.1
   resolution: "@patternfly/react-icons@npm:6.3.1"
@@ -5159,16 +5170,6 @@ __metadata:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
   checksum: 10c0/2072babe83bad4de05e71b27c1180886912c99f24de8e5358cad06e9410a9643171b5dcda69d7e5c36f1010a2457ec9fdbb89cc9d54d92e63ede82de12c543cb
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-icons@npm:^6.5.0-prerelease.11":
-  version: 6.5.0-prerelease.11
-  resolution: "@patternfly/react-icons@npm:6.5.0-prerelease.11"
-  peerDependencies:
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/d0d91d9e011747dde34a0d3521cd92d58ff29281f6fb1e442c72cf0ea1ca8b3a69e270497e0644ffa499601484394bc9fdf12b070f8568114a7fcfed0428a8c8
   languageName: node
   linkType: hard
 
@@ -18961,6 +18962,7 @@ __metadata:
     "@patternfly/react-console": "npm:6.1.0"
     "@patternfly/react-data-view": "npm:6.4.0-prerelease.8"
     "@patternfly/react-docs": "npm:7.5.0-prerelease.26"
+    "@patternfly/react-icons": "npm:6.5.0-prerelease.11"
     "@patternfly/react-log-viewer": "npm:6.3.0"
     "@patternfly/react-topology": "npm:6.5.0-prerelease.3"
     "@patternfly/react-user-feedback": "npm:6.2.0"


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/4892

Preview - can be seen on any full page example:
https://pf-org--pr-4896-site.surge.sh/ai/generative-uis/compass/html-demos/card-view/

This adds something pretty simple. Not sure how to add this without it taking up the entire switcher. Seems like maybe we need a label or something? Not sure - @bekah-stephens wdyt?

<img width="159" height="165" alt="Screenshot 2025-12-16 at 10 09 59 AM" src="https://github.com/user-attachments/assets/dbaa0292-7968-48d4-ba2c-aba46ba4beec" />
