### PR TITLE
fix(docs-framework): let examples shrink to fit window width

### DIFF
--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -27,7 +27,6 @@ p.pf-v6-c-content--p.ws-p {
 }
 
 .ws-example-page-wrapper {
-  min-width: 825px;
-  max-width: 1200px;
+  max-width: min(100%, 1200px);
   flex-grow: 1;
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/5074

In https://github.com/patternfly/patternfly-org/pull/4802, the example area was given the change below, which added `min-width: 825px`. That's keeping the examples from shrinking below 825px

<img width="428" height="170" alt="Screenshot 2026-07-14 at 6 01 11 PM" src="https://github.com/user-attachments/assets/f20184de-67b8-4003-a37e-28f3576b10d3" />

I'm pretty sure that was to fix a bug on example pages that have narrow example content and no text that would make the example area fill the content width like this. AFAIK it only showed up on one example page, but I don't remember which example it was.

<img width="1657" height="959" alt="Screenshot 2026-07-14 at 6 06 33 PM" src="https://github.com/user-attachments/assets/c5530ef4-16a2-4c7a-b0ba-4420d718fe46" />

That said, `flex-grow: 1` fixes that specific bug ^, so we can revert back to the old max-width and fix the bug caused by the new min-width. 