### PR TITLE
prototype: responsive TOC redesign (Panel vs Drawer)

### DIFF
--- a/packages/documentation-framework/components/index.js
+++ b/packages/documentation-framework/components/index.js
@@ -10,6 +10,7 @@ export * from './sideNav/sideNav';
 export * from './topNav/topNav';
 export * from './link/link.jsx';
 export * from './tableOfContents/tableOfContents';
+export * from './tableOfContents/tocPrototype';
 export * from './inlineAlert/inlineAlert';
 export * from './themeSelector/themeSelector';
 export * from './feedbackButton/feedbackButton';

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.css
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.css
@@ -1,3 +1,15 @@
+/**
+ * PROTOTYPE: Responsive TOC redesign styles
+ * See tableOfContents.js for breakpoint behavior notes.
+ */
+
+/* —— Shared —— */
+.ws-toc-item .pf-m-link {
+  text-wrap: wrap;
+  text-align: left;
+}
+
+/* —— XL+ / 2xl (≥1450px): sidebar JumpLinks (existing) —— */
 .ws-toc {
   align-self: flex-start;
   position: sticky;
@@ -16,32 +28,17 @@
 }
 
 .ws-toc.pf-m-expanded {
-  box-shadow: var(--pf-t--global--box-shadow--sm--bottom)
+  box-shadow: var(--pf-t--global--box-shadow--sm--bottom);
 }
 
 .ws-toc .pf-v6-c-jump-links__toggle button {
   background-color: var(--pf-t--global--background--color--secondary--default);
 }
 
-/* Mobile jumplinks */
-@media (max-width: 1449px) {
-  .ws-toc.pf-m-expanded .pf-v6-c-jump-links__main {
-    max-height: 65vh;
-    overflow-y:auto;
-  }
-
-  .ws-toc .pf-v6-c-jump-links__header {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-  }
-}
-
 .ws-toc .pf-v6-c-jump-links__main {
   scrollbar-width: none;
 }
 
-/* Hide TOC scrollbar Chrome, Safari & Opera */
 .ws-toc .pf-v6-c-jump-links__main::-webkit-scrollbar {
   display: none;
 }
@@ -52,7 +49,6 @@
     max-width: 320px;
     max-height: calc(100vh - 76px);
     overflow-y: auto;
-    /* Hide TOC scrollbar IE, Edge & Firefox */
     -ms-overflow-style: none;
     scrollbar-width: none;
     padding: 0 0 0 var(--pf-t--global--spacer--2xl);
@@ -66,15 +62,300 @@
   .ws-toc.pf-m-expanded {
     box-shadow: none;
   }
-}
 
