### PR TITLE
Replace PatternFly Kotlin with PatternFly Java

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/get-involved/community.md
+++ b/packages/documentation-site/patternfly-docs/content/get-involved/community.md
@@ -108,7 +108,7 @@ Flyers sometimes branch out to build their own groups and projects. While the fo
 
 - **[PatternFly Elements](https://patternflyelements.org):** A community-led project creating web components to use across Red Hat's sites and products. It also offers theming options for your own brand library.
 
-- **[PatternFly Kotlin](https://github.com/patternfly-kotlin/patternfly-kotlin):** A Kotlin implementation of PatternFly based on fritz2, built for Kotlin/JS. This project provides reactive PatternFly components that match the fritz2 API. For a quick overview, refer to [the PatternFly Kotlin showcase](https://patternfly-kotlin.github.io/patternfly-kotlin-showcase/#home).
+- **[PatternFly Java](https://github.com/patternfly-java/patternfly-java):** A Java implementation of PatternFly targeting GWT and J2CL. The goal of this project is to provide all PatternFly charts, components, and layouts in Java. For a quick overview, view the [PatternFly Java showcase](https://patternfly-java.github.io/).
 
 - **[Ansible Component Guide and Figma Library](https://www.figma.com/design/dOVzoCFCRlPXifj2WstR79/AAP-PF6-Style---Component-Guide?node-id=3-10950&t=PBFhyMs7gUxzGRH2-1):** An additional Figma library built on PatternFly components. It's a rapid prototyping tool for repeatable design patterns, tailored for Ansible but with many components applicable to other products.
 

--- a/packages/site/src/content/get-started/about-patternfly.mdx
+++ b/packages/site/src/content/get-started/about-patternfly.mdx
@@ -272,7 +272,7 @@ Sometimes Flyers branch out and build groups of their own, creating new communit
 
 - **[PatternFly Elements](https://patternflyelements.org):** A community created by web-based developers at Red Hat, focused on creating web components for use across Red Hat's sites and SaaS products. It offers theming options for your own brand library.
 
-- **[PatternFly Kotlin](https://github.com/patternfly-kotlin/patternfly-kotlin):** A Kotlin implementation of PatternFly based on fritz2, targeting Kotlin/JS. The goal of this project is to provide all PatternFly components in Kotlin, matching the reactive nature of fritz2. The components use stores, handlers, and other elements from the fritz2 API. For a quick overview, [view the PatternFly Kotlin showcase.](https://patternfly-kotlin.github.io/patternfly-kotlin-showcase/#home)
+- **[PatternFly Java](https://github.com/patternfly-java/patternfly-java):** A Java implementation of PatternFly targeting GWT and J2CL. The goal of this project is to provide all PatternFly charts, components, and layouts in Java. For a quick overview, view the [PatternFly Java showcase](https://patternfly-java.github.io/).
 
 - **[Ansible Component Guide and Sketch Library](https://www.sketch.com/s/6ccbd710-267d-4b69-9dae-bc19e1551056):** An additional resource that designers can use that is built on top of existing PatternFly components. It is a rapid mockup prototyping tool that can be used to quickly put together repeatable design patterns and layouts across projects. This is specific to Ansible, but many of the components are generalized and can fit many product use cases.
 


### PR DESCRIPTION
PatternFly Kotlin is no longer actively maintained. It is replaced by [PatternFly Java](https://github.com/patternfly-java). 

This PR updates the relevant section in the Markdown files. 