### PR TITLE
docs(AI): update marketplace page for rh-uxd/ai-helpers

### DIFF
--- a/packages/documentation-site/patternfly-docs/content/AI/ai.md
+++ b/packages/documentation-site/patternfly-docs/content/AI/ai.md
@@ -36,7 +36,7 @@ When used thoughtfully, **AI** can enhance user experiences through personalized
 
 ### AI-assisted development
 
-- **[Marketplace](/ai/ai-assisted-development/marketplace):** Plugins that give AI coding assistants knowledge and skills to generate more accurate, PatternFly-compliant code.
+- **[Marketplace](/ai/ai-assisted-development/marketplace):** Plugins for PatternFly and UXD workflows that give AI coding assistants knowledge and skills to generate more accurate, design-system-compliant code.
 - **[PatternFly CLI](/ai/ai-assisted-development/patternfly-cli):** A command-line tool for scaffolding projects, performing code modifications, and running project-related tasks.
 - **[PatternFly MCP](/ai/ai-assisted-development/patternfly-mcp):** An MCP server that gives AI coding tools PatternFly knowledge and capabilities.
 - **[Rapid prototyping](/ai/ai-assisted-development/rapid-prototyping):** Guidance for generating and iterating AI features during early stages of design.

--- a/packages/documentation-site/patternfly-docs/content/AI/marketplace/marketplace.md
+++ b/packages/documentation-site/patternfly-docs/content/AI/marketplace/marketplace.md
@@ -5,9 +5,9 @@ subsection: AI-assisted development
 sortValue: 3
 ---
 
