### PR TITLE
chore(docs): Adjust spacing

### DIFF
--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -2,6 +2,10 @@
   --ws-code-editor--tooltip--MaxWidth: 16ch;
 }
 
+.ws-heading.ws-example-heading {
+  margin-block-end: -0.5rem;
+}
+
 .ws-code-editor:not(.ws-example-code-expanded) > .pf-v6-c-code-editor__header::before {
   --pf-v6-c-code-editor__header--before--BorderBottomWidth: 0;
 }

--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -6,11 +6,6 @@
   --pf-v6-c-code-editor__header--before--BorderBottomWidth: 0;
 }
 
-/* Code editor: space before the next block (e.g. section heading). */
-[data-prose-content] .ws-code-editor:has(.pf-v6-c-code-editor__header-content:last-child) {
-  margin-block-end: var(--pf-t--global--spacer--lg);
-}
-
 .ws-code-editor-control {
   --pf-v6-c-button--m-control--BackgroundColor: transparent;
   --pf-v6-c-button--m-control--active--BackgroundColor: transparent;

--- a/packages/documentation-framework/components/example/example.css
+++ b/packages/documentation-framework/components/example/example.css
@@ -6,6 +6,11 @@
   --pf-v6-c-code-editor__header--before--BorderBottomWidth: 0;
 }
 
