### PR TITLE
fix: keep examples from pushing jump links off screen

### DIFF
--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -29,4 +29,5 @@ p.pf-v6-c-content--p.ws-p {
 .ws-example-page-wrapper {
   max-width: min(100%, 1200px);
   flex-grow: 1;
+  min-width: 0;
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-org/issues/5084

Included steps in the issue on how to reproduce but here they are

> The main content area isn't shrinking properly based on the example content.
> 
> To reproduce
> 
> * Go to one of these examples
>   * https://staging.patternfly.org/components/table/
>   * https://staging.patternfly.org/components/tooltip/
> * Resize the browser to 1450px or just above, which is the point at which the jump links move to the right side of the page
> * Note that the jump links are not visible and you have to scroll over to the right to get them in view

