### PR TITLE
fix: update beta alert to remove forum link and update Slack URL

### DIFF
--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -76,8 +76,8 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
         <InlineAlert title="Beta feature">
           This beta component is currently under review and is still open for further evolution. It is available for use
           in product. Beta components are considered for promotion on a quarterly basis. Please join in and give us your
-          feedback or submit any questions on the <a href="https://forum.patternfly.org/">PatternFly forum</a> or via{' '}
-          <a href="//slack.patternfly.org/" target="_blank" rel="noopener noreferrer">
+          feedback or submit any questions via{' '}
+          <a href="https://patternfly.slack.com" target="_blank" rel="noopener noreferrer">
             Slack
           </a>
           . To learn more about the process, visit our{' '}


### PR DESCRIPTION
## Summary

Fixes #4900

This PR updates the beta component alert message in the MDX template to:
- Remove the link to the PatternFly forum (which has been sunsetted)
- Update the Slack URL from `//slack.patternfly.org/` to `https://patternfly.slack.com`

## Changes

- **File modified**: `packages/documentation-framework/templates/mdx.js`
- Removed forum reference from beta alert message (lines 79-80)
- Updated Slack URL to use proper HTTPS format

## Test plan

- [ ] Verify beta alert displays correctly on beta component documentation pages
- [ ] Confirm Slack link opens correctly to https://patternfly.slack.com
- [ ] Ensure no forum link appears in the beta alert message

🤖 Generated with [Claude Code](https://claude.com/claude-code)