+/* Code editor: space before the next block (e.g. section heading). */
+[data-prose-content] .ws-code-editor:has(.pf-v6-c-code-editor__header-content:last-child) {
+  margin-block-end: var(--pf-t--global--spacer--lg);
+}
+
 .ws-code-editor-control {
   --pf-v6-c-button--m-control--BackgroundColor: transparent;
   --pf-v6-c-button--m-control--active--BackgroundColor: transparent;

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -9,8 +9,7 @@ import {
   Label,
   Switch,
   Tooltip,
-  Stack,
-  StackItem,
+  Stack
 } from '@patternfly/react-core';
 import * as reactCoreModule from '@patternfly/react-core';
 import * as reactCoreNextModule from '@patternfly/react-core/next';
@@ -117,8 +116,6 @@ export const Example = ({
   // absolute url to hosted file
   sourceLink = ''
 }) => {
-
-
   if (isFullscreenPreview) {
     isFullscreen = false;
   }
@@ -284,7 +281,9 @@ export const Example = ({
                   className={css('ws-full-page-utils-position-btn', utilsProps.className)}
                   isClicked={fullPageUtilsPosition === utilsProps.className}
                   onClick={() => setFullPageUtilsPosition(utilsProps.className)}
-                  aria-label={`${utilsProps.label}${fullPageUtilsPosition === utilsProps.className ? ', selected' : ''}`}
+                  aria-label={`${utilsProps.label}${
+                    fullPageUtilsPosition === utilsProps.className ? ', selected' : ''
+                  }`}
                   icon={fullPageUtilsPosition === utilsProps.className ? utilsProps.iconClicked : utilsProps.icon}
                 />
               </Tooltip>
@@ -303,7 +302,7 @@ export const Example = ({
   const fullscreenLink = (() => {
     const cleanPathname = loc.pathname.replace(/\/$/, '');
     const sourcePath = `/${source}`;
-    
+
     // Check if the source is already at the end of the pathname to avoid duplication
     // Using endsWith instead of includes to prevent false positives (e.g., /react-console matching /react)
     if (cleanPathname.endsWith(sourcePath)) {
@@ -348,19 +347,19 @@ export const Example = ({
   const metaText = hasMetaText && tooltips;
 
   const thumbnailDimensions = {
-    width: "800",
-    height: "450"
-  }
+    width: '800',
+    height: '450'
+  };
 
   return (
     <Stack hasGutter>
-      <StackItem>
+      <Stack hasGutter>
         <AutoLinkHeader metaText={metaText} headingLevel="h3">
           {title}
         </AutoLinkHeader>
         {children}
-      </StackItem>
-      <StackItem>
+      </Stack>
+      <Stack hasGutter>
         {isFullscreen ? (
           <div>
             <a
@@ -369,7 +368,12 @@ export const Example = ({
               target="_blank"
               aria-label={`Open fullscreen ${title} example`}
             >
-              <img src={thumbnail} width={thumbnailDimensions.width} height={thumbnailDimensions.height} alt={`${title} screenshot`} />
+              <img
+                src={thumbnail}
+                width={thumbnailDimensions.width}
+                height={thumbnailDimensions.height}
+                alt={`${title} screenshot`}
+              />
             </a>
           </div>
         ) : (
@@ -377,8 +381,8 @@ export const Example = ({
             {livePreview}
           </div>
         )}
-      </StackItem>
-      <StackItem>
+      </Stack>
+      <Stack hasGutter>
         <ExampleToolbar
           lang={lang}
           isFullscreen={isFullscreen}
@@ -389,7 +393,7 @@ export const Example = ({
           codeBoxParams={codeBoxParams}
           exampleTitle={title}
         />
-      </StackItem>
+      </Stack>
     </Stack>
   );
 };

--- a/packages/documentation-framework/components/example/example.js
+++ b/packages/documentation-framework/components/example/example.js
@@ -354,7 +354,7 @@ export const Example = ({
   return (
     <Stack hasGutter>
       <Stack hasGutter>
-        <AutoLinkHeader metaText={metaText} headingLevel="h3">
+        <AutoLinkHeader metaText={metaText} headingLevel="h3" className="ws-example-heading">
           {title}
         </AutoLinkHeader>
         {children}

--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -1,7 +1,25 @@
 @import './content-sources/ai-guidelines.css';
 
+/* Org docs rely on Stack hasGutter for block spacing; suppress paragraph margins. */
 p.pf-v6-c-content--p.ws-p {
   margin: 0;
+}
+
+/* Component/code docs and other prose-heavy sources need editorial paragraph spacing. */
+[data-prose-content] p.pf-v6-c-content--p.ws-p {
+  margin-block-end: var(--pf-v6-c-content--MarginBlockEnd);
+}
+
+/* Org docs: Stack gutter handles spacing before template sections; not content headings. */
+:not([data-prose-content]) .ws-example-page-wrapper.pf-m-gutter .ws-stack-section-heading {
+  margin-block-start: 0;
+}
+
+/* Prose docs: editorial heading spacing (Stack hasGutter is off; typography handles rhythm). */
+[data-prose-content] .ws-heading.ws-h2,
+[data-prose-content] .ws-heading.ws-h3,
+[data-prose-content] .ws-heading.ws-h4 {
+  margin-block-end: var(--pf-t--global--spacer--lg);
 }
 
 .ws-code {

--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -36,4 +36,5 @@
   max-width: min(100%, 1200px);
   flex-grow: 1;
   min-width: 0;
+  gap: 2.5rem;
 }

--- a/packages/documentation-framework/templates/mdx.css
+++ b/packages/documentation-framework/templates/mdx.css
@@ -1,25 +1,13 @@
 @import './content-sources/ai-guidelines.css';
 
-/* Org docs rely on Stack hasGutter for block spacing; suppress paragraph margins. */
-p.pf-v6-c-content--p.ws-p {
+/* Stack gutter already spaces direct children; don't also use paragraph margins. */
+.pf-v6-l-stack.pf-m-gutter > p.pf-v6-c-content--p.ws-p {
   margin: 0;
 }
 
-/* Component/code docs and other prose-heavy sources need editorial paragraph spacing. */
-[data-prose-content] p.pf-v6-c-content--p.ws-p {
-  margin-block-end: var(--pf-v6-c-content--MarginBlockEnd);
-}
-
-/* Org docs: Stack gutter handles spacing before template sections; not content headings. */
-:not([data-prose-content]) .ws-example-page-wrapper.pf-m-gutter .ws-stack-section-heading {
+/* Stack gutter provides spacing before template section headings. */
+.ws-example-page-wrapper.pf-m-gutter .ws-stack-section-heading {
   margin-block-start: 0;
-}
-
-/* Prose docs: editorial heading spacing (Stack hasGutter is off; typography handles rhythm). */
-[data-prose-content] .ws-heading.ws-h2,
-[data-prose-content] .ws-heading.ws-h3,
-[data-prose-content] .ws-heading.ws-h4 {
-  margin-block-end: var(--pf-t--global--spacer--lg);
 }
 
 .ws-code {

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -87,7 +87,25 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
     ensureID(toc);
   }
 
-  const isComponentCodeDocs = ['react', 'react-demos', 'html', 'html-demos', 'react-templates'].includes(source);
+  // Markdown sourced from component/code repos needs editorial paragraph spacing.
+  const isProseContent = [
+    'react',
+    'react-next',
+    'react-deprecated',
+    'react-demos',
+    'react-templates',
+    'html',
+    'html-demos',
+    'html-deprecated',
+    'ECharts-docs',
+    'ECharts',
+    'ECharts-next',
+    '-Victory',
+    '-Victory-next',
+    'ai-guidelines',
+    'extensions',
+    'components'
+  ].includes(source);
 
   const InlineAlerts = (optIn ||
     beta ||
@@ -134,14 +152,18 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
   );
   // Create dynamic component for @reach/router
   const ChildComponent = () => (
-    <div className={source !== 'landing-pages' ? 'pf-v6-l-flex pf-v6-m-column pf-m-nowrap-on-2xl' : ''} data-content-source={source}>
+    <div
+      className={source !== 'landing-pages' ? 'pf-v6-l-flex pf-v6-m-column pf-m-nowrap-on-2xl' : ''}
+      data-content-source={source}
+      {...(isProseContent && { 'data-prose-content': true })}
+    >
       {toc.length > 1 && <TableOfContents items={toc} />}
-      <Stack hasGutter className={(source !== 'landing-pages' && 'ws-example-page-wrapper')}>
+      <Stack hasGutter={!isProseContent} className={(source !== 'landing-pages' && 'ws-example-page-wrapper')}>
         {InlineAlerts}
         {source !== 'css-variables' && <Component />}
         {source !== 'css-variables' && functionDocumentation.length > 0 && (
           <StackItem>
-            <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2" id="functions">
+            <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2 ws-stack-section-heading" id="functions">
               Functions
             </AutoLinkHeader>
             <FunctionsTable functionDescriptions={functionDocumentation} />
@@ -149,7 +171,7 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
         )}
         {source !== 'css-variables' && propsTitle && (
           <StackItem>
-            <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2" id="props">
+            <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2 ws-stack-section-heading" id="props">
               {propsTitle}
             </AutoLinkHeader>
             {propComponents.map((component) => (
@@ -165,7 +187,7 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
         )}
         {source === 'css-variables' && cssPrefix.length > 0 && (
           <StackItem>
-            <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2" id="css-variables">
+            <AutoLinkHeader headingLevel="h2" className="pf-v6-c-content--h2 ws-stack-section-heading" id="css-variables">
               {cssVarsTitle}
             </AutoLinkHeader>
             {cssPrefix.map((prefix, index) => (

--- a/packages/documentation-framework/templates/mdx.js
+++ b/packages/documentation-framework/templates/mdx.js
@@ -87,26 +87,6 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
     ensureID(toc);
   }
 
-  // Markdown sourced from component/code repos needs editorial paragraph spacing.
-  const isProseContent = [
-    'react',
-    'react-next',
-    'react-deprecated',
-    'react-demos',
-    'react-templates',
-    'html',
-    'html-demos',
-    'html-deprecated',
-    'ECharts-docs',
-    'ECharts',
-    'ECharts-next',
-    '-Victory',
-    '-Victory-next',
-    'ai-guidelines',
-    'extensions',
-    'components'
-  ].includes(source);
-
   const InlineAlerts = (optIn ||
     beta ||
     deprecated ||
@@ -155,10 +135,9 @@ const MDXChildTemplate = ({ Component, source, toc = [], index = 0, id }) => {
     <div
       className={source !== 'landing-pages' ? 'pf-v6-l-flex pf-v6-m-column pf-m-nowrap-on-2xl' : ''}
       data-content-source={source}
-      {...(isProseContent && { 'data-prose-content': true })}
     >
       {toc.length > 1 && <TableOfContents items={toc} />}
-      <Stack hasGutter={!isProseContent} className={(source !== 'landing-pages' && 'ws-example-page-wrapper')}>
+      <Stack hasGutter className={source !== 'landing-pages' && 'ws-example-page-wrapper'}>
         {InlineAlerts}
         {source !== 'css-variables' && <Component />}
         {source !== 'css-variables' && functionDocumentation.length > 0 && (


### PR DESCRIPTION
We used to determine the gutter based on whether items were component docs - this brings that back so we can adjust where margins are used.

I don't know the full history, but it was removed here: https://github.com/patternfly/patternfly-org/pull/4127/changes#diff-da135efaa2b01f501f1ac196874e6c6ae745345196f59a4581445639bf5384c4R94

I don't know if there's a reason why I shouldn't bring it back - please tell me!

Fixes https://github.com/patternfly/patternfly-org/issues/4257

Assisted-by: Cursor