### PR TITLE
fix(theme switch): change unified theme class name

### DIFF
--- a/packages/documentation-framework/hooks/useTheme.js
+++ b/packages/documentation-framework/hooks/useTheme.js
@@ -15,7 +15,7 @@ const CONTRAST_MODES = {
 
 const THEME_VARIANT_MODES = {
   DEFAULT: 'theme-default',
-  UNIFIED: 'theme-unified'
+  UNIFIED: 'theme-redhat'
 };
 
 export const THEME_TYPES = {


### PR DESCRIPTION
I changed just the class name `pf-v6-theme-unified` to `pf-v6-theme-redhat` to match the core implementation.
I left "unified" as the label and variable names for the time being until a final name for the theme is set.