-.ws-toc-item .pf-m-link {
-  text-wrap: wrap;
-  text-align: left;
-}
-
-@media (min-width: 1450px) {
   .ws-toc .pf-v6-c-jump-links__main {
     margin-bottom: var(--jump-links-main-margin-bottom);
   }
+}
+
+/* —— Sticky tabs: slot for Lg TOC menu toggle —— */
+.ws-sticky-nav-tabs {
+  display: flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--sm);
+}
+
+.ws-sticky-nav-tabs .pf-v6-c-tabs__list {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ws-toc-menu-slot {
+  display: none;
+  flex: 0 0 auto;
+  align-items: center;
+  margin-inline-start: auto;
+  /* No extra slot padding — tabs pf-m-page-insets (~24px) remains */
+  padding-inline-end: 0;
+}
+
+/* Show slot only at Lg (below 2xl sidebar breakpoint) */
+@media (min-width: 992px) and (max-width: 1449px) {
+  .ws-toc-menu-slot {
+    display: flex;
+  }
+}
+
+/* —— Title row slot kept for layout hooks; unused while no-tabs uses fixed placement —— */
+.ws-toc-title-slot-item {
+  margin-inline-start: auto;
+  display: none;
+}
+
+.ws-toc-title-slot {
+  display: none;
+}
+
+/* —— Menu toggle (Lg plain / Md floating) —— */
+.ws-toc-menu-toggle {
+  flex-shrink: 0;
+  pointer-events: auto;
+}
+
+.ws-toc-menu-toggle.pf-m-expanded,
+.ws-toc-menu-toggle[aria-expanded='true'] {
+  background-color: var(--pf-t--global--background--color--action--plain--clicked);
+}
+
+/* Floating toggle row (md with tabs — sticky below tabs, no content push) */
+.ws-toc-floating {
+  position: sticky;
+  top: calc(var(--ws-toc-sticky-offset, 0px) + var(--pf-t--global--spacer--sm));
+  z-index: 200;
+  display: flex;
+  justify-content: flex-end;
+  align-self: stretch;
+  width: 100%;
+  /* Zero flow height so the toggle overlays content instead of pushing it down */
+  height: 0;
+  margin-block-end: 0;
+  overflow: visible;
+  /* Avoid blocking clicks on page content behind the sticky row */
+  pointer-events: none;
+}
+
+/*
+ * No-tabs / overview: fixed on document.body with a constant right edge.
+ * top is set in JS to the page title (then below stuck toolbars on scroll).
+ */
+.ws-toc-floating-no-tabs {
+  --ws-toc-feedback-clearance: 2.75rem;
+  position: fixed;
+  right: var(--ws-toc-feedback-clearance);
+  left: auto;
+  width: auto;
+  margin: 0;
+  z-index: 300;
+}
+
+.ws-toc-floating-no-tabs:not([style*='top']) {
+  visibility: hidden;
+}
+
+.ws-toc-menu-toggle-floating {
+  background-color: var(--pf-t--global--background--color--floating--default, var(--pf-t--global--background--color--primary--default));
+  box-shadow: var(--pf-t--global--box-shadow--md);
+  border-radius: var(--pf-t--global--border--radius--small);
+  /* Keep toggle at its natural MenuToggle size even when the sticky row has height: 0 */
+  flex-shrink: 0;
+  transform: none;
+  min-width: var(--pf-t--global--spacer--2xl);
+  min-height: var(--pf-t--global--spacer--2xl);
+}
+
+.ws-toc-menu-toggle-floating:hover {
+  background-color: var(--pf-t--global--background--color--floating--hover, var(--pf-t--global--background--color--primary--hover));
+}
+
+@media (max-width: 991px) {
+  .ws-toc-floating:not(.ws-toc-floating-no-tabs) {
+    --ws-toc-feedback-clearance: 2.75rem;
+    margin-inline-end: calc(
+      -1 * var(--pf-v6-c-page__main-section--PaddingInlineEnd, var(--pf-t--global--spacer--md)) +
+        var(--ws-toc-feedback-clearance)
+    );
+  }
+
+  .ws-toc-panel {
+    max-width: min(287px, calc(100vw - var(--ws-toc-feedback-clearance, 2.75rem) - var(--pf-t--global--spacer--lg)));
+  }
+}
+
+/* —— Floating panel with jumplinks —— */
+.ws-toc-panel {
+  width: 287px;
+  max-width: min(287px, calc(100vw - var(--pf-t--global--spacer--2xl)));
+  max-height: min(347px, 65vh);
+  border-radius: var(--pf-t--global--border--radius--medium);
+  overflow: hidden;
+  pointer-events: auto;
+}
+
+.ws-toc-panel .pf-v6-c-panel__main {
+  overflow-y: auto;
+  max-height: inherit;
+}
+
+.ws-toc-panel-jumplinks {
+  width: 100%;
+  background: none;
+  box-shadow: none;
+  margin: 0;
+  padding: var(--pf-t--global--spacer--md);
+}
+
+.ws-toc-panel-jumplinks .pf-v6-c-jump-links__main {
+  scrollbar-width: thin;
+}
+
+.ws-toc-panel-jumplinks .pf-v6-c-jump-links__list {
+  padding-inline-start: 0;
+}
+
+/* —— Pill overlay Drawer surface —— */
+.ws-toc-drawer.pf-v6-c-drawer,
+.ws-toc-drawer {
+  /* Stay in normal page flow; do not create a nested scrollport */
+  display: block;
+  height: auto;
+  min-height: 0;
+  /* PF drawer sets overflow-x:hidden which breaks position:sticky tabs */
+  overflow: visible !important;
+}
+
+/*
+ * Closed panel is collapsed out of flow (below), so we do not need
+ * overflow:hidden on __main (that broke sticky tabs / toolbars).
+ */
+.ws-toc-drawer > .pf-v6-c-drawer__main {
+  overflow: visible;
+  min-height: 0;
+}
+
+.ws-toc-drawer .pf-v6-c-drawer__content {
+  overflow: visible;
+  flex-basis: 100%;
+  flex-shrink: 0;
+  min-width: 0;
+  min-height: 0;
+}
+
+.ws-toc-drawer-content-body {
+  display: block;
+  min-height: 0;
+  height: auto;
+  padding: 0;
+}
+
+/* Closed: keep panel out of layout so it never leaves a blank gutter */
+.ws-toc-drawer:not(.pf-m-expanded):not(.ws-toc-drawer-expanded) .ws-toc-drawer-panel.pf-v6-c-drawer__panel {
+  position: absolute;
+  inset-inline-end: 0;
+  width: 0;
+  min-width: 0;
+  max-width: 0;
+  flex-basis: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/*
+ * Expanded: fixed within #ws-page-main (backdrop-filter containing block),
+ * inset by medium spacer on top, bottom, and inline-end.
+ */
+.ws-toc-drawer.pf-m-expanded .ws-toc-drawer-panel.pf-v6-c-drawer__panel,
+.ws-toc-drawer-expanded .ws-toc-drawer-panel.pf-v6-c-drawer__panel {
+  --pf-v6-c-drawer--m-expanded__panel--inset: var(--pf-t--global--spacer--md);
+  --pf-v6-c-drawer__panel--MarginBlock: 0;
+  margin: 0 !important;
+
+  position: fixed;
+  top: var(--pf-t--global--spacer--md);
+  inset-block-start: var(--pf-t--global--spacer--md);
+  bottom: var(--pf-t--global--spacer--md);
+  inset-block-end: var(--pf-t--global--spacer--md);
+  inset-inline-end: var(--pf-t--global--spacer--md);
+  height: auto;
+  max-height: none;
+  /* Let PF defaults drive size (50% / 450px at xl); width needed because we're fixed */
+  width: var(--pf-v6-c-drawer__panel--FlexBasis);
+  min-width: var(--pf-v6-c-drawer__panel--MinWidth);
+  max-width: none;
+  /* Override PF slide transform so inset metrics control placement */
+  transform: none !important;
+  z-index: 1000;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  visibility: visible;
+}
+
+/* <768px: overlay the full page-main area (md inset on all sides) */
+@media (max-width: 767px) {
+  .ws-toc-drawer.pf-m-expanded .ws-toc-drawer-panel.pf-v6-c-drawer__panel,
+  .ws-toc-drawer-expanded .ws-toc-drawer-panel.pf-v6-c-drawer__panel {
+    inset-inline-start: var(--pf-t--global--spacer--md);
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    flex-basis: auto !important;
+  }
+}
+
+.ws-toc-drawer-panel-body {
+  padding-block-start: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.ws-toc-drawer-jumplinks {
+  width: 100%;
+  background: none;
+  box-shadow: none;
+  margin: 0;
+  padding: var(--pf-t--global--spacer--md);
+}
+
+.ws-toc-drawer-jumplinks .pf-v6-c-jump-links__main {
+  scrollbar-width: thin;
+}
+
+.ws-toc-drawer-jumplinks .pf-v6-c-jump-links__list {
+  padding-inline-start: 0;
+}
+
+/* Keep floating TOC toggle under the open drawer */
+.ws-toc-menu-toggle-under-drawer {
+  z-index: 1 !important;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ws-toc-floating-no-tabs.ws-toc-menu-toggle-under-drawer {
+  z-index: 1 !important;
+}
+
+/* —— Prototype surface switcher (Panel | Drawer) —— */
+.ws-toc-surface-switcher {
+  position: fixed;
+  inset-block-end: var(--pf-t--global--spacer--md);
+  inset-inline-start: var(--pf-t--global--spacer--md);
+  z-index: 400;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--xs);
+  padding: var(--pf-t--global--spacer--sm);
+  background-color: var(--pf-t--global--background--color--floating--default, var(--pf-t--global--background--color--primary--default));
+  box-shadow: var(--pf-t--global--box-shadow--md);
+  border-radius: var(--pf-t--global--border--radius--small);
+}
+
+.ws-toc-surface-switcher-label {
+  font-size: var(--pf-t--global--font--size--body--sm);
+  color: var(--pf-t--global--text--color--subtle);
 }

--- a/packages/documentation-framework/components/tableOfContents/tableOfContents.js
+++ b/packages/documentation-framework/components/tableOfContents/tableOfContents.js
@@ -1,34 +1,240 @@
+/**
+ * PROTOTYPE: Responsive TOC redesign
+ * Branch: prototype/responsive-toc
+ *
+ * Breakpoints (aligned with Figma + PF tokens):
+ * - XL+ / 2xl (≥1450px): expanded sidebar JumpLinks (unchanged)
+ * - Lg (992–1449px): plain icon MenuToggle in sticky tabs → Panel or pill Drawer
+ * - Md and below (<992px): floating sticky MenuToggle → Panel or pill Drawer
+ *   - With tabs: floats below sticky tabs
+ *   - Without tabs (overview pages): fixed to viewport right (aligned with feedback);
+ *     top tracks title, then pins below sticky toolbars — no horizontal jump on scroll
+ *
+ * Surface comparison (localStorage ws-toc-surface): Panel (default) | Drawer (pill overlay)
+ *
+ * Not production-ready — for design-system feedback only.
+ */
 import React from 'react';
-import { JumpLinks, JumpLinksItem, JumpLinksList } from '@patternfly/react-core';
+import { createPortal } from 'react-dom';
+import {
+  JumpLinks,
+  JumpLinksItem,
+  JumpLinksList,
+  MenuToggle,
+  Panel,
+  PanelMain,
+  Popper,
+  Tooltip,
+  Icon
+} from '@patternfly/react-core';
+import ListIcon from '@patternfly/react-icons/dist/esm/icons/list-icon';
 import { trackEvent } from '../../helpers';
+import { TOC_SURFACE, useTocPrototype } from './tocPrototype';
+
+const TOC_SIDEBAR_MIN = 1450; // PF 2xl — full sidebar jumplinks
+const TOC_LG_MIN = 992; // PF lg (62rem) — toggle in sticky tabs
+
+const getMenuSlot = () =>
+  typeof document !== 'undefined' ? document.getElementById('ws-toc-menu-slot') : null;
+
+const getStickyToolbarHeight = () => {
+  if (typeof document === 'undefined') {
+    return 0;
+  }
+  const toolbars = document.querySelectorAll('.pf-v6-c-toolbar.pf-m-sticky');
+  let height = 0;
+  toolbars.forEach((toolbar) => {
+    height += toolbar.offsetHeight;
+  });
+  return height;
+};
+
+const getTocMode = (width, hasTabsSlot) => {
+  if (width >= TOC_SIDEBAR_MIN) {
+    return 'sidebar';
+  }
+  if (width >= TOC_LG_MIN && hasTabsSlot) {
+    return 'tabs';
+  }
+  return 'floating';
+};
 
 export const TableOfContents = ({ items }) => {
-  // Used to recalculate JumpLinks offset if screen size changes
-  const [width, setWidth] = React.useState(window.innerWidth);
-  // Used to calculate where TOC is positioned in smaller viewports
+  const { surface, isDrawerOpen, setIsDrawerOpen, setDrawerContent } = useTocPrototype();
+  const isDrawerSurface = surface === TOC_SURFACE.DRAWER;
+
+  const [width, setWidth] = React.useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth : TOC_SIDEBAR_MIN
+  );
   const [stickyNavHeight, setStickyNavHeight] = React.useState(0);
+  const [stickyToolbarHeight, setStickyToolbarHeight] = React.useState(0);
+  const [menuSlotEl, setMenuSlotEl] = React.useState(getMenuSlot);
+  // Viewport top (px) for no-tabs fixed toggle — only vertical tracking, right stays constant
+  const [noTabsFixedTop, setNoTabsFixedTop] = React.useState(null);
+  const [isPanelOpen, setIsPanelOpen] = React.useState(false);
+  const toggleRef = React.useRef(null);
+  const noTabsFloatingRef = React.useRef(null);
+
+  const hasTabsSlot = Boolean(menuSlotEl);
+  const mode = getTocMode(width, hasTabsSlot);
+
+  const isOpen = isDrawerSurface ? isDrawerOpen : isPanelOpen;
+  const setIsOpen = isDrawerSurface ? setIsDrawerOpen : setIsPanelOpen;
+
+  // Sticky offset: tabs (when present) + sticky toolbars (overview galleries, etc.)
+  const stickyOffset = stickyNavHeight + stickyToolbarHeight;
+
+  const syncLayout = React.useCallback(() => {
+    const stickyNav = document.getElementById('ws-sticky-nav-tabs');
+    setStickyNavHeight(stickyNav ? stickyNav.offsetHeight : 0);
+    setStickyToolbarHeight(getStickyToolbarHeight());
+    setMenuSlotEl(getMenuSlot());
+  }, []);
+
+  /**
+   * No-tabs pages: fixed toggle portaled to document.body (avoids transformed
+   * ancestors breaking position:fixed). Constant `right`; `top` tracks the title
+   * while visible, then pins below stuck sticky toolbars.
+   */
+  const syncNoTabsFixedTop = React.useCallback(() => {
+    if (hasTabsSlot) {
+      setNoTabsFixedTop(null);
+      return;
+    }
+    const scrollEl = document.getElementById('ws-page-main');
+    const titleEl = document.getElementById('ws-page-title');
+    if (!scrollEl) {
+      return;
+    }
+
+    const mainTop = scrollEl.getBoundingClientRect().top;
+    const spacer = 8;
+    const toggleH = noTabsFloatingRef.current?.offsetHeight || 37;
+
+    // While the title is visible, top-align with the title
+    if (titleEl) {
+      const titleRect = titleEl.getBoundingClientRect();
+      if (titleRect.bottom > mainTop + spacer) {
+        setNoTabsFixedTop(Math.max(mainTop + spacer, titleRect.top + (titleRect.height - toggleH) / 2));
+        return;
+      }
+    }
+
+    let stuckToolbarHeight = 0;
+    document.querySelectorAll('.pf-v6-c-toolbar.pf-m-sticky').forEach((toolbar) => {
+      const rect = toolbar.getBoundingClientRect();
+      if (rect.top <= mainTop + 1) {
+        stuckToolbarHeight += toolbar.offsetHeight;
+      }
+    });
+    setStickyToolbarHeight(stuckToolbarHeight);
+    setNoTabsFixedTop(mainTop + stuckToolbarHeight + spacer);
+  }, [hasTabsSlot]);
 
   React.useEffect(() => {
-    if (document.getElementById('ws-sticky-nav-tabs')) {
-      setStickyNavHeight(document.getElementById('ws-sticky-nav-tabs').offsetHeight);
+    syncLayout();
+  }, [syncLayout, mode, width]);
+
+  React.useEffect(() => {
+    syncNoTabsFixedTop();
+    const scrollEl = document.getElementById('ws-page-main');
+    if (!scrollEl) {
+      return undefined;
     }
-  }, []);
+    const onScroll = () => {
+      syncNoTabsFixedTop();
+    };
+    scrollEl.addEventListener('scroll', onScroll, { passive: true });
+
+    const observer =
+      typeof MutationObserver !== 'undefined'
+        ? new MutationObserver(() => {
+            syncLayout();
+            syncNoTabsFixedTop();
+          })
+        : null;
+    observer?.observe(scrollEl, { childList: true, subtree: true });
+
+    return () => {
+      scrollEl.removeEventListener('scroll', onScroll);
+      observer?.disconnect();
+    };
+  }, [syncLayout, syncNoTabsFixedTop]);
+
+  React.useEffect(() => {
+    const onResize = () => {
+      const nextWidth = window.innerWidth;
+      setWidth((prev) => {
+        if (prev !== nextWidth) {
+          setIsOpen(false);
+        }
+        return nextWidth;
+      });
+      syncLayout();
+      syncNoTabsFixedTop();
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [syncLayout, syncNoTabsFixedTop, setIsOpen]);
+
+  React.useLayoutEffect(() => {
+    if (!hasTabsSlot && mode === 'floating') {
+      syncNoTabsFixedTop();
+    }
+  }, [hasTabsSlot, mode, syncNoTabsFixedTop]);
+
+  React.useEffect(() => {
+    if (mode === 'sidebar') {
+      setIsPanelOpen(false);
+      setIsDrawerOpen(false);
+    }
+  }, [mode, setIsDrawerOpen]);
+
+  // Close panel when switching away from panel surface
+  React.useEffect(() => {
+    if (isDrawerSurface) {
+      setIsPanelOpen(false);
+    }
+  }, [isDrawerSurface]);
+
+  // Escape closes drawer surface (panel handled by Popper)
+  React.useEffect(() => {
+    if (!isDrawerSurface || !isDrawerOpen) {
+      return undefined;
+    }
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setIsDrawerOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isDrawerSurface, isDrawerOpen, setIsDrawerOpen]);
+
+  const getOffset = () => {
+    if (width >= TOC_SIDEBAR_MIN) {
+      return 88 + stickyNavHeight;
+    }
+    if (width >= 768) {
+      return 142 + stickyOffset;
+    }
+    return 190 + stickyOffset;
+  };
+
+  const closeSurface = () => setIsOpen(false);
+
+  const handleJumpClick = (id) => {
+    trackEvent('jump_link_click', 'click_event', id.toUpperCase());
+    closeSurface();
+  };
 
   const updateWidth = () => {
     const { innerWidth } = window;
-    innerWidth !== width && setWidth(innerWidth);
-  };
-
-  const getOffset = () => {
-    if (width >= 1450) {
-      return 88 + stickyNavHeight;
-    } else if (width >= 768) {
-      return 142 + stickyNavHeight;
-    } else {
-      return 190 + stickyNavHeight;
+    if (innerWidth !== width) {
+      setWidth(innerWidth);
     }
   };
-  
+
   let jumpLinksItems = [];
   let wasSublistRendered = false;
 
@@ -45,7 +251,7 @@ export const TableOfContents = ({ items }) => {
               className="ws-toc-item"
               onKeyDown={updateWidth}
               onMouseDown={updateWidth}
-              onClick={() => trackEvent('jump_link_click', 'click_event', curItem.id.toUpperCase())}
+              onClick={() => handleJumpClick(curItem.id)}
             >
               {curItem.text}
             </JumpLinksItem>
@@ -56,30 +262,29 @@ export const TableOfContents = ({ items }) => {
   };
 
   const renderJumpLinksItems = () => {
+    jumpLinksItems = [];
+    wasSublistRendered = false;
     items.forEach((item, index) => {
-      let nextItem = items[index + 1];
-      // Don't render empty <JumpLinksItem> for an array of sublist items
+      const nextItem = items[index + 1];
       if (wasSublistRendered) {
         wasSublistRendered = false;
         return;
       }
       if (!Array.isArray(nextItem) && Array.isArray(item)) {
-        {
-          item.map((curItem) =>
-            jumpLinksItems.push(
-              <JumpLinksItem
-                key={curItem.id}
-                href={`#${curItem.id}`}
-                className="ws-toc-item"
-                onKeyDown={updateWidth}
-                onMouseDown={updateWidth}
-                onClick={() => trackEvent('jump_link_click', 'click_event', curItem.id.toUpperCase())}
-              >
-                {curItem.text}
-              </JumpLinksItem>
-            )
-          );
-        }
+        item.forEach((curItem) =>
+          jumpLinksItems.push(
+            <JumpLinksItem
+              key={curItem.id}
+              href={`#${curItem.id}`}
+              className="ws-toc-item"
+              onKeyDown={updateWidth}
+              onMouseDown={updateWidth}
+              onClick={() => handleJumpClick(curItem.id)}
+            >
+              {curItem.text}
+            </JumpLinksItem>
+          )
+        );
       } else {
         jumpLinksItems.push(
           <JumpLinksItem
@@ -88,7 +293,7 @@ export const TableOfContents = ({ items }) => {
             className="ws-toc-item"
             onKeyDown={updateWidth}
             onMouseDown={updateWidth}
-            onClick={() => trackEvent('jump_link_click', 'click_event', item.id.toUpperCase())}
+            onClick={() => handleJumpClick(item.id)}
           >
             {Array.isArray(nextItem) ? renderSublist(item, nextItem) : item.text}
           </JumpLinksItem>
@@ -98,19 +303,171 @@ export const TableOfContents = ({ items }) => {
     return jumpLinksItems;
   };
 
-  return (
+  const jumpLinksChildren = renderJumpLinksItems();
+  const offset = getOffset();
+
+  const drawerJumpLinks = (
     <JumpLinks
-      label="Table of contents"
       isVertical
       scrollableSelector="#ws-page-main"
-      className="ws-toc"
-      style={{ top: stickyNavHeight,
-        '--jump-links-main-margin-bottom': `${stickyNavHeight}px`
-      }}
-      offset={getOffset()}
-      expandable={{ default: 'expandable', '2xl': 'nonExpandable' }}
+      className="ws-toc-drawer-jumplinks"
+      offset={offset}
+      aria-label="Table of contents"
     >
-      {renderJumpLinksItems()}
+      {jumpLinksChildren}
     </JumpLinks>
+  );
+
+  // Register jumplinks into the page-level pill Drawer when using drawer surface
+  React.useEffect(() => {
+    if (mode === 'sidebar' || !isDrawerSurface) {
+      setDrawerContent(null);
+      return undefined;
+    }
+    setDrawerContent(drawerJumpLinks);
+    return () => setDrawerContent(null);
+    // drawerJumpLinks is recreated each render; depend on inputs that change its content
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, isDrawerSurface, items, offset, setDrawerContent]);
+
+  // — XL+ / 2xl: existing sidebar JumpLinks —
+  if (mode === 'sidebar') {
+    return (
+      <JumpLinks
+        label="Table of contents"
+        isVertical
+        scrollableSelector="#ws-page-main"
+        className="ws-toc"
+        style={{
+          top: stickyNavHeight,
+          '--jump-links-main-margin-bottom': `${stickyNavHeight}px`
+        }}
+        offset={offset}
+        expandable={{ default: 'expandable', '2xl': 'nonExpandable' }}
+      >
+        {jumpLinksChildren}
+      </JumpLinks>
+    );
+  }
+
+  // — Lg / Md: MenuToggle opens Panel (Popper) or page-level pill Drawer —
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      variant="plain"
+      className={[
+        mode === 'floating' ? 'ws-toc-menu-toggle ws-toc-menu-toggle-floating' : 'ws-toc-menu-toggle',
+        isDrawerSurface && isDrawerOpen ? 'ws-toc-menu-toggle-under-drawer' : ''
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      isExpanded={isOpen}
+      onClick={() => setIsOpen((open) => !open)}
+      aria-label="Table of contents"
+      aria-haspopup="dialog"
+      icon={
+        <Icon size="lg">
+          <ListIcon aria-hidden="true" />
+        </Icon>
+      }
+    />
+  );
+
+  const panel = (
+    <Panel variant="raised" className="ws-toc-panel" isScrollable>
+      <PanelMain>
+        <JumpLinks
+          isVertical
+          scrollableSelector="#ws-page-main"
+          className="ws-toc-panel-jumplinks"
+          offset={offset}
+          aria-label="Table of contents"
+        >
+          {jumpLinksChildren}
+        </JumpLinks>
+      </PanelMain>
+    </Panel>
+  );
+
+  const menu = isDrawerSurface ? (
+    <>
+      <Tooltip content="Table of contents" position="left" triggerRef={toggleRef} />
+      {toggle}
+    </>
+  ) : (
+    <>
+      <Tooltip content="Table of contents" position="left" triggerRef={toggleRef} />
+      <Popper
+        trigger={toggle}
+        triggerRef={toggleRef}
+        popper={panel}
+        isVisible={isPanelOpen}
+        position="end"
+        direction="down"
+        distance={8}
+        minWidth="287px"
+        enableFlip
+        preventOverflow
+        appendTo={() => document.getElementById('ws-page-main') || document.body}
+        onDocumentClick={(event, triggerElement, popperElement) => {
+          if (
+            isPanelOpen &&
+            !triggerElement?.contains(event.target) &&
+            !popperElement?.contains(event.target)
+          ) {
+            setIsPanelOpen(false);
+          }
+        }}
+        onDocumentKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            setIsPanelOpen(false);
+          }
+        }}
+      />
+    </>
+  );
+
+  if (mode === 'tabs') {
+    if (!menuSlotEl) {
+      return null;
+    }
+    return createPortal(menu, menuSlotEl);
+  }
+
+  // No-tabs: portal to body so position:fixed is viewport-relative (not trapped by page transforms)
+  if (!hasTabsSlot) {
+    if (typeof document === 'undefined') {
+      return null;
+    }
+    return createPortal(
+      <div
+        ref={noTabsFloatingRef}
+        className={[
+          'ws-toc-floating',
+          'ws-toc-floating-no-tabs',
+          isDrawerSurface && isDrawerOpen ? 'ws-toc-menu-toggle-under-drawer' : ''
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        style={{
+          top: noTabsFixedTop != null ? `${noTabsFixedTop}px` : undefined
+        }}
+      >
+        {menu}
+      </div>,
+      document.body
+    );
+  }
+
+  // Floating below sticky tabs (md)
+  return (
+    <div
+      className="ws-toc-floating"
+      style={{
+        '--ws-toc-sticky-offset': `${stickyOffset}px`
+      }}
+    >
+      {menu}
+    </div>
   );
 };

--- a/packages/documentation-framework/components/tableOfContents/tocPrototype.js
+++ b/packages/documentation-framework/components/tableOfContents/tocPrototype.js
@@ -1,0 +1,141 @@
+/**
+ * PROTOTYPE: TOC surface comparison (Panel vs pill overlay Drawer)
+ * Persists surface choice in localStorage for design/dev review.
+ */
+import React from 'react';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelContent,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerPanelBody,
+  ToggleGroup,
+  ToggleGroupItem
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+
+export const TOC_SURFACE = {
+  PANEL: 'panel',
+  DRAWER: 'drawer'
+};
+
+const STORAGE_KEY = 'ws-toc-surface';
+
+const TocPrototypeContext = React.createContext({
+  surface: TOC_SURFACE.PANEL,
+  setSurface: () => {},
+  isDrawerOpen: false,
+  setIsDrawerOpen: () => {},
+  drawerContent: null,
+  setDrawerContent: () => {}
+});
+
+const readStoredSurface = () => {
+  if (typeof window === 'undefined') {
+    return TOC_SURFACE.PANEL;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === TOC_SURFACE.DRAWER || stored === TOC_SURFACE.PANEL) {
+      return stored;
+    }
+  } catch {
+    // ignore
+  }
+  return TOC_SURFACE.PANEL;
+};
+
+export const TocPrototypeProvider = ({ children }) => {
+  const [surface, setSurfaceState] = React.useState(readStoredSurface);
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+  const [drawerContent, setDrawerContent] = React.useState(null);
+
+  const setSurface = React.useCallback((next) => {
+    setSurfaceState(next);
+    setIsDrawerOpen(false);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const value = React.useMemo(
+    () => ({
+      surface,
+      setSurface,
+      isDrawerOpen,
+      setIsDrawerOpen,
+      drawerContent,
+      setDrawerContent
+    }),
+    [surface, setSurface, isDrawerOpen, drawerContent]
+  );
+
+  return <TocPrototypeContext.Provider value={value}>{children}</TocPrototypeContext.Provider>;
+};
+
+export const useTocPrototype = () => React.useContext(TocPrototypeContext);
+
+/** Wraps page content in a pill overlay Drawer for the Drawer surface option. */
+export const TocDrawerShell = ({ children }) => {
+  const { surface, isDrawerOpen, setIsDrawerOpen, drawerContent } = useTocPrototype();
+  const isDrawerSurface = surface === TOC_SURFACE.DRAWER;
+  const drawerExpanded = isDrawerSurface && isDrawerOpen;
+
+  const panelContent = (
+    <DrawerPanelContent className="ws-toc-drawer-panel" focusTrap={{ enabled: true }}>
+      <DrawerHead>
+        <span tabIndex={isDrawerOpen ? 0 : -1}>Table of contents</span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={() => setIsDrawerOpen(false)} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody className="ws-toc-drawer-panel-body" hasNoPadding>
+        {drawerContent}
+      </DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+
+  return (
+    <Drawer
+      className={css('ws-toc-drawer', drawerExpanded && 'ws-toc-drawer-expanded')}
+      isExpanded={drawerExpanded}
+      isPill
+      position="end"
+      onExpand={() => {}}
+    >
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody className="ws-toc-drawer-content-body">{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+/** Fixed switcher so reviewers can compare Panel vs Drawer without code changes. */
+export const TocSurfaceSwitcher = () => {
+  const { surface, setSurface } = useTocPrototype();
+
+  return (
+    <div className="ws-toc-surface-switcher" role="group" aria-label="TOC prototype surface">
+      <span className="ws-toc-surface-switcher-label">TOC surface</span>
+      <ToggleGroup aria-label="Choose TOC open surface">
+        <ToggleGroupItem
+          text="Panel"
+          buttonId="ws-toc-surface-panel"
+          isSelected={surface === TOC_SURFACE.PANEL}
+          onChange={() => setSurface(TOC_SURFACE.PANEL)}
+        />
+        <ToggleGroupItem
+          text="Drawer"
+          buttonId="ws-toc-surface-drawer"
+          isSelected={surface === TOC_SURFACE.DRAWER}
+          onChange={() => setSurface(TOC_SURFACE.DRAWER)}
+        />
+      </ToggleGroup>
+    </div>
+  );
+};

--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -26,8 +26,16 @@ p.pf-v6-c-content--p.ws-p {
   z-index: var(--pf-t--global--z-index--2xl);
 }
 
+/* PROTOTYPE: allow content to shrink so Md TOC floating behavior can be reviewed */
 .ws-example-page-wrapper {
-  min-width: 825px;
+  min-width: 0;
   max-width: 1200px;
   flex-grow: 1;
+  width: 100%;
+}
+
+@media (min-width: 1450px) {
+  .ws-example-page-wrapper {
+    min-width: 825px;
+  }
 }

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -19,6 +19,11 @@ import { css } from '@patternfly/react-styles';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Router, useLocation } from '@reach/router';
 import { CSSVariables, PropsTable, TableOfContents, Link, AutoLinkHeader, InlineAlert, FeedbackButton } from '../components';
+import {
+  TocPrototypeProvider,
+  TocDrawerShell,
+  TocSurfaceSwitcher
+} from '../components/tableOfContents/tocPrototype';
 import { capitalize, getTitle, slugger, trackEvent } from '../helpers';
 import './mdx.css';
 import { convertToReactComponent } from '@patternfly/ast-helpers';
@@ -30,7 +35,8 @@ const StickyTabs = React.memo(({ sourceKeys, tabNames, activeSource, path }) => 
 
   return (
     <PageSection id="ws-sticky-nav-tabs" stickyBase="top" isStickyStuck={isStickyStuck} type="tabs">
-      <div className="pf-v6-c-tabs pf-m-page-insets">
+      {/* PROTOTYPE: flex row hosts source tabs + Lg TOC menu slot (#ws-toc-menu-slot) */}
+      <div className="pf-v6-c-tabs pf-m-page-insets ws-sticky-nav-tabs">
         <ul className="pf-v6-c-tabs__list">
           {sourceKeys.map((source, index) => (
             <li
@@ -44,6 +50,7 @@ const StickyTabs = React.memo(({ sourceKeys, tabNames, activeSource, path }) => 
             </li>
           ))}
         </ul>
+        <div id="ws-toc-menu-slot" className="ws-toc-menu-slot" />
       </div>
     </PageSection>
   );
@@ -288,70 +295,77 @@ export const MDXTemplate = ({ title, sources = [], path, id, componentsData }) =
   const showTabs = (!isSinglePage && !hideTabName) || isComponent || isUtility || isPattern;
 
   return (
-    <React.Fragment>
-      <PageGroup>
-        <PageSection className={getClassName()} variant={!isSinglePage ? PageSectionVariants.light : ''} isWidthLimited>
-          <Content isEditorial>
-            <Flex alignItems={{ default: 'alignItemsCenter' }}>
-              <FlexItem>
-                <Title headingLevel="h1" size="4xl" id="ws-page-title">
-                  {title}
-                </Title>
-              </FlexItem>
-              <FlexItem>
-                <Flex display={{ default: 'inlineFlex' }}>
-                  {isDeprecated && (
-                    <FlexItem spacer={{ default: 'spacerSm' }}>
-                      <Tooltip content="Deprecated components are available for use but are no longer being maintained or enhanced.">
-                        <Button variant="plain" hasNoPadding>
-                          <Label color="grey">Deprecated</Label>
-                        </Button>
-                      </Tooltip>
-                    </FlexItem>
-                  )}
-                  {isDemo && (
-                    <FlexItem spacer={{ default: 'spacerSm' }}>
-                      <Tooltip content="Demos show how multiple components can be used in a single design.">
-                        <Button variant="plain" hasNoPadding>
-                          <Label color="purple">Demo</Label>
-                        </Button>
-                      </Tooltip>
-                    </FlexItem>
-                  )}
-                  {isBeta && (
-                    <FlexItem spacer={{ default: 'spacerSm' }}>
-                      <Tooltip content="This beta component is currently under review and is still open for further evolution.">
-                        <Button variant="plain" hasNoPadding>
-                          <Label color="blue">Beta</Label>
-                        </Button>
-                      </Tooltip>
-                    </FlexItem>
-                  )}
-                </Flex>
-              </FlexItem>
-            </Flex>
-            {isComponent && summary && <SummaryComponent />}
-          </Content>
-        </PageSection>
-        {showTabs && (
-          <StickyTabs sourceKeys={sourceKeys} tabNames={tabNames} activeSource={activeSource} path={path} />
-        )}
-        <PageSection id="main-content" isFilled className="pf-m-light-100">
-          {isSinglePage && <MDXChildTemplate {...sources[0]} id={id} />}
-          {!isSinglePage && (
-            <Router className="pf-v6-u-h-100" primary={false}>
-              {sources
-                .map((source, index) => {
-                  source.index = index;
-                  return source;
-                })
-                .map(MDXChildTemplate)}
-            </Router>
+    <TocPrototypeProvider>
+      <TocDrawerShell>
+        <PageGroup>
+          <PageSection className={getClassName()} variant={!isSinglePage ? PageSectionVariants.light : ''} isWidthLimited>
+            <Content isEditorial>
+              <Flex alignItems={{ default: 'alignItemsCenter' }} className="ws-page-title-row">
+                <FlexItem>
+                  <Title headingLevel="h1" size="4xl" id="ws-page-title">
+                    {title}
+                  </Title>
+                </FlexItem>
+                <FlexItem>
+                  <Flex display={{ default: 'inlineFlex' }}>
+                    {isDeprecated && (
+                      <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <Tooltip content="Deprecated components are available for use but are no longer being maintained or enhanced.">
+                          <Button variant="plain" hasNoPadding>
+                            <Label color="grey">Deprecated</Label>
+                          </Button>
+                        </Tooltip>
+                      </FlexItem>
+                    )}
+                    {isDemo && (
+                      <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <Tooltip content="Demos show how multiple components can be used in a single design.">
+                          <Button variant="plain" hasNoPadding>
+                            <Label color="purple">Demo</Label>
+                          </Button>
+                        </Tooltip>
+                      </FlexItem>
+                    )}
+                    {isBeta && (
+                      <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <Tooltip content="This beta component is currently under review and is still open for further evolution.">
+                          <Button variant="plain" hasNoPadding>
+                            <Label color="blue">Beta</Label>
+                          </Button>
+                        </Tooltip>
+                      </FlexItem>
+                    )}
+                  </Flex>
+                </FlexItem>
+                {/* PROTOTYPE: title-row slot (unused while no-tabs uses fixed placement) */}
+                <FlexItem className="ws-toc-title-slot-item" align={{ default: 'alignRight' }}>
+                  <div id="ws-toc-title-slot" className="ws-toc-title-slot" />
+                </FlexItem>
+              </Flex>
+              {isComponent && summary && <SummaryComponent />}
+            </Content>
+          </PageSection>
+          {showTabs && (
+            <StickyTabs sourceKeys={sourceKeys} tabNames={tabNames} activeSource={activeSource} path={path} />
           )}
-        </PageSection>
-        <BackToTop className="ws-back-to-top" scrollableSelector="#ws-page-main" />
-        {hasFeedbackButton && <FeedbackButton />}
-      </PageGroup>
-    </React.Fragment>
+          <PageSection id="main-content" isFilled className="pf-m-light-100">
+            {isSinglePage && <MDXChildTemplate {...sources[0]} id={id} />}
+            {!isSinglePage && (
+              <Router className="pf-v6-u-h-100" primary={false}>
+                {sources
+                  .map((source, index) => {
+                    source.index = index;
+                    return source;
+                  })
+                  .map(MDXChildTemplate)}
+              </Router>
+            )}
+          </PageSection>
+          <BackToTop className="ws-back-to-top" scrollableSelector="#ws-page-main" />
+          {hasFeedbackButton && <FeedbackButton />}
+        </PageGroup>
+        <TocSurfaceSwitcher />
+      </TocDrawerShell>
+    </TocPrototypeProvider>
   );
 };


### PR DESCRIPTION
## Summary
- **WIP prototype** for design/dev feedback — not intended to merge as-is.
- Responsive TOC behaviors by breakpoint:
  - **≥1450px:** existing sidebar JumpLinks
  - **992–1449px:** MenuToggle in sticky tabs
  - **&lt;992px:** floating MenuToggle (below tabs, or fixed on overview pages)
- Bottom-left **TOC surface** switcher to compare **Panel** (raised + Popper) vs **pill overlay Drawer** (PF defaults for width/min-width; full-bleed overlay under 768px).
- Choice persists in `localStorage` (`ws-toc-surface`).

## Preview / review notes
- Use the fixed **TOC surface** control (bottom-left) to switch Panel vs Drawer.
- Hard refresh if HMR misses CSS.
- Figma: https://www.figma.com/design/Q6aimf2M8cfoA3C7aOnlgD/pf.org---Responsive-TOC-redesign?node-id=123-526

## Test plan
- [ ] Component page with tabs (e.g. Accordion): Lg toggle in tabs; Md floating toggle; XL+ sidebar unchanged
- [ ] Overview / no-tabs page: fixed toggle placement vs Give feedback; no horizontal jump on scroll
- [ ] Drawer surface: opens with PF default width; md inset top/bottom/end; &lt;768px full page-main overlay
- [ ] Drawer closed: no blank gutter; sticky tabs still stick
- [ ] Panel surface still works as before
- [ ] Surface choice survives reload


Made with [Cursor](https://cursor.com)