-The [PatternFly AI Helpers](https://github.com/patternfly/ai-helpers) marketplace is an open source collection of **plugins** for AI coding tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Cursor](https://www.cursor.com/). These plugins provide models with knowledge and skills that are tailored to PatternFly workflows, so your AI tools can generate more accurate solutions that follow our best practices.
+The [AI Helpers](https://github.com/rh-uxd/ai-helpers) marketplace is an open source collection of **plugins** for AI coding tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Cursor](https://www.cursor.com/). Hosted in the `rh-uxd/ai-helpers` repository, it includes plugins for both PatternFly and UXD workflows. These plugins provide models with knowledge and skills tailored to our design system and team practices, so your AI tools can generate more accurate solutions that follow our best practices.
 
-Whether you're building PatternFly UIs, prototyping in code, or evaluating AI tooling for your team, our AI Helpers can simplify and enhance your experience.
+Whether you're building PatternFly UIs, prototyping in code, or evaluating AI tooling for your team, AI Helpers can simplify and enhance your experience.
 
 With AI Helpers installed, you can expect a few benefits when using generative AI:
 
@@ -15,41 +15,49 @@ With AI Helpers installed, you can expect a few benefits when using generative A
 - Faster prototyping and development cycles.
 - Fewer common implementation mistakes.
 - Built-in awareness of PatternFly coding standards, accessibility, and design tokens.
+- Support for UXD workflows such as prototyping, research, and design review.
 
 ## What plugins are available?
 
-The AI Helpers marketplace is organized into plugins, each focused on a different area of PatternFly — from building and testing React components, to working with design tokens and accessibility, to reviewing Figma changes. New plugins are added regularly as the community contributes.
+The AI Helpers marketplace is organized into plugins across PatternFly and UXD:
 
-We are actively maintaining and evolving our plugins based on the needs of our maintainers and users. For the current list of plugins, view our [plugin catalog](https://github.com/patternfly/ai-helpers/blob/main/PLUGINS.md).
+- **PatternFly plugins** cover React component development, design guidance, design audits, migration, code review, team workflows, and MCP documentation access. On Claude Code, you can install the `patternfly` meta-plugin to get the PatternFly sub-plugins in one step.
+- **UXD plugins** (such as `uxd-workshop`) support prototyping, research, design review, and related team workflows.
+
+New plugins are added regularly as the community contributes. For the current list of plugins and skills, view our [plugin catalog](https://github.com/rh-uxd/ai-helpers/blob/main/PLUGINS.md).
 
 ## Get started
 
 You can use our plugins with the AI coding tool of your choice, such as Claude Code or Cursor, by following these onboarding steps.
 
-For the best experience, set up the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) to give AI tools direct access to PatternFly component documentation, prop schemas, and design guidelines. While our plugins work without the PatternFly MCP, connecting your tools to it will provide stronger results.
+For the best experience, set up the [PatternFly MCP server](https://github.com/patternfly/patternfly-mcp) to give AI tools direct access to PatternFly component documentation, prop schemas, and design guidelines. On Claude Code, MCP is included when you install the `patternfly` meta-plugin. On Cursor, the MCP server requires [separate setup](https://github.com/rh-uxd/ai-helpers/blob/main/FAQ.md#how-do-i-test-a-skill-without-the-patternfly-mcp-server).
 
 ### Claude Code
 
-To use our AI Helpers in Claude Code:
+To use AI Helpers in Claude Code:
 
 1. Add the AI Helpers marketplace:
 ```bash
-/plugin marketplace add patternfly/ai-helpers
+claude plugins marketplace add rh-uxd/ai-helpers
 ```
 
-2. Install the specific plugins you need:
+2. Install the PatternFly meta-plugin (recommended), which auto-installs the PatternFly sub-plugins:
 ```bash
-/plugin install react@ai-helpers
+claude plugins install patternfly@uxd-ai-helpers
 ```
 
-3. Utilize the plugin's skills and knowledge in your project.
+Or install individual plugins as needed (for example, `claude plugins install pf-react@uxd-ai-helpers`). Don't install both `patternfly` and individual PatternFly sub-plugins — `patternfly` already includes them.
+
+3. Use the plugin's skills and knowledge in your project. Skills are available as slash commands, such as `/pf-react:pf-test-gen`.
 
 ### Cursor
 
-Cursor can discover plugins from `.cursor-plugin/` directories. If you also have Claude Code installed, Cursor may pick up installed plugins automatically via its third-party plugin settings. See the [AI Helpers README](https://github.com/patternfly/ai-helpers#cursor) for details.
+In Cursor, add the marketplace in **Settings → Marketplace**, then install the plugins you need. See the [Plugins table in the AI Helpers README](https://github.com/rh-uxd/ai-helpers#plugins) for the full list.
+
+After installing, skills work the same way — as slash commands in any project. For MCP server access, also install `pf-mcp` and complete the [Cursor MCP setup](https://github.com/rh-uxd/ai-helpers/blob/main/FAQ.md#how-do-i-test-a-skill-without-the-patternfly-mcp-server).
 
 ## How can I contribute a plugin?
 
-The PatternFly AI Helpers marketplace is open source and welcomes contributions from our community. Whether you want to add a new skill to an existing plugin, create an entirely new plugin, or improve the documentation that AI tools rely on, there's a place for your contribution.
+The AI Helpers marketplace is open source and welcomes contributions from our community. Whether you want to add a new skill to an existing plugin, create an entirely new plugin, or improve the documentation that AI tools rely on, there's a place for your contribution.
 
-To get started, check out the [contributing guide](https://github.com/patternfly/ai-helpers/blob/main/CONTRIBUTING.md) and the [step-by-step skill creation guide](https://github.com/patternfly/ai-helpers/blob/main/CONTRIBUTING-SKILLS.md).
+To get started, check out the [contributing guide](https://github.com/rh-uxd/ai-helpers/blob/main/CONTRIBUTING.md) and the [step-by-step skill creation guide](https://github.com/rh-uxd/ai-helpers/blob/main/CONTRIBUTING-SKILLS.md).

--- a/packages/documentation-site/patternfly-docs/content/AI/rapid-prototyping/enhancing-existing-projects.md
+++ b/packages/documentation-site/patternfly-docs/content/AI/rapid-prototyping/enhancing-existing-projects.md
@@ -16,6 +16,6 @@ If you need to start a new project, follow our guidelines for [starting a new pr
 
 ## Get started
 
-AI development tools work best when they have context about the frameworks and patterns your project uses. The [PatternFly AI Helpers](https://github.com/patternfly/ai-helpers) marketplace plugins provide your AI tools with this context, leading to more accurate component suggestions, better adherence to design patterns, and improved consistency across your codebase.
+AI development tools work best when they have context about the frameworks and patterns your project uses. The [AI Helpers](https://github.com/rh-uxd/ai-helpers) marketplace plugins provide your AI tools with this context, leading to more accurate component suggestions, better adherence to design patterns, and improved consistency across your codebase.
 
 Because these plugins are installed directly within your AI tools, there are no project dependencies to manage. To set up and use our plugins, refer to our [Marketplace](/ai/marketplace) page.

--- a/packages/documentation-site/patternfly-docs/content/AI/rapid-prototyping/new-prototypes.md
+++ b/packages/documentation-site/patternfly-docs/content/AI/rapid-prototyping/new-prototypes.md
@@ -28,13 +28,13 @@ The patternfly-react-seed ai_enabled branch comes pre-configured with:
 
 1. Clone or download the patternfly-react-seed repository using the ai_enabled branch.
 2. Install dependencies according to [the project's README](https://github.com/patternfly/patternfly-react-seed/tree/ai_enabled?tab=readme-ov-file#patternfly-seed).
-3. To give your AI tools additional context and skills for PatternFly development, install plugins from our [AI Helpers](https://github.com/patternfly/ai-helpers) marketplace. For instructions on getting started, refer to our [Marketplace](/ai/marketplace) page.
+3. To give your AI tools additional context and skills for PatternFly development, install plugins from our [AI Helpers](https://github.com/rh-uxd/ai-helpers) marketplace. For instructions on getting started, refer to our [Marketplace](/ai/marketplace) page.
 4. Start the development server.
 5. Begin prototyping with your AI development tools.
 
 ## How do I prototype?
 
-Once you've set up the patternfly-react-seed and installed the PatternFly AI Helpers plugins, follow these steps to begin prototyping:
+Once you've set up the patternfly-react-seed and installed the AI Helpers plugins, follow these steps to begin prototyping:
 
 1. **Define your scope**: Clearly articulate what you want to build using [vibe coding principles](/ai/rapid-prototyping/#effective-prompting-with-vibe-coding). Describe the experience, not the technical implementation.
 2. **Leverage AI assistance**: Use AI tools to generate PatternFly components based on your requirements, communicating through natural language descriptions of user needs and design intent.

--- a/packages/documentation-site/patternfly-docs/content/AI/rapid-prototyping/rapid-prototyping.md
+++ b/packages/documentation-site/patternfly-docs/content/AI/rapid-prototyping/rapid-prototyping.md
@@ -24,7 +24,7 @@ Rapid prototyping with PatternFly code offers several key benefits:
 
 ## Get started
 
-For the best results with AI-assisted prototyping, install the [PatternFly AI Helpers](/ai/marketplace) marketplace plugins. These give your AI tools additional knowledge and skills that lead to more accurate code generation.
+For the best results with AI-assisted prototyping, install the [AI Helpers](/ai/marketplace) marketplace plugins. These give your AI tools additional knowledge and skills that lead to more accurate code generation.
 
 Choose your path based on your current situation:
 

--- a/packages/documentation-site/patternfly-docs/pages/featured-posts-data.js
+++ b/packages/documentation-site/patternfly-docs/pages/featured-posts-data.js
@@ -18,13 +18,13 @@ export const featuredPostsData = {
       "https://miro.medium.com/v2/resize:fit:600/format:webp/1*L3CtrJqE9TyypMVqYQR_3g.png",
   },
   post3: {
-    title: "PatternFly's AI marketplace",
-    author: "Jeff Puzzo",
-    length: "7 min read",
-    URL: "https://medium.com/patternfly/patternflys-ai-marketplace-7b78aa5ead64",
+    title: "Harmonizing the Red Hat experience",
+    author: "Erin Donehoo",
+    length: "5 min read",
+    URL: "https://medium.com/patternfly/harmonizing-the-red-hat-experience-f5dc5c52e1be",
     // Use resize:fit:600 in URL
     imageURL:
-      "https://miro.medium.com/v2/resize:fit:600/format:webp/1*nRzzKkHAXqqHfRQx6jUiXQ.png",
+      "https://miro.medium.com/v2/resize:fit:600/format:webp/1*KYvrm8V0w7ThnpNc8iO_Gw.png",
   },
   post4: {
     title: "A dual mandate for design system maturity",


### PR DESCRIPTION
Reflect the moved marketplace and PatternFly + UXD plugin structure ([UXDOPS-2806](https://redhat.atlassian.net/browse/UXDOPS-2